### PR TITLE
Add FixedBitWidth native slice support

### DIFF
--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -22,6 +22,7 @@
 #include "dwio/nimble/common/NimbleException.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
@@ -166,6 +167,20 @@ std::string_view sliceConstant(
       ConstantEncoding<T>::slice(encoded, offset, length, buffer, options));
 }
 
+std::string_view sliceFixedBitWidth(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE(
+      dataType,
+      T,
+      FixedBitWidthEncoding<T>::slice(
+          encoded, offset, length, buffer, options));
+}
+
 } // namespace
 
 std::string_view EncodingSliceFactory::slice(
@@ -191,6 +206,9 @@ std::string_view EncodingSliceFactory::slice(
       return sliceTrivial(encoded, dataType, offset, length, buffer, options);
     case EncodingType::RLE:
       return sliceRLE(encoded, dataType, offset, length, buffer, options);
+    case EncodingType::FixedBitWidth:
+      return sliceFixedBitWidth(
+          encoded, dataType, offset, length, buffer, options);
     case EncodingType::Nullable:
       return sliceNullable(encoded, dataType, offset, length, buffer, options);
     case EncodingType::SparseBool:

--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -31,7 +31,6 @@
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
-#include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/common/EncodingTypeDispatch.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstring>
 #include <span>
 #include <type_traits>
 
@@ -87,6 +88,13 @@ class FixedBitWidthEncoding final
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
       Buffer& buffer,
       const Encoding::Options& options = {});
 
@@ -400,6 +408,78 @@ std::string_view FixedBitWidthEncoding<T>::encode(
   compressionEncoder.write(pos);
 
   NIMBLE_DCHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string_view FixedBitWidthEncoding<T>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
+  const auto sourcePrefixSize =
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  const char* sourcePos = encoded.data() + sourcePrefixSize;
+  const auto sourceCompressionType =
+      static_cast<CompressionType>(encoding::readChar(sourcePos));
+  const auto baseline = encoding::read<physicalType>(sourcePos);
+  const auto bitWidth = static_cast<uint8_t>(encoding::readChar(sourcePos));
+
+  velox::BufferPtr uncompressed;
+  std::string_view packedData{
+      sourcePos, static_cast<size_t>(encoded.end() - sourcePos)};
+  if (sourceCompressionType != CompressionType::Uncompressed) {
+    uncompressed = Compression::uncompress(
+        buffer.getMemoryPool(),
+        sourceCompressionType,
+        DataType::Undefined,
+        packedData,
+        options.decompressCounter(),
+        options.bufferPool);
+    packedData = {uncompressed->as<char>(), uncompressed->size()};
+  }
+
+  const auto packedBytes = FixedBitArray::bufferSize(length, bitWidth);
+  const auto prefixSize =
+      EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+  const auto encodingSize =
+      prefixSize + FixedBitWidthEncoding<T>::kPrefixSize + packedBytes;
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  EncodingPrefix::serialize(
+      EncodingType::FixedBitWidth,
+      TypeTraits<T>::dataType,
+      length,
+      options.useVarintRowCount,
+      pos);
+  encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
+  encoding::write(baseline, pos);
+  encoding::writeChar(bitWidth, pos);
+
+  if (packedBytes > 0) {
+    std::memset(pos, 0, packedBytes);
+    const auto sourceBitOffset = static_cast<uint64_t>(offset) * bitWidth;
+    const auto sliceBits = static_cast<uint64_t>(length) * bitWidth;
+    if (sourceBitOffset % 8 == 0 && sliceBits % 8 == 0) {
+      std::memcpy(pos, packedData.data() + sourceBitOffset / 8, packedBytes);
+    } else {
+      velox::bits::copyBits(
+          reinterpret_cast<const uint64_t*>(packedData.data()),
+          sourceBitOffset,
+          reinterpret_cast<uint64_t*>(pos),
+          /*targetOffset=*/0,
+          sliceBits);
+    }
+    pos += packedBytes;
+  }
+
+  NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
   return {reserved, encodingSize};
 }
 

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -412,7 +412,9 @@ std::pair<uint32_t, uint32_t> NullableEncoding<T>::countNonNullsForSlice(
     Buffer& buffer,
     const Encoding::Options& options) {
   const auto rowEnd = offset + length;
-  NIMBLE_CHECK_GT(rowEnd, 0, "Nullable slice requires a non-empty row range.");
+  if (rowEnd == 0) {
+    return {0, 0};
+  }
 
   auto* pool = &buffer.getMemoryPool();
   auto encoding = EncodingFactory{options}.create(

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -24,6 +24,38 @@ struct UncompressedData {
   velox::BufferPtr buffer;
 };
 
+struct StringPayload {
+  CompressionType compressionType;
+  std::string_view lengths;
+  std::string_view blob;
+};
+
+StringPayload readStringPayload(std::string_view encoded, uint32_t dataOffset) {
+  const char* pos = encoded.data() + dataOffset;
+  const auto compressionType =
+      static_cast<CompressionType>(encoding::readChar(pos));
+  const uint32_t lengthsSize = encoding::readUint32(pos);
+  const std::string_view lengths{pos, lengthsSize};
+  pos += lengthsSize;
+  return {
+      .compressionType = compressionType,
+      .lengths = lengths,
+      .blob = {pos, static_cast<size_t>(encoded.end() - pos)}};
+}
+
+void writeStringHeader(
+    uint32_t rowCount,
+    bool useVarint,
+    CompressionType compressionType,
+    std::string_view serializedLengths,
+    char*& pos) {
+  EncodingPrefix::serialize(
+      EncodingType::Trivial, DataType::String, rowCount, useVarint, pos);
+  encoding::writeChar(static_cast<char>(compressionType), pos);
+  encoding::writeUint32(serializedLengths.size(), pos);
+  encoding::writeBytes(serializedLengths, pos);
+}
+
 UncompressedData uncompressIfNeeded(
     velox::memory::MemoryPool& pool,
     CompressionType compressionType,
@@ -74,26 +106,23 @@ TrivialEncoding<std::string_view>::TrivialEncoding(
     : TypedEncoding<std::string_view, std::string_view>{pool, data, options},
       row_{0},
       buffer_{&pool} {
-  auto pos = data.data() + this->dataOffset();
-  const auto dataCompressionType =
-      static_cast<CompressionType>(encoding::readChar(pos));
-  const auto lengthsSize = encoding::readUint32(pos);
+  const auto payload = readStringPayload(data, this->dataOffset());
   lengths_ = EncodingFactory(options).create(
-      pool, {pos, lengthsSize}, stringBufferFactory);
-  blob_ = pos + lengthsSize;
+      pool, payload.lengths, stringBufferFactory);
+  blob_ = payload.blob.data();
 
-  if (dataCompressionType != CompressionType::Uncompressed) {
+  if (payload.compressionType != CompressionType::Uncompressed) {
     dataUncompressed_ = Compression::uncompress(
         pool,
-        dataCompressionType,
+        payload.compressionType,
         DataType::String,
-        {blob_, static_cast<size_t>(data.end() - blob_)},
+        payload.blob,
         options.decompressCounter(),
         options.bufferPool);
     blob_ = dataUncompressed_->as<char>();
     uncompressedDataBytes_ = dataUncompressed_->size();
   } else {
-    uncompressedDataBytes_ = data.size() - std::distance(data.data(), blob_);
+    uncompressedDataBytes_ = payload.blob.size();
   }
   // TODO(huamengjiang): if we want to reduce the temporary memory peak, we can
   // pass the string buffer factory into the compression api.
@@ -189,12 +218,12 @@ std::string_view TrivialEncoding<std::string_view>::encode(
 
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
-  Encoding::serializePrefix(
-      EncodingType::Trivial, DataType::String, valueCount, useVarint, pos);
-  encoding::writeChar(
-      static_cast<char>(compressionEncoder.compressionType()), pos);
-  encoding::writeUint32(serializedLengths.size(), pos);
-  encoding::writeBytes(serializedLengths, pos);
+  writeStringHeader(
+      valueCount,
+      useVarint,
+      compressionEncoder.compressionType(),
+      serializedLengths,
+      pos);
   compressionEncoder.write(pos);
 
   NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
@@ -207,32 +236,31 @@ std::string_view TrivialEncoding<std::string_view>::slice(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
   const auto sourcePrefixSize =
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
-  const char* sourcePos = encoded.data() + sourcePrefixSize;
-  const auto compressionType =
-      static_cast<CompressionType>(encoding::readChar(sourcePos));
-
-  const uint32_t lengthsSize = encoding::readUint32(sourcePos);
-  const std::string_view lengthsData{sourcePos, lengthsSize};
-  sourcePos += lengthsSize;
+  const auto payload = readStringPayload(encoded, sourcePrefixSize);
   const auto blob = uncompressIfNeeded(
       buffer.getMemoryPool(),
-      compressionType,
+      payload.compressionType,
       DataType::String,
-      {sourcePos, static_cast<size_t>(encoded.end() - sourcePos)},
+      payload.blob,
       options);
   const char* blobData = blob.data;
 
   const auto slicedLengths =
-      EncodingFactory::slice(lengthsData, offset, length, buffer, options);
+      EncodingFactory::slice(payload.lengths, offset, length, buffer, options);
   const auto rowEnd = offset + length;
   auto materializedLengths =
       makeScratchVector<uint32_t>(buffer.getMemoryPool(), options, rowEnd);
   materializedLengths.resize(rowEnd);
   auto lengthsEncoding = EncodingFactory{options}.create(
       buffer.getMemoryPool(),
-      lengthsData,
+      payload.lengths,
       [](uint32_t /*totalLength*/) -> void* { return nullptr; });
   lengthsEncoding->materialize(rowEnd, materializedLengths.data());
   const auto sliceBegin = materializedLengths.begin() + offset;
@@ -247,15 +275,12 @@ std::string_view TrivialEncoding<std::string_view>::slice(
       prefixSize + kPrefixSize + slicedLengths.size() + blobBytes;
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
-  EncodingPrefix::serialize(
-      EncodingType::Trivial,
-      DataType::String,
+  writeStringHeader(
       length,
       options.useVarintRowCount,
+      CompressionType::Uncompressed,
+      slicedLengths,
       pos);
-  encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
-  encoding::writeUint32(slicedLengths.size(), pos);
-  encoding::writeBytes(slicedLengths, pos);
   encoding::writeBytes({blobData + blobOffset, blobBytes}, pos);
   NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
   releaseScratchVector(materializedLengths, options);
@@ -406,6 +431,11 @@ std::string_view TrivialEncoding<bool>::slice(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
   const auto sourcePrefixSize =
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
   const char* sourcePos = encoded.data() + sourcePrefixSize;

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -336,6 +336,11 @@ std::string_view TrivialEncoding<T>::slice(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+
   const auto sourcePrefixSize =
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
   const char* sourcePos = encoded.data() + sourcePrefixSize;

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -15,6 +15,8 @@
  */
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 
+#include <utility>
+
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
@@ -158,7 +160,8 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     std::string_view data,
     std::function<void*(uint32_t)> stringBufferFactory,
     const Encoding::Options& options) const {
-  return EncodingFactory{options}.create(pool, data, stringBufferFactory);
+  return EncodingFactory{options}.create(
+      pool, data, std::move(stringBufferFactory));
 }
 
 std::string_view EncodingFactory::slice(
@@ -189,6 +192,8 @@ std::string_view EncodingFactory::encode(
       std::move(selection), physicalValues, buffer, options);
 }
 
+// The encoding layout is honored, except for nullable encodings, which are
+// replaced with the appropriate nullable encoding.
 template <typename T>
 std::string_view EncodingFactory::encodeWithCapturedLayout(
     std::string_view encodedLayoutSource,

--- a/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
@@ -208,6 +208,102 @@ TYPED_TEST(FixedBitWidthEncodingTest, decodesByteRoundedPayload) {
   EXPECT_EQ(result, std::vector<uint32_t>(values.begin(), values.end()));
 }
 
+TYPED_TEST(FixedBitWidthEncodingTest, slice) {
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  for (const bool useExactBits : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useExactBits=" << useExactBits);
+    nimble::Encoding::Options options{
+        .useVarintRowCount = TypeParam::useVarint};
+    options.fixedBitWidthUseExactBits = useExactBits;
+
+    nimble::Vector<uint32_t> values{this->pool_.get()};
+    for (uint32_t i = 0; i < 32; ++i) {
+      values.push_back(1000 + (i * 7) % 64);
+    }
+
+    nimble::Buffer sourceBuffer{*this->pool_};
+    const auto encoded =
+        nimble::test::Encoder<nimble::FixedBitWidthEncoding<uint32_t>>::encode(
+            sourceBuffer,
+            values,
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    for (const auto range :
+         {Range{/*offset=*/0, /*length=*/0},
+          Range{/*offset=*/0, /*length=*/5},
+          Range{/*offset=*/1, /*length=*/7},
+          Range{/*offset=*/4, /*length=*/8},
+          Range{/*offset=*/27, /*length=*/5}}) {
+      SCOPED_TRACE(
+          testing::Message()
+          << "offset=" << range.offset << " length=" << range.length);
+      nimble::Buffer sliceBuffer{*this->pool_};
+      const auto sliced = nimble::EncodingFactory::slice(
+          encoded, range.offset, range.length, sliceBuffer, options);
+
+      EXPECT_EQ(
+          nimble::EncodingPrefix::encodingType(sliced),
+          nimble::EncodingType::FixedBitWidth);
+      EXPECT_EQ(
+          nimble::EncodingPrefix::readRowCount(
+              sliced, options.useVarintRowCount),
+          range.length);
+
+      auto encoding = nimble::EncodingFactory{options}.create(
+          *this->pool_, sliced, this->stringBufferFactory());
+      std::vector<uint32_t> result(range.length);
+      encoding->materialize(range.length, result.data());
+
+      const std::vector<uint32_t> expected{
+          values.begin() + range.offset,
+          values.begin() + range.offset + range.length};
+      EXPECT_EQ(result, expected);
+    }
+  }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, sliceCompressedSource) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  nimble::Vector<uint32_t> values{this->pool_.get()};
+  for (uint32_t i = 0; i < 512; ++i) {
+    values.push_back(1000 + i % 128);
+  }
+
+  nimble::Buffer sourceBuffer{*this->pool_};
+  const auto encoded =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<uint32_t>>::encode(
+          sourceBuffer, values, nimble::CompressionType::Zstd, options);
+
+  constexpr uint32_t kOffset{17};
+  constexpr uint32_t kLength{65};
+  nimble::Buffer sliceBuffer{*this->pool_};
+  const auto sliced = nimble::EncodingFactory::slice(
+      encoded, kOffset, kLength, sliceBuffer, options);
+
+  const auto prefixSize =
+      nimble::EncodingPrefix::prefixSize(sliced, TypeParam::useVarint);
+  EXPECT_EQ(
+      static_cast<nimble::CompressionType>(
+          static_cast<uint8_t>(sliced[prefixSize])),
+      nimble::CompressionType::Uncompressed);
+
+  auto encoding = nimble::EncodingFactory{options}.create(
+      *this->pool_, sliced, this->stringBufferFactory());
+  std::vector<uint32_t> result(kLength);
+  encoding->materialize(kLength, result.data());
+
+  const std::vector<uint32_t> expected{
+      values.begin() + kOffset, values.begin() + kOffset + kLength};
+  EXPECT_EQ(result, expected);
+}
+
 TYPED_TEST(FixedBitWidthEncodingTest, singleValue) {
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};

--- a/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
@@ -250,7 +250,7 @@ TYPED_TEST(SparseBoolEncodingTest, skipThenMaterialize) {
 TYPED_TEST(SparseBoolEncodingTest, slice) {
   const nimble::Encoding::Options options{
       .useVarintRowCount = TypeParam::useVarint};
-  for (const auto values :
+  for (const auto& values :
        {this->toVector(
             {false,
              false,

--- a/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
@@ -228,3 +228,86 @@ TEST_F(TrivialEncodingTest, sliceRangesForSupportedTypes) {
   expectSliceRanges<std::string_view>(
       makeStringValues(stringStorage, valueCount), nimble::DataType::String);
 }
+
+TEST_F(TrivialEncodingTest, invalidSliceRange) {
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+
+    const auto uint32Values = makeVector<uint32_t>({10, 20, 30});
+    const auto uint32Encoded =
+        nimble::test::Encoder<nimble::TrivialEncoding<uint32_t>>::encode(
+            *buffer_,
+            uint32Values,
+            nimble::CompressionType::Uncompressed,
+            options);
+    nimble::Buffer uint32SliceBuffer{*pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<uint32_t>::slice(
+            uint32Encoded,
+            /*offset=*/4,
+            /*length=*/0,
+            uint32SliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<uint32_t>::slice(
+            uint32Encoded,
+            /*offset=*/2,
+            /*length=*/2,
+            uint32SliceBuffer,
+            options),
+        "");
+
+    const auto boolValues = makeBoolValues(/*valueCount=*/3);
+    const auto boolEncoded =
+        nimble::test::Encoder<nimble::TrivialEncoding<bool>>::encode(
+            *buffer_,
+            boolValues,
+            nimble::CompressionType::Uncompressed,
+            options);
+    nimble::Buffer boolSliceBuffer{*pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<bool>::slice(
+            boolEncoded,
+            /*offset=*/4,
+            /*length=*/0,
+            boolSliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<bool>::slice(
+            boolEncoded,
+            /*offset=*/2,
+            /*length=*/2,
+            boolSliceBuffer,
+            options),
+        "");
+
+    std::vector<std::string> stringStorage;
+    const auto stringValues = makeStringValues(stringStorage, /*valueCount=*/3);
+    const auto stringEncoded = nimble::test::
+        Encoder<nimble::TrivialEncoding<std::string_view>>::encode(
+            *buffer_,
+            stringValues,
+            nimble::CompressionType::Uncompressed,
+            options);
+    nimble::Buffer stringSliceBuffer{*pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<std::string_view>::slice(
+            stringEncoded,
+            /*offset=*/4,
+            /*length=*/0,
+            stringSliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<std::string_view>::slice(
+            stringEncoded,
+            /*offset=*/2,
+            /*length=*/2,
+            stringSliceBuffer,
+            options),
+        "");
+  }
+}


### PR DESCRIPTION
Summary:
Adds native serialized slicing for `FixedBitWidthEncoding` so FixedBitWidth streams no longer fall back to materialize + re-encode in `EncodingSliceFactory`.

The implementation preserves the original baseline and bit width, emits an uncompressed sliced FixedBitWidth stream, copies packed bytes directly for byte-aligned ranges, and uses `velox::bits::copyBits` for exact-bit or otherwise misaligned ranges.

Differential Revision: D113726614


