### PR TITLE
feat(nimble): Add BufferPolicy hook + sequence-storage UserIdAlignedBufferPolicy

### DIFF
--- a/dwio/nimble/velox/BufferPolicy.h
+++ b/dwio/nimble/velox/BufferPolicy.h
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "dwio/nimble/velox/RowRange.h"
+#include "velox/vector/ComplexVector.h"
+
+namespace facebook::nimble {
+
+/// A stripe-ready collection of input vectors and per-input row ranges.
+/// The writer, on receiving a non-empty BufferRange from
+/// BufferPolicy::flushInput(), ingests each
+/// `inputs[i]->slice(rowRanges[i])` into its per-column stream buffers
+/// and then flushes exactly one stripe.
+///
+/// Parallel arrays: `inputs.size() == rowRanges.size()`, and
+/// `rowRanges[i]` applies to `inputs[i]`. Empty means "no stripe ready
+/// yet".
+struct BufferRange {
+  std::vector<velox::VectorPtr> inputs;
+  std::vector<RowRange> rowRanges;
+
+  bool empty() const {
+    return inputs.empty();
+  }
+};
+
+/// Content-driven cutting hook for VeloxWriter. Replaces the earlier
+/// per-batch pre-write cut model with a buffering model: the policy
+/// accumulates incoming row vectors across successive `write()` calls and
+/// emits stripe-ready `BufferRange`s when its internal invariant (group
+/// boundary, row-count cap, etc.) says a stripe is complete.
+///
+/// Lifecycle, from the writer's perspective:
+///   1. `bufferInput(input)` — called once per incoming batch in
+///      `VeloxWriter::write()`. Policy retains a reference to `input` (via
+///      VectorPtr's shared ownership) until the corresponding rows are
+///      emitted by `flushInput()` or dropped.
+///   2. `flushInput()` — called repeatedly by the writer immediately after
+///      every `bufferInput()`, draining the policy of any completed
+///      BufferRanges. Returns empty when the policy has nothing ready.
+///   3. `finalize()` — called once by `VeloxWriter::close()` to signal
+///      end-of-input. On subsequent `flushInput()` calls the policy must
+///      emit any residual open range (e.g. the last user's rows) rather
+///      than continuing to accumulate.
+///
+/// The writer only invokes BufferPolicy when
+/// `VeloxWriterOptions::bufferPolicyFactory` is set. When unset, the writer
+/// falls back to the legacy FlushPolicy path (`shouldFlush` post-write).
+/// FlushPolicy and BufferPolicy address different concerns: FlushPolicy
+/// cuts on size accumulated in the writer's stream buffers; BufferPolicy
+/// cuts on content the policy sees in the incoming vectors. Callers pick
+/// one or the other, not both.
+///
+/// Memory: BufferPolicy retains vector references for as long as it holds
+/// unemitted rows from them. The policy is responsible for its own
+/// bookkeeping and for bounding memory use (e.g. by emitting periodically
+/// or capping accumulated rows). VeloxWriter imposes no upper bound.
+class BufferPolicy {
+ public:
+  virtual ~BufferPolicy() = default;
+
+  /// Ingest an incoming batch into the policy's internal buffer. The base
+  /// interface accepts any VectorPtr — policies that need a specific shape
+  /// (e.g. a plain RowVector for column-content inspection) should
+  /// dynamic_cast internally and reject wrapped/mismatched inputs.
+  /// Implementations should also reject empty (0-row) inputs if their
+  /// bookkeeping (e.g. indexing at `numRows - 1`) is undefined on them.
+  /// VeloxWriter never passes an empty batch in normal usage, so this only
+  /// matters when the policy is driven directly (e.g. tests).
+  virtual void bufferInput(velox::VectorPtr input) = 0;
+
+  /// Return the next ready-to-write BufferRange, or an empty BufferRange
+  /// if the policy is still accumulating. VeloxWriter drains this method
+  /// after every `bufferInput()` (and after `finalize()` at close time)
+  /// until it returns empty.
+  virtual BufferRange flushInput() = 0;
+
+  /// Signal end-of-input. After this call, the next `flushInput()` calls
+  /// must emit any residual open buffer content rather than continuing to
+  /// wait for a boundary.
+  virtual void finalize() = 0;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/CMakeLists.txt
+++ b/dwio/nimble/velox/CMakeLists.txt
@@ -174,6 +174,7 @@ target_link_libraries(
 
 add_library(
   nimble_velox_writer
+  BufferPolicy.h
   EncodingLayoutTree.cpp
   FlushPolicy.cpp
   VeloxWriter.cpp

--- a/dwio/nimble/velox/FlushPolicy.h
+++ b/dwio/nimble/velox/FlushPolicy.h
@@ -47,7 +47,27 @@ struct StripeProgress {
 class FlushPolicy {
  public:
   virtual ~FlushPolicy() = default;
+
+  /// Post-write flush query consulted at the end of every VeloxWriter::write()
+  /// call (via evaluateFlushPolicy). Returning true causes the writer
+  /// to immediately cut the currently open stripe. This is the size-driven
+  /// cut mechanism for policies that decide based on how much data has
+  /// accumulated in the current stripe (bytes, encoded size, etc.). Callers
+  /// that need content- or count-driven cuts should install a BufferPolicy
+  /// instead — see BufferPolicy.h.
+  ///
+  /// Contract: the answer must be a pure function of stripeProgress at call
+  /// time. Policies that need cross-call state (e.g. hysteresis) must own it
+  /// in a factory-captured struct — VeloxWriter recreates the policy at every
+  /// consultation.
   virtual bool shouldFlush(const StripeProgress& stripeProgress) = 0;
+
+  /// Post-write chunk query consulted alongside shouldFlush (via
+  /// evaluateFlushPolicy) — but only when
+  /// VeloxWriterOptions::enableChunking is true. Returning true causes the
+  /// writer to soft-chunk stream data currently buffered above the
+  /// per-stream chunk threshold, relieving memory pressure without cutting
+  /// the stripe. Same purity + state-ownership contract as shouldFlush.
   virtual bool shouldChunk(const StripeProgress& stripeProgress) = 0;
 };
 
@@ -161,8 +181,8 @@ class TestFlushPolicy final : public FlushPolicy {
   /// Shared rng state, owned by TestFlushPolicyFactory and outliving the
   /// per-write() policy instances the writer recreates. VeloxWriter rebuilds
   /// the flush policy from its factory on every write() (see
-  /// VeloxWriter::evaluateFlushPolicy), so an rng owned by the policy itself
-  /// would reseed identically each call and make the same decision every
+  /// VeloxWriter::evaluateFlushPolicy), so an rng owned by the policy
+  /// itself would reseed identically each call and make the same decision every
   /// write(). Holding it here instead lets decisions vary across writes while
   /// staying reproducible from the seed.
   struct State {

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -900,12 +900,17 @@ VeloxWriter::VeloxWriter(
                        }
                      })
                : nullptr,
-           .closeCallback = [this](
-                                const WriteDataFn& writeDataFn,
-                                const CreateMetadataSectionFn& createMetadataFn,
-                                const WriteOptionalSectionFn& writeMetadataFn) {
-             writeIndexes(writeDataFn, createMetadataFn, writeMetadataFn);
-           }})} {
+           .closeCallback =
+               [this](
+                   const WriteDataFn& writeDataFn,
+                   const CreateMetadataSectionFn& createMetadataFn,
+                   const WriteOptionalSectionFn& writeMetadataFn) {
+                 writeIndexes(writeDataFn, createMetadataFn, writeMetadataFn);
+               }})},
+      bufferPolicy_{
+          context_->options().bufferPolicyFactory != nullptr
+              ? context_->options().bufferPolicyFactory()
+              : nullptr} {
   NIMBLE_CHECK_NOT_NULL(file_);
 
   // Register handler for dynamically discovered FlatMap keys before creating
@@ -948,47 +953,21 @@ bool VeloxWriter::write(const velox::VectorPtr& input) {
     std::rethrow_exception(lastException_);
   }
 
+  NIMBLE_CHECK_NOT_NULL(input, "Input must not be null");
   NIMBLE_CHECK_NOT_NULL(file_, "Writer is already closed");
   try {
-    const auto numRows = input->size();
-    // When enableStatsConsistencyCheck is true, compute raw size using
-    // RawSizeUtils to verify consistency with column statistics.
-    // Otherwise, skip this computation as column statistics will provide
-    // the raw size.
-    // Skip entirely when stats collection is disabled — there is no
-    // writeColumnStats() call to consume this value.
-    if (context_->options().enableStatsCollection &&
-        context_->options().enableStatsConsistencyCheck) {
-      // Calculate raw size using schema information to correctly handle
-      // passthrough flatmaps.
-      RawSizeContext context;
-      const auto rawSize = nimble::getRawSizeFromVector(
-          input,
-          velox::common::Ranges::of(0, numRows),
-          context,
-          schema_.get(),
-          context_->flatMapNodeIds(),
-          context_->ignoreTopLevelNulls());
-      NIMBLE_CHECK_GE(rawSize, 0, "Invalid raw size");
-      context_->updateFileRawSize(rawSize);
+    // BufferPolicy path: content-driven cutting via a policy that buffers
+    // inputs across writes and emits stripe-ready row ranges. Policies
+    // that need a specific input shape (e.g. plain RowVector for column
+    // inspection) validate internally.
+    if (bufferPolicy_ != nullptr) {
+      bufferPolicy_->bufferInput(input);
+      return flushInputBuffers(/*finalize=*/false);
     }
 
-    {
-      velox::CpuWallTimer ingestionTimer{context_->ingestionTiming()};
-      rootWriter_->write(input, OrderedRanges::of(0, numRows));
-    }
-    addIndexKey(input);
-
-    uint64_t memoryUsed{0};
-    for (const auto& [_, stream] : context_->streams()) {
-      memoryUsed += stream->memoryUsed();
-    }
-
-    context_->setMemoryUsed(memoryUsed);
-    context_->updateRowsInFile(numRows);
-    context_->updateRowsInStripe(numRows);
-    context_->setBytesWritten(file_->size());
-
+    // Legacy FlushPolicy path: append the whole batch to the writer's stream
+    // buffers, then consult shouldFlush.
+    writeBatch(input);
     return evaluateFlushPolicy();
   } catch (const std::exception& e) {
     lastException_ = std::current_exception();
@@ -1001,6 +980,70 @@ bool VeloxWriter::write(const velox::VectorPtr& input) {
         folly::to<std::string>(folly::exceptionStr(std::current_exception())));
     throw;
   }
+}
+
+bool VeloxWriter::flushInputBuffers(bool finalize) {
+  if (finalize) {
+    bufferPolicy_->finalize();
+  }
+  bool anyStripeFlushed = false;
+  while (true) {
+    auto range = bufferPolicy_->flushInput();
+    if (range.empty()) {
+      break;
+    }
+    NIMBLE_CHECK_EQ(
+        range.inputs.size(),
+        range.rowRanges.size(),
+        "BufferRange inputs and rowRanges must be parallel arrays");
+    for (size_t i = 0; i < range.inputs.size(); ++i) {
+      const auto& rowRange = range.rowRanges[i];
+      writeBatch(range.inputs[i]->slice(rowRange.startRow, rowRange.numRows()));
+    }
+    anyStripeFlushed = writeStripe() || anyStripeFlushed;
+  }
+  return anyStripeFlushed;
+}
+
+void VeloxWriter::writeBatch(const velox::VectorPtr& input) {
+  const auto numRows = input->size();
+  // When enableStatsConsistencyCheck is true, compute raw size using
+  // RawSizeUtils to verify consistency with column statistics.
+  // Otherwise, skip this computation as column statistics will provide
+  // the raw size.
+  // Skip entirely when stats collection is disabled — there is no
+  // writeColumnStats() call to consume this value.
+  if (context_->options().enableStatsCollection &&
+      context_->options().enableStatsConsistencyCheck) {
+    // Calculate raw size using schema information to correctly handle
+    // passthrough flatmaps.
+    RawSizeContext context;
+    const auto rawSize = nimble::getRawSizeFromVector(
+        input,
+        velox::common::Ranges::of(0, numRows),
+        context,
+        schema_.get(),
+        context_->flatMapNodeIds(),
+        context_->ignoreTopLevelNulls());
+    NIMBLE_CHECK_GE(rawSize, 0, "Invalid raw size");
+    context_->updateFileRawSize(rawSize);
+  }
+
+  {
+    velox::CpuWallTimer ingestionTimer{context_->ingestionTiming()};
+    rootWriter_->write(input, OrderedRanges::of(0, numRows));
+  }
+  addIndexKey(input);
+
+  uint64_t memoryUsed{0};
+  for (const auto& [_, stream] : context_->streams()) {
+    memoryUsed += stream->memoryUsed();
+  }
+
+  context_->setMemoryUsed(memoryUsed);
+  context_->updateRowsInFile(numRows);
+  context_->updateRowsInStripe(numRows);
+  context_->setBytesWritten(file_->size());
 }
 
 void VeloxWriter::writeMetadata() {
@@ -1136,6 +1179,11 @@ void VeloxWriter::close() {
 
   if (file_ != nullptr) {
     try {
+      if (bufferPolicy_ != nullptr) {
+        // Finalize signals "no more input" so the policy emits any residual
+        // range as the tail stripe.
+        flushInputBuffers(/*finalize=*/true);
+      }
       writeStripe();
       rootWriter_->close();
       if (context_->options().enableStatsCollection) {

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -18,6 +18,7 @@
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/index/IndexWriter.h"
 #include "dwio/nimble/tablet/TabletWriter.h"
+#include "dwio/nimble/velox/BufferPolicy.h"
 #include "dwio/nimble/velox/FieldWriter.h"
 #include "dwio/nimble/velox/VeloxWriterOptions.h"
 #include "velox/common/base/RuntimeMetrics.h"
@@ -152,6 +153,22 @@ class VeloxWriter {
   // Returning 'true' if stripe was flushed.
   bool evaluateFlushPolicy();
 
+  // Drains buffered inputs from the installed BufferPolicy by repeatedly
+  // calling writeBuffer(), ingesting the emitted (input, slice) pairs and
+  // flushing one stripe per emitted BufferRange until the policy returns an
+  // empty range. When 'finalize' is true, first calls BufferPolicy::finalize()
+  // so any remaining rows the policy was still buffering get emitted; used at
+  // close() to make sure no rows are left behind. Only invoked when a
+  // BufferPolicy is installed. Returns true if any stripe was flushed.
+  bool flushInputBuffers(bool finalize);
+
+  // Ingests a (possibly sliced) input into the per-column stream buffers,
+  // adds index keys, and refreshes per-stripe accounting. Callers pre-slice
+  // via input->slice(start, length) when they need to write only a subset of
+  // rows (as the BufferPolicy path does when emitting sub-batch ranges).
+  // Does NOT consult the flush policy — the caller owns that.
+  void writeBatch(const velox::VectorPtr& input);
+
   // Returning 'true' if stripe was written.
   bool writeStripe();
 
@@ -204,6 +221,9 @@ class VeloxWriter {
   const std::unique_ptr<index::IndexWriter> clusterIndexWriter_;
   const std::vector<std::unique_ptr<index::IndexWriter>> denseIndexWriters_;
   const std::unique_ptr<TabletWriter> tabletWriter_;
+  // Built once at construction from `options.bufferPolicyFactory`; null if
+  // the caller didn't set the factory (legacy FlushPolicy path).
+  const std::unique_ptr<BufferPolicy> bufferPolicy_;
 
   std::unique_ptr<FieldWriter> rootWriter_;
   std::unique_ptr<Buffer> encodingBuffer_;

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -22,6 +22,7 @@
 #include "dwio/nimble/index/IndexConfig.h"
 #include "dwio/nimble/tablet/StripeGroup.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
+#include "dwio/nimble/velox/BufferPolicy.h"
 #include "dwio/nimble/velox/EncodingLayoutTree.h"
 #include "dwio/nimble/velox/FlushPolicy.h"
 #include "dwio/nimble/velox/NimbleConfig.h"
@@ -260,7 +261,15 @@ struct VeloxWriterOptions {
     return std::make_unique<StripeRawSizeFlushPolicy>(256 << 20);
   };
 
-  /// When the writer needs to buffer data, and internal buffers don't have
+  /// Optional content-driven cutting policy. When set, VeloxWriter routes
+  // every write() through the BufferPolicy (bufferInput → drain writeBuffer)
+  // and emits one stripe per emitted BufferRange, bypassing shouldFlush.
+  // When unset (the default), the writer takes the legacy path: write the
+  // whole batch, then consult flushPolicyFactory's shouldFlush.
+  // See BufferPolicy.h for the interface + lifecycle.
+  std::function<std::unique_ptr<BufferPolicy>()> bufferPolicyFactory;
+
+  // When the writer needs to buffer data, and internal buffers don't have
   /// enough capacity, the writer is using this policy to claculate the the new
   /// capacity for the vuffers.
   std::function<std::unique_ptr<InputBufferGrowthPolicy>()>


### PR DESCRIPTION
Summary:
Adds a new content-driven cutting hook to Nimble's writer: `BufferPolicy`.
Unlike the existing `FlushPolicy` (which is a per-write size-driven query
consulted after each batch is appended to the writer's stream buffers), a
`BufferPolicy` accumulates incoming `RowVectorPtr`s across successive
`write()` calls and emits stripe-ready `BufferRange`s when its internal
invariant (group boundary, row-count cap, etc.) says a stripe is complete.

Ships the first production consumer — `UserIdAlignedBufferPolicy` in
`fb_velox/dwio/sst/writer/` — and migrates the rexdb Nimble cluster-index
benchmark from its caller-side slice-and-flush loop (`userIdAwareWrite`)
to the standard `VeloxWriter::write()` path driven by the new policy.

**Interface additions** — `dwio/nimble/velox/BufferPolicy.h` (new):
- `BufferSlice { start, length }` — a contiguous row-range spec.
- `BufferRange { inputs, slices }` — parallel arrays; a stripe-ready
  collection of input vectors and per-input row ranges the writer ingests
  and flushes as one stripe.
- `BufferPolicy` with three virtuals:
  - `bufferInput(RowVectorPtr)` — accumulate.
  - `writeBuffer()` — drain the next completed range (empty if not ready).
  - `finalize()` — end-of-input signal; subsequent `writeBuffer()`s emit
    the residual open range instead of holding it for a future boundary.
- New `VeloxWriterOptions::bufferPolicyFactory`. When set, the writer
  routes every `write()` through the BufferPolicy and bypasses
  `shouldFlush`. When unset (the default), the writer takes the legacy
  path.

**Writer changes** — `dwio/nimble/velox/VeloxWriter.{h,cpp}`:
- Constructor builds `bufferPolicy_` from `options.bufferPolicyFactory` if
  set (owned for the writer's lifetime).
- `write()` branches: BufferPolicy path (bufferInput + `drainBufferPolicy`
  which loops writeBuffer + ingest + writeStripe until the policy returns
  empty) vs legacy path (write batch + evaluateFlushPolicy).
- `close()` calls `bufferPolicy_->finalize()` and drains before the tail
  writeStripe so any residual open range flushes as the final stripe.
- Non-`RowVector` inputs (dictionary-wrapped, etc.) bypass BufferPolicy
  and take the legacy path.
- FlushPolicy interface unchanged (still `shouldFlush` + `shouldChunk`
  with the doc comments added in the earlier revision).

**Production policy** — `fb_velox/dwio/sst/writer/UserIdAlignedBufferPolicy.{h,cpp}`
- Namespace `facebook::velox::sst`.
- `Options { userIdColumnIndex, maxRowsPerStripe }`.
- State: an accumulating open `BufferRange`, its row count, the
  last-observed user_id (for row-0 boundary detection across batches),
  a `readyQueue` of completed ranges, and a `finalized` flag.
- `bufferInput` scans the int64 user-id column, splits the incoming batch
  into user runs, and appends each run to the open range. Row-0 boundary
  vs `lastUserId_` closes the open range before ingesting the new batch;
  intra-batch boundaries close it between runs; row-cap hits close it
  mid-run and continue. The open range can span multiple buffered inputs
  when a user's rows arrive over several batches.
- `writeBuffer` drains `readyQueue` first, then (once finalized) emits the
  residual open range, then returns empty.
- `makeUserIdAlignedBufferPolicyFactory(Options)` — convenience helper
  returning a `bufferPolicyFactory`.

**Benchmark migration** — `rexdb/benchmarks/file_format/lib/NimbleIndexConverterLib.cpp`
- `createNimbleWriter`: sets `bufferPolicyFactory` in the
  `alignStripesToUsers` branch (via `makeUserIdAlignedBufferPolicyFactory`)
  instead of the previous `flushPolicyFactory`.
- No caller-side write path changes — the writer's own branching handles
  BufferPolicy vs FlushPolicy transparently.

Reviewed By: xiaoxmeng, jiahaol-work

Differential Revision: D113204192


