### PR TITLE
refactor(encoding): Add read_factors (default-selection) mode to nimble.encoding_selection_config (#1032)

### DIFF
--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -51,7 +51,7 @@ ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
   for (const auto& part : parts) {
     std::vector<std::string> kv;
     folly::split('=', part, kv);
-    NIMBLE_CHECK_EQ(
+    NIMBLE_USER_CHECK_EQ(
         kv.size(),
         2,
         "Invalid read factor format. "
@@ -59,7 +59,7 @@ ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
         "Unable to parse '{}'.",
         part);
     const auto value = folly::tryTo<float>(kv[1]);
-    NIMBLE_CHECK(
+    NIMBLE_USER_CHECK(
         value.hasValue(),
         "Unable to parse read factor value '{}' in '{}'. Expected valid float value.",
         kv[1],
@@ -75,13 +75,53 @@ ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors(
         break;
       }
     }
-    NIMBLE_CHECK(
+    NIMBLE_USER_CHECK(
         found,
         "Unknown or unexpected read factor encoding '{}'. Allowed values: {}",
         key,
         folly::join(",", possibleEncodingStrs));
   }
   return encodingReadFactors;
+}
+
+/* static */ std::optional<ManualEncodingSelectionPolicyFactory>
+ManualEncodingSelectionPolicyFactory::create(
+    std::string_view configStr,
+    std::optional<CompressionOptions> compressionOptions) {
+  std::optional<std::string_view> readFactors;
+  std::vector<std::string_view> entries;
+  folly::split(',', configStr, entries);
+  for (const auto entry : entries) {
+    const auto colonPos = entry.find(':');
+    NIMBLE_USER_CHECK(
+        colonPos != std::string_view::npos,
+        "Malformed nimble.encoding_selection_config entry '{}'; want key:value.",
+        entry);
+    const auto key = entry.substr(0, colonPos);
+    const auto value = entry.substr(colonPos + 1);
+    if (key == "type") {
+      // The dispatcher (createEncodingSelectionPolicyFactory) routes here only
+      // for type 'default'; reject a mismatched type reaching this factory.
+      NIMBLE_USER_CHECK_EQ(
+          value,
+          "default",
+          "nimble.encoding_selection_config type is not valid for the default encoding selection policy.");
+      continue;
+    } else if (key == "read_factors") {
+      // A repeated read_factors key takes the last value (last-one-wins).
+      readFactors = value;
+    } else {
+      NIMBLE_USER_FAIL(
+          "Unknown nimble.encoding_selection_config key '{}' for type 'default'.",
+          key);
+    }
+  }
+  if (!readFactors.has_value()) {
+    return std::nullopt;
+  }
+  return ManualEncodingSelectionPolicyFactory{
+      parseEncodingReadFactors(std::string(*readFactors)),
+      std::move(compressionOptions)};
 }
 
 ManualEncodingSelectionPolicyFactory::ManualEncodingSelectionPolicyFactory(

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -282,6 +282,18 @@ class ManualEncodingSelectionPolicyFactory {
   static std::vector<std::pair<nimble::EncodingType, float>>
   parseEncodingReadFactors(const std::string& readFactorsConfig);
 
+  /// Builds a factory from a nimble.encoding_selection_config string of the
+  /// form "type:default[,read_factors:<E1>=<f1>;<E2>=<f2>;...]". Ignores the
+  /// 'type' key (already used by createEncodingSelectionPolicyFactory). Returns
+  /// nullopt when no 'read_factors' are given, so the caller keeps the
+  /// nimble.manual_encoding_selection_read_factors default; otherwise a factory
+  /// whose read factors override that config. NimbleUserError on a malformed
+  /// entry or unknown key.
+  static std::optional<ManualEncodingSelectionPolicyFactory> create(
+      std::string_view configStr,
+      std::optional<CompressionOptions> compressionOptions =
+          CompressionOptions{});
+
   ManualEncodingSelectionPolicyFactory(
       std::vector<std::pair<EncodingType, float>> encodingReadFactors =
           defaultEncodingReadFactors(),

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -91,8 +91,12 @@ class Config : public velox::config::ConfigBase {
   ///       candidate set; streams with no compatible encoding in the set (e.g.
   ///       empty streams) still fall back to Trivial. Test/fuzz only; not for
   ///       production.
-  /// An empty/unset config keeps the default (manual) policy. See
-  /// RandomEncodingSelectionPolicy. E.g. "type:random,seed:42".
+  ///   type:default[,read_factors:<E1>=<f1>;<E2>=<f2>;...]
+  ///       Default (manual) selection; 'read_factors' (optional) overrides the
+  ///       MANUAL_ENCODING_SELECTION_READ_FACTORS config.
+  /// An empty/unset config, or type:default without read_factors, keeps the
+  /// default (manual) policy. See RandomEncodingSelectionPolicy. E.g.
+  /// "type:random,seed:42" or "type:default,read_factors:Trivial=0.5".
   // @lint-ignore CLANGTIDY facebook-hte-NonPodStaticDeclaration
   static Entry<std::string> ENCODING_SELECTION_CONFIG;
 

--- a/dwio/nimble/velox/writer/EncodingSelectionPolicyFactory.cpp
+++ b/dwio/nimble/velox/writer/EncodingSelectionPolicyFactory.cpp
@@ -16,6 +16,7 @@
 #include "dwio/nimble/velox/writer/EncodingSelectionPolicyFactory.h"
 
 #include <folly/String.h>
+#include <glog/logging.h>
 #include <vector>
 
 #include "dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.h"
@@ -57,7 +58,23 @@ createEncodingSelectionPolicyFactory(
       !type.empty(),
       "nimble.encoding_selection_config '{}' is missing a 'type'.",
       configStr);
+  if (type == "default") {
+    // The manual factory parses its own keys; nullopt (no read_factors) keeps
+    // the nimble.manual_encoding_selection_read_factors default.
+    auto manualFactory = ManualEncodingSelectionPolicyFactory::create(
+        configStr, std::move(compressionOptions));
+    if (!manualFactory.has_value()) {
+      return std::nullopt;
+    }
+    return
+        [factory = std::move(*manualFactory)](
+            DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+          return factory.createPolicy(dataType);
+        };
+  }
   if (type == "random") {
+    LOG(WARNING)
+        << "Using test-only Nimble random encoding selection; not for production use.";
     return
         [factory = testing::RandomEncodingSelectionPolicyFactory::create(
              configStr, std::move(compressionOptions))](
@@ -66,7 +83,7 @@ createEncodingSelectionPolicyFactory(
         };
   }
   NIMBLE_USER_FAIL(
-      "Invalid nimble.encoding_selection_config type '{}'. Valid: 'random'.",
+      "Invalid nimble.encoding_selection_config type '{}'. Valid: 'default', 'random'.",
       type);
 }
 


### PR DESCRIPTION
Summary:

Follow-up to D110052628. Extends `nimble.encoding_selection_config` to configure the default (manual) encoding selection, not just random selection.

- New `read_factors:<E1>=<f1>;<E2>=<f2>;...` mode: runs the default `ManualEncodingSelectionPolicy` with the given read factors (parsed by `ManualEncodingSelectionPolicyFactory::parseEncodingReadFactors`). This OVERRIDES the `nimble.manual_encoding_selection_read_factors` config.
- `createEncodingSelectionPolicyCreator()` dispatches the config: `read_factors` -> manual, `seed` -> random. The two modes are mutually exclusive (`NimbleUserError` otherwise). `NimbleWriterOptionBuilder` uses it, falling back to the default policy when the config is empty.
- Shared the `key:value` tokenizer between the random and default parsers.
- `parseEncodingReadFactors` now raises `NimbleUserError` (was `NimbleInternalError`) on malformed input, since it parses user config.

Reviewed By: xiaoxmeng

Differential Revision: D113358849


