### PR TITLE
feat: Add BlockBitPacking native slice support (#1033)

### DIFF
--- a/dwio/nimble/common/Vector.h
+++ b/dwio/nimble/common/Vector.h
@@ -17,10 +17,14 @@
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "velox/buffer/Buffer.h"
+#include "velox/buffer/BufferPool.h"
 #include "velox/common/memory/Memory.h"
 
 #include <array>
+#include <cstdint>
 #include <memory>
+#include <type_traits>
+#include <utility>
 
 namespace facebook::nimble {
 
@@ -364,6 +368,135 @@ class Vector {
 #ifndef NDEBUG
   inline static std::array<T, sizeof(size_t)> placeholder_;
 #endif
+};
+
+/// Owns a temporary Vector and returns its allocation to a BufferPool.
+template <typename V>
+class ScopedVector {
+ public:
+  ScopedVector(
+      uint64_t size,
+      velox::memory::MemoryPool* pool,
+      velox::BufferPool* bufferPool)
+      : bufferPool_{bufferPool},
+        vector_{acquireVectorBuffer(size, pool, bufferPool)} {
+    vector_.resize(size);
+  }
+
+  ~ScopedVector() {
+    if (bufferPool_ != nullptr) {
+      auto buffer = vector_.releaseBuffer();
+      if (buffer != nullptr) {
+        bufferPool_->release(std::move(buffer));
+      }
+    }
+  }
+
+  ScopedVector(const ScopedVector&) = delete;
+  ScopedVector& operator=(const ScopedVector&) = delete;
+
+  operator Vector<V>&() {
+    return vector_;
+  }
+
+  operator const Vector<V>&() const {
+    return vector_;
+  }
+
+  Vector<V>* operator->() {
+    return &vector_;
+  }
+
+  const Vector<V>* operator->() const {
+    return &vector_;
+  }
+
+  Vector<V>& operator*() {
+    return vector_;
+  }
+
+  const Vector<V>& operator*() const {
+    return vector_;
+  }
+
+  V& operator[](uint64_t i) {
+    return vector_[i];
+  }
+
+  const V& operator[](uint64_t i) const {
+    return vector_[i];
+  }
+
+  V* begin() {
+    return vector_.begin();
+  }
+
+  V* end() {
+    return vector_.end();
+  }
+
+  const V* begin() const {
+    return vector_.begin();
+  }
+
+  const V* end() const {
+    return vector_.end();
+  }
+
+  V* data() {
+    return vector_.data();
+  }
+
+  const V* data() const {
+    return vector_.data();
+  }
+
+  uint64_t size() const {
+    return vector_.size();
+  }
+
+  bool empty() const {
+    return vector_.empty();
+  }
+
+  uint64_t capacity() const {
+    return vector_.capacity();
+  }
+
+  void reserve(uint64_t size) {
+    vector_.reserve(size);
+  }
+
+  void resize(uint64_t size) {
+    vector_.resize(size);
+  }
+
+  void push_back(V value) {
+    vector_.push_back(value);
+  }
+
+  template <typename... Args>
+  void emplace_back(Args&&... args) {
+    vector_.emplace_back(std::forward<Args>(args)...);
+  }
+
+ private:
+  static Vector<V> acquireVectorBuffer(
+      uint64_t size,
+      velox::memory::MemoryPool* pool,
+      velox::BufferPool* bufferPool) {
+    using InnerType =
+        typename std::conditional<std::is_same_v<V, bool>, uint8_t, V>::type;
+    if (bufferPool != nullptr && size > 0) {
+      if (auto buffer = bufferPool->get(size * sizeof(InnerType))) {
+        return Vector<V>{std::move(buffer)};
+      }
+    }
+    return Vector<V>{pool};
+  }
+
+  velox::BufferPool* const bufferPool_;
+  Vector<V> vector_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/common/tests/EncodingTypeTest.cpp
+++ b/dwio/nimble/common/tests/EncodingTypeTest.cpp
@@ -27,7 +27,7 @@ namespace facebook::nimble::test {
 
 // --- EncodingPhysicalType<int32_t>: identity mapping ---
 
-TEST(EncodingTypeTest, Int32IdentityMapping) {
+TEST(EncodingTypeTest, int32IdentityMapping) {
   int32_t value = 42;
   auto physical = EncodingPhysicalType<int32_t>::asEncodingPhysicalType(value);
   static_assert(std::is_same_v<decltype(physical), uint32_t>);
@@ -35,14 +35,14 @@ TEST(EncodingTypeTest, Int32IdentityMapping) {
   EXPECT_EQ(logical, 42);
 }
 
-TEST(EncodingTypeTest, Int32NegativeRoundTrip) {
+TEST(EncodingTypeTest, int32NegativeRoundTrip) {
   int32_t value = -12345;
   auto physical = EncodingPhysicalType<int32_t>::asEncodingPhysicalType(value);
   auto logical = EncodingPhysicalType<int32_t>::asEncodingLogicalType(physical);
   EXPECT_EQ(logical, -12345);
 }
 
-TEST(EncodingTypeTest, Int32Limits) {
+TEST(EncodingTypeTest, int32Limits) {
   {
     int32_t value = std::numeric_limits<int32_t>::min();
     auto physical =
@@ -63,7 +63,7 @@ TEST(EncodingTypeTest, Int32Limits) {
 
 // --- EncodingPhysicalType<float>: float <-> uint32_t bitwise conversion ---
 
-TEST(EncodingTypeTest, FloatRoundTrip) {
+TEST(EncodingTypeTest, floatRoundTrip) {
   float value = 3.14f;
   auto physical = EncodingPhysicalType<float>::asEncodingPhysicalType(value);
   static_assert(std::is_same_v<decltype(physical), uint32_t>);
@@ -71,7 +71,7 @@ TEST(EncodingTypeTest, FloatRoundTrip) {
   EXPECT_FLOAT_EQ(logical, 3.14f);
 }
 
-TEST(EncodingTypeTest, FloatNegativeZero) {
+TEST(EncodingTypeTest, floatNegativeZero) {
   float value = -0.0f;
   auto physical = EncodingPhysicalType<float>::asEncodingPhysicalType(value);
   auto logical = EncodingPhysicalType<float>::asEncodingLogicalType(physical);
@@ -82,14 +82,14 @@ TEST(EncodingTypeTest, FloatNegativeZero) {
   EXPECT_NE(bits, 0u); // -0.0f has sign bit set
 }
 
-TEST(EncodingTypeTest, FloatNaN) {
+TEST(EncodingTypeTest, floatNaN) {
   float value = std::numeric_limits<float>::quiet_NaN();
   auto physical = EncodingPhysicalType<float>::asEncodingPhysicalType(value);
   auto logical = EncodingPhysicalType<float>::asEncodingLogicalType(physical);
   EXPECT_TRUE(std::isnan(logical));
 }
 
-TEST(EncodingTypeTest, FloatInfinity) {
+TEST(EncodingTypeTest, floatInfinity) {
   float value = std::numeric_limits<float>::infinity();
   auto physical = EncodingPhysicalType<float>::asEncodingPhysicalType(value);
   auto logical = EncodingPhysicalType<float>::asEncodingLogicalType(physical);
@@ -98,7 +98,7 @@ TEST(EncodingTypeTest, FloatInfinity) {
 
 // --- EncodingPhysicalType<double>: double <-> uint64_t bitwise conversion ---
 
-TEST(EncodingTypeTest, DoubleRoundTrip) {
+TEST(EncodingTypeTest, doubleRoundTrip) {
   double value = 2.718281828;
   auto physical = EncodingPhysicalType<double>::asEncodingPhysicalType(value);
   static_assert(std::is_same_v<decltype(physical), uint64_t>);
@@ -106,14 +106,14 @@ TEST(EncodingTypeTest, DoubleRoundTrip) {
   EXPECT_DOUBLE_EQ(logical, 2.718281828);
 }
 
-TEST(EncodingTypeTest, DoubleNaN) {
+TEST(EncodingTypeTest, doubleNaN) {
   double value = std::numeric_limits<double>::quiet_NaN();
   auto physical = EncodingPhysicalType<double>::asEncodingPhysicalType(value);
   auto logical = EncodingPhysicalType<double>::asEncodingLogicalType(physical);
   EXPECT_TRUE(std::isnan(logical));
 }
 
-TEST(EncodingTypeTest, DoubleNegativeZero) {
+TEST(EncodingTypeTest, doubleNegativeZero) {
   double value = -0.0;
   auto physical = EncodingPhysicalType<double>::asEncodingPhysicalType(value);
   auto logical = EncodingPhysicalType<double>::asEncodingLogicalType(physical);
@@ -125,7 +125,7 @@ TEST(EncodingTypeTest, DoubleNegativeZero) {
 
 // --- asEncodingPhysicalTypeSpan ---
 
-TEST(EncodingTypeTest, AsEncodingPhysicalTypeSpanFloat) {
+TEST(EncodingTypeTest, asEncodingPhysicalTypeSpanFloat) {
   std::vector<float> values = {1.0f, 2.0f, 3.0f, -0.0f};
   auto span = std::span<const float>(values);
   auto physicalSpan =
@@ -140,7 +140,7 @@ TEST(EncodingTypeTest, AsEncodingPhysicalTypeSpanFloat) {
   }
 }
 
-TEST(EncodingTypeTest, AsEncodingPhysicalTypeSpanInt32) {
+TEST(EncodingTypeTest, asEncodingPhysicalTypeSpanInt32) {
   std::vector<int32_t> values = {-1, 0, 1, 100};
   auto span = std::span<const int32_t>(values);
   auto physicalSpan =
@@ -154,7 +154,7 @@ TEST(EncodingTypeTest, AsEncodingPhysicalTypeSpanInt32) {
   }
 }
 
-TEST(EncodingTypeTest, AsEncodingPhysicalTypeSpanEmpty) {
+TEST(EncodingTypeTest, asEncodingPhysicalTypeSpanEmpty) {
   std::vector<float> values;
   auto span = std::span<const float>(values);
   auto physicalSpan =

--- a/dwio/nimble/common/tests/VectorTest.cpp
+++ b/dwio/nimble/common/tests/VectorTest.cpp
@@ -15,6 +15,8 @@
  */
 #include "dwio/nimble/common/Vector.h"
 #include <gtest/gtest.h>
+#include <numeric>
+#include "velox/buffer/BufferPool.h"
 #include "velox/common/memory/Memory.h"
 
 DECLARE_bool(velox_enable_memory_usage_track_in_default_memory_pool);
@@ -61,7 +63,7 @@ class VectorTest : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> pool_;
 };
 
-TEST_F(VectorTest, FromRange) {
+TEST_F(VectorTest, fromRange) {
   std::vector<int32_t> source{4, 5, 6};
   nimble::Vector<int32_t> v1(pool_.get(), source.begin(), source.end());
   EXPECT_EQ(3, v1.size());
@@ -70,7 +72,7 @@ TEST_F(VectorTest, FromRange) {
   EXPECT_EQ(6, v1[2]);
 }
 
-TEST_F(VectorTest, EqualOp1) {
+TEST_F(VectorTest, equalOp1) {
   nimble::Vector<int32_t> v1(pool_.get());
   v1.push_back(1);
   v1.emplace_back(2);
@@ -97,7 +99,7 @@ TEST_F(VectorTest, EqualOp1) {
   EXPECT_EQ(5, v2[1]);
 }
 
-TEST_F(VectorTest, ExplicitMoveEqualOp) {
+TEST_F(VectorTest, explicitMoveEqualOp) {
   nimble::Vector<int32_t> v1(pool_.get());
   v1.push_back(1);
   v1.emplace_back(2);
@@ -126,7 +128,7 @@ TEST_F(VectorTest, ExplicitMoveEqualOp) {
   ASSERT_TRUE(v2.empty());
 }
 
-TEST_F(VectorTest, MoveEqualOp1) {
+TEST_F(VectorTest, moveEqualOp1) {
   nimble::Vector<int32_t> v1(pool_.get());
   v1.push_back(1);
   v1.emplace_back(2);
@@ -141,7 +143,7 @@ TEST_F(VectorTest, MoveEqualOp1) {
   EXPECT_EQ(5, v1[1]);
 }
 
-TEST_F(VectorTest, CopyCtr) {
+TEST_F(VectorTest, copyCtr) {
   nimble::Vector<int32_t> v2(pool_.get());
   v2.push_back(3);
   v2.emplace_back(4);
@@ -164,7 +166,7 @@ TEST_F(VectorTest, CopyCtr) {
   EXPECT_EQ(4, v2[1]);
 }
 
-TEST_F(VectorTest, BoolInitializerList) {
+TEST_F(VectorTest, boolInitializerList) {
   nimble::Vector<bool> v1(pool_.get(), {true, false, true});
   EXPECT_EQ(3, v1.size());
   EXPECT_EQ(true, v1[0]);
@@ -172,7 +174,7 @@ TEST_F(VectorTest, BoolInitializerList) {
   EXPECT_EQ(true, v1[2]);
 }
 
-TEST_F(VectorTest, BoolEqualOp1) {
+TEST_F(VectorTest, boolEqualOp1) {
   nimble::Vector<bool> v1(pool_.get());
   v1.push_back(false);
   v1.emplace_back(true);
@@ -200,7 +202,7 @@ TEST_F(VectorTest, BoolEqualOp1) {
   EXPECT_EQ(false, v2[1]);
 }
 
-TEST_F(VectorTest, BoolMoveEqualOp1) {
+TEST_F(VectorTest, boolMoveEqualOp1) {
   nimble::Vector<bool> v1(pool_.get());
   v1.push_back(true);
   v1.emplace_back(false);
@@ -217,7 +219,7 @@ TEST_F(VectorTest, BoolMoveEqualOp1) {
   EXPECT_EQ(true, v1[1]);
 }
 
-TEST_F(VectorTest, BoolCopyCtr) {
+TEST_F(VectorTest, boolCopyCtr) {
   nimble::Vector<bool> v2(pool_.get());
   v2.push_back(true);
   v2.emplace_back(false);
@@ -233,7 +235,75 @@ TEST_F(VectorTest, BoolCopyCtr) {
   EXPECT_EQ(false, v2[1]);
 }
 
-TEST_F(VectorTest, MemoryCleanup) {
+TEST_F(VectorTest, scopedVectorReleasesBufferToPool) {
+  velox::BufferPool bufferPool{velox::BufferPool::kDefaultCapacity};
+
+  {
+    nimble::ScopedVector<uint32_t> scratch{
+        /*size=*/4, pool_.get(), &bufferPool};
+    ASSERT_EQ(scratch.size(), 4);
+    scratch[0] = 123;
+    EXPECT_EQ(scratch[0], 123);
+    EXPECT_EQ(bufferPool.size(), 0);
+  }
+  EXPECT_EQ(bufferPool.size(), 1);
+
+  {
+    nimble::ScopedVector<uint32_t> scratch{
+        /*size=*/2, pool_.get(), &bufferPool};
+    EXPECT_EQ(scratch.size(), 2);
+    EXPECT_EQ(bufferPool.size(), 0);
+  }
+  EXPECT_EQ(bufferPool.size(), 1);
+}
+
+TEST_F(VectorTest, scopedVectorWorksWithoutBufferPool) {
+  nimble::ScopedVector<bool> scratch{
+      /*size=*/3, pool_.get(), /*bufferPool=*/nullptr};
+  ASSERT_EQ(scratch.size(), 3);
+  scratch[0] = true;
+  scratch[1] = false;
+  EXPECT_TRUE(scratch[0]);
+  EXPECT_FALSE(scratch[1]);
+}
+
+TEST_F(VectorTest, scopedVectorOperations) {
+  nimble::ScopedVector<uint32_t> scratch{
+      /*size=*/0, pool_.get(), /*bufferPool=*/nullptr};
+  EXPECT_TRUE(scratch.empty());
+
+  scratch.reserve(3);
+  EXPECT_GE(scratch.capacity(), 3);
+  scratch.push_back(1);
+  scratch.emplace_back(2);
+  scratch.resize(3);
+  scratch[2] = 3;
+
+  EXPECT_EQ(scratch.size(), 3);
+
+  nimble::Vector<uint32_t>& values = scratch;
+  EXPECT_EQ(values.size(), scratch.size());
+  EXPECT_EQ(values.data(), scratch.data());
+  EXPECT_EQ(values[0], 1);
+
+  EXPECT_EQ(scratch->capacity(), scratch.capacity());
+  EXPECT_EQ((*scratch)[1], 2);
+  EXPECT_EQ(scratch[2], 3);
+  EXPECT_EQ(std::accumulate(scratch.begin(), scratch.end(), uint32_t{0}), 6);
+
+  const auto& constScratch = scratch;
+  const nimble::Vector<uint32_t>& constValues = constScratch;
+  EXPECT_EQ(constValues.data(), constScratch.data());
+  EXPECT_EQ(constValues[0], 1);
+  EXPECT_EQ(constScratch->size(), 3);
+  EXPECT_EQ((*constScratch)[1], 2);
+  EXPECT_EQ(constScratch[2], 3);
+  EXPECT_EQ(
+      std::accumulate(constScratch.begin(), constScratch.end(), uint32_t{0}),
+      6);
+}
+
+TEST_F(VectorTest, memoryCleanup) {
   EXPECT_EQ(0, pool_->usedBytes());
   {
     nimble::Vector<int32_t> v(pool_.get());
@@ -262,7 +332,7 @@ TEST_F(VectorTest, MemoryCleanup) {
   EXPECT_EQ(0, pool_->usedBytes());
 }
 
-TEST_F(VectorTest, ReserveActualSize) {
+TEST_F(VectorTest, reserveActualSize) {
   EXPECT_EQ(0, pool_->usedBytes());
 
   // There is no good way to assert the exact expected size because of padding

--- a/dwio/nimble/encodings/ALPEncoding.h
+++ b/dwio/nimble/encodings/ALPEncoding.h
@@ -205,7 +205,6 @@ class ALPEncoding final
       std::span<const physicalType> values,
       Buffer& buffer,
       const Encoding::Options& options = {}) {
-    const bool useVarint = options.useVarintRowCount;
     if (values.empty()) {
       NIMBLE_INCOMPATIBLE_ENCODING("ALP encoding cannot encode empty data.");
     }
@@ -256,13 +255,18 @@ class ALPEncoding final
         (exceptionCount > 0 ? varint::varintSize(exceptionCount) : 0) +
         varint::varintSize(serializedEncoded.size());
     const uint32_t encodingSize =
-        Encoding::serializePrefixSize(rowCount, useVarint) + metadataSize +
-        serializedEncoded.size() + exceptionPositionsSize + exceptionValuesSize;
+        Encoding::serializePrefixSize(rowCount, options.useVarintRowCount) +
+        metadataSize + serializedEncoded.size() + exceptionPositionsSize +
+        exceptionValuesSize;
 
     char* reserved = buffer.reserve(encodingSize);
     char* pos = reserved;
     Encoding::serializePrefix(
-        EncodingType::ALP, TypeTraits<T>::dataType, rowCount, useVarint, pos);
+        EncodingType::ALP,
+        TypeTraits<T>::dataType,
+        rowCount,
+        options.useVarintRowCount,
+        pos);
 
     detail::alp::writeHeader(
         detail::alp::Header{

--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -26,8 +26,10 @@
 #include "dwio/nimble/common/Constants.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/compression/Compression.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
@@ -35,6 +37,8 @@
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/views/EncodingViewFactory.h"
+#include "folly/ScopeGuard.h"
 #include "velox/common/base/BitUtil.h"
 #include "velox/dwio/common/DecoderUtil.h"
 #include "velox/dwio/common/Lemire/BitPacking/bitpackinghelpers.h"
@@ -100,6 +104,13 @@ class BlockBitPackingEncoding final
       Buffer& buffer,
       const Encoding::Options& options = {});
 
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
   /// Estimates the uncompressed encoded size using the same per-block packing
   /// decisions as encode(). The per-block metadata is routed through nested
   /// encoding selection (data-dependent size), so it is estimated as Trivial
@@ -119,8 +130,10 @@ class BlockBitPackingEncoding final
       return std::nullopt;
     }
 
+    uint32_t rowCount{0};
     uint64_t packedSize = 0;
     for (const auto& block : blocks) {
+      rowCount += block.count;
       const auto rawSize = block.count * sizeof(physicalType);
       const auto range = block.max - block.min;
       const auto bw = range == 0 ? 0 : velox::bits::bitsRequired(range);
@@ -137,11 +150,20 @@ class BlockBitPackingEncoding final
       }
     }
 
-    const uint64_t metadataSize = kMetadataHeaderSize +
-        TrivialEncoding<physicalType>::estimateSize(numBlocks) +
-        TrivialEncoding<uint8_t>::estimateSize(numBlocks) +
-        TrivialEncoding<uint32_t>::estimateSize(numBlocks);
-    return EncodingPrefix::kFixedPrefixSize + metadataSize + packedSize;
+    const auto baselinesSize = estimateMetadataSize<physicalType>(numBlocks);
+    const auto bitWidthsSize = estimateMetadataSize<uint8_t>(numBlocks);
+    const auto offsetsSize = estimateMetadataSize<uint32_t>(numBlocks);
+    const auto firstBlockRows = std::min<uint32_t>(blockSize, rowCount);
+    const uint64_t metadataSize = headerSize(
+                                      blockSize,
+                                      numBlocks,
+                                      static_cast<uint32_t>(baselinesSize),
+                                      static_cast<uint32_t>(bitWidthsSize),
+                                      static_cast<uint32_t>(offsetsSize),
+                                      firstBlockRows) +
+        baselinesSize + bitWidthsSize + offsetsSize;
+    return EncodingPrefix::serializedSize(rowCount, /*useVarint=*/false) +
+        metadataSize + packedSize;
   }
 
   std::string debugString(int offset) const final;
@@ -149,15 +171,6 @@ class BlockBitPackingEncoding final
  private:
   friend class BlockBitPackingEncodingView<T>;
 
-  // Fixed metadata header written before the three nested sub-streams:
-  // compressionType + blockSize + numBlocks + three 4-byte sub-stream size
-  // prefixes. Shared by encode() and estimateSize() so the two stay in sync.
-  static constexpr uint32_t kMetadataHeaderSize =
-      sizeof(uint8_t) /*compressionType=*/ + sizeof(uint16_t) /*blockSize=*/ +
-      sizeof(uint16_t) /*numBlocks=*/ +
-      3 * sizeof(uint32_t) /*subStreamSizePrefixes=*/;
-
-  // Per-block encoding plan used while serializing and estimating size.
   struct BlockInfo {
     physicalType baseline;
     uint8_t bitWidth;
@@ -166,6 +179,294 @@ class BlockBitPackingEncoding final
     uint32_t count;
     bool skipEncoding;
   };
+
+  static void writeBlockPayload(
+      std::span<const physicalType> values,
+      const BlockInfo& block,
+      char* output) {
+    if (block.skipEncoding) {
+      std::memcpy(output, values.data(), block.count * sizeof(physicalType));
+      return;
+    }
+
+    if (block.bitWidth == 0) {
+      return;
+    }
+
+    if constexpr (sizeof(physicalType) == 4) {
+      // The 32-bit path uses Lemire fastpack for full 32-value groups; a
+      // trailing partial group falls back to FixedBitArray so callers can use
+      // any block row count.
+      constexpr uint32_t kGroupSize = 32;
+      const auto baseline32 = static_cast<uint32_t>(block.baseline);
+      auto* dst = reinterpret_cast<uint32_t*>(output);
+      const auto* src = reinterpret_cast<const uint32_t*>(values.data());
+
+      const auto fullGroups = block.count / kGroupSize;
+      const auto remainder = block.count % kGroupSize;
+
+      uint32_t tmp[kGroupSize];
+      for (uint32_t group = 0; group < fullGroups; ++group) {
+        for (uint32_t i = 0; i < kGroupSize; ++i) {
+          tmp[i] = src[group * kGroupSize + i] - baseline32;
+        }
+        velox::fastpforlib::fastpack(tmp, dst, block.bitWidth);
+        dst += block.bitWidth;
+      }
+      if (remainder > 0) {
+        const auto remainderOffset =
+            fullGroups * kGroupSize * block.bitWidth / 8;
+        FixedBitArray fba(output + remainderOffset, block.bitWidth);
+        for (uint32_t i = 0; i < remainder; ++i) {
+          fba.set(i, values[fullGroups * kGroupSize + i] - block.baseline);
+        }
+      }
+    } else {
+      FixedBitArray fba(output, block.bitWidth);
+      fba.bulkSetWithBaseline(0, block.count, values.data(), block.baseline);
+    }
+  }
+
+  static void writePayload(
+      std::span<const physicalType> values,
+      std::span<const BlockInfo> blocks,
+      uint32_t totalPackedSize,
+      char*& pos) {
+    std::memset(pos, 0, totalPackedSize);
+    uint32_t dataOffset{0};
+    for (const auto& block : blocks) {
+      writeBlockPayload(
+          values.subspan(block.start, block.count), block, pos + dataOffset);
+      dataOffset += block.packedSize;
+    }
+    pos += totalPackedSize;
+  }
+
+  static uint32_t headerSize(
+      uint16_t blockSize,
+      uint32_t numBlocks,
+      uint32_t baselinesSize,
+      uint32_t bitWidthsSize,
+      uint32_t offsetsSize,
+      uint32_t firstBlockRows) {
+    return /*compressionType=*/sizeof(uint8_t) + varint::varintSize(blockSize) +
+        varint::varintSize(numBlocks) + varint::varintSize(baselinesSize) +
+        varint::varintSize(bitWidthsSize) + varint::varintSize(offsetsSize) +
+        varint::varintSize(firstBlockRows);
+  }
+
+  static void writeSizedChild(std::string_view value, char*& pos) {
+    varint::writeVarint(static_cast<uint32_t>(value.size()), &pos);
+    encoding::writeBytes(value, pos);
+  }
+
+  template <typename MetadataType>
+  static uint64_t estimateMetadataSize(uint32_t rowCount) {
+    const auto trivialSize =
+        TrivialEncoding<MetadataType>::estimateSize(rowCount);
+    const auto fixedBitWidthSize =
+        FixedBitWidthEncoding<MetadataType>::estimateSize(
+            rowCount,
+            /*minValue=*/0,
+            /*maxValue=*/
+            std::numeric_limits<
+                typename TypeTraits<MetadataType>::physicalType>::max(),
+            Encoding::Options{});
+    return std::min(trivialSize, fixedBitWidthSize);
+  }
+
+  struct BlockSliceInfo {
+    // Source block that contributes rows to this output block.
+    uint32_t blockIndex{0};
+    // Byte offset of the source block payload, adjusted for raw partial blocks.
+    uint32_t packedOffset{0};
+    // First row copied from the source block.
+    uint32_t rowOffset{0};
+    // Bytes written for this output block.
+    uint32_t packedSize{0};
+    // Rows written for this output block.
+    uint32_t rowCount{0};
+    // Output bit width; zero also represents constant blocks.
+    uint8_t bitWidth{0};
+    // True when the payload is copied as raw physical values.
+    bool skipEncoding{false};
+  };
+
+  // Parsed stream metadata. lastBlockRows is derived from rowCount and the
+  // first-block override; it is not serialized.
+  struct SourceHeader {
+    uint32_t rowCount{0};
+    uint16_t blockSize{0};
+    uint16_t numBlocks{0};
+    CompressionType compressionType{CompressionType::Uncompressed};
+    std::string_view encodedBaselines;
+    std::string_view encodedBitWidths;
+    std::string_view encodedBlockOffsets;
+    uint32_t firstBlockRows{0};
+    uint32_t lastBlockRows{0};
+    std::string_view packedData;
+  };
+
+  static SourceHeader parseSourceHeader(
+      std::string_view encoded,
+      const Encoding::Options& options) {
+    SourceHeader source;
+    source.rowCount =
+        EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+    const char* pos = encoded.data() +
+        EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+    source.compressionType =
+        static_cast<CompressionType>(encoding::readChar(pos));
+    source.blockSize = static_cast<uint16_t>(varint::readVarint32(&pos));
+    source.numBlocks = static_cast<uint16_t>(varint::readVarint32(&pos));
+    NIMBLE_CHECK_GT(source.blockSize, 0);
+    NIMBLE_CHECK_GT(source.numBlocks, 0);
+    NIMBLE_CHECK_GT(source.rowCount, 0);
+
+    const auto baselinesSize = varint::readVarint32(&pos);
+    source.encodedBaselines = {pos, baselinesSize};
+    pos += baselinesSize;
+    const auto bitWidthsSize = varint::readVarint32(&pos);
+    source.encodedBitWidths = {pos, bitWidthsSize};
+    pos += bitWidthsSize;
+    const auto blockOffsetsSize = varint::readVarint32(&pos);
+    source.encodedBlockOffsets = {pos, blockOffsetsSize};
+    pos += blockOffsetsSize;
+    source.firstBlockRows = varint::readVarint32(&pos);
+    NIMBLE_CHECK_GT(source.firstBlockRows, 0);
+    NIMBLE_CHECK_LE(source.firstBlockRows, source.blockSize);
+    NIMBLE_CHECK_LE(source.firstBlockRows, source.rowCount);
+    source.lastBlockRows = source.numBlocks == 1 ? source.firstBlockRows
+                                                 : source.rowCount -
+            source.firstBlockRows - (source.numBlocks - 2) * source.blockSize;
+    NIMBLE_CHECK_GT(source.lastBlockRows, 0);
+    NIMBLE_CHECK_LE(source.lastBlockRows, source.blockSize);
+
+    source.packedData = {pos, static_cast<size_t>(encoded.end() - pos)};
+    return source;
+  }
+
+  static std::string_view packedDataSource(
+      const SourceHeader& source,
+      velox::BufferPtr& uncompressedData,
+      velox::memory::MemoryPool* pool,
+      const Encoding::Options& options) {
+    if (source.compressionType == CompressionType::Uncompressed) {
+      return source.packedData;
+    }
+    NIMBLE_CHECK_NOT_NULL(pool);
+    uncompressedData = Compression::uncompress(
+        *pool,
+        source.compressionType,
+        DataType::Undefined,
+        source.packedData,
+        options.decompressCounter(),
+        options.bufferPool);
+    return {uncompressedData->as<char>(), uncompressedData->size()};
+  }
+
+  static void readBlockOffsets(
+      const SourceHeader& source,
+      uint32_t blockOffset,
+      uint32_t blockCount,
+      uint32_t packedDataSize,
+      Vector<uint32_t>& output,
+      velox::memory::MemoryPool* pool,
+      const Encoding::Options& options) {
+    // Each block size is derived from its start offset and the next block's
+    // start offset. For the final source block, the next offset is the packed
+    // data size because there is no stored successor offset.
+    NIMBLE_CHECK_NOT_NULL(pool);
+    const auto numReadBlocks =
+        blockCount + (blockOffset + blockCount < source.numBlocks ? 1 : 0);
+    detail::createTypedEncodingView<uint32_t>(
+        source.encodedBlockOffsets, pool, options)
+        ->read(blockOffset, numReadBlocks, output.data());
+    if (numReadBlocks == blockCount) {
+      output[blockCount] = packedDataSize;
+    }
+  }
+
+  // Sliced streams can preserve a partial first block, so row counts are based
+  // on the parsed source header instead of blockIndex * blockSize.
+  static uint32_t blockRowCount(
+      const SourceHeader& source,
+      uint32_t blockIndex) {
+    if (blockIndex == 0) {
+      return source.firstBlockRows;
+    }
+    if (blockIndex == source.numBlocks - 1) {
+      return source.lastBlockRows;
+    }
+    return source.blockSize;
+  }
+
+  // Returns the number of rows in the given block (may be less than
+  // blockSize_ for the last block).
+  uint32_t blockRowCount(uint32_t blockIndex) const {
+    if (blockIndex == 0) {
+      return firstBlockRows_;
+    }
+    if (blockIndex == numBlocks_ - 1) {
+      return lastBlockRows_;
+    }
+    return blockSize_;
+  }
+
+  // Row offset for sliced streams where the first block may not be full.
+  static uint32_t blockRowOffset(
+      const SourceHeader& source,
+      uint32_t blockIndex) {
+    if (blockIndex == 0) {
+      return 0;
+    }
+    return source.firstBlockRows + (blockIndex - 1) * source.blockSize;
+  }
+
+  static uint32_t blockIndex(const SourceHeader& source, uint32_t row) {
+    if (row < source.firstBlockRows) {
+      return 0;
+    }
+    const auto blockIndex =
+        1 + (row - source.firstBlockRows) / source.blockSize;
+    NIMBLE_CHECK_LT(blockIndex, source.numBlocks);
+    return blockIndex;
+  }
+
+  uint32_t blockIndex(uint32_t row) const {
+    if (row < firstBlockRows_) {
+      return 0;
+    }
+    const auto blockIndex = 1 + (row - firstBlockRows_) / blockSize_;
+    NIMBLE_CHECK_LT(blockIndex, numBlocks_);
+    return blockIndex;
+  }
+
+  uint32_t blockRowOffset(uint32_t blockIndex) const {
+    if (blockIndex == 0) {
+      return 0;
+    }
+    return firstBlockRows_ + (blockIndex - 1) * blockSize_;
+  }
+
+  // Returns the byte size of a block payload for the selected storage mode.
+  static uint32_t getPackedSize(uint32_t rowCount, uint8_t bitWidth) {
+    if (bitWidth == kRawBlockBitWidth) {
+      return static_cast<uint32_t>(rowCount * sizeof(physicalType));
+    }
+    if (bitWidth == 0) {
+      return uint32_t{0};
+    }
+    return static_cast<uint32_t>(FixedBitArray::bufferSize(rowCount, bitWidth));
+  }
+
+  static void writeBlockSlicesPayload(
+      const SourceHeader& source,
+      std::string_view packedData,
+      std::span<const BlockSliceInfo> blockSlices,
+      std::span<const uint32_t> sliceOffsets,
+      uint32_t totalPackedSize,
+      char*& pos);
 
   // Reads a single decoded value at the given absolute row index.
   physicalType readSingleValue(uint32_t row) const;
@@ -176,10 +477,6 @@ class BlockBitPackingEncoding final
       uint32_t blockValueOffset,
       uint32_t blockValueCount,
       physicalType* output) const;
-
-  // Returns the number of rows in the given block (may be less than
-  // blockSize_ for the last block).
-  uint32_t blockRowCount(uint32_t blockIndex) const;
 
   // Unpacks 'numRows' bit-packed values in fixed-size groups, falling
   // back to FixedBitArray for any trailing remainder.
@@ -196,11 +493,22 @@ class BlockBitPackingEncoding final
       uint32_t start,
       uint32_t count);
 
+  // Materializes one serialized per-block metadata child stream.
+  template <typename MetadataType>
+  void readMetadataStream(
+      std::string_view encoded,
+      Vector<MetadataType>& output,
+      velox::memory::MemoryPool& pool,
+      const std::function<void*(uint32_t)>& stringBufferFactory,
+      const Encoding::Options& options) const;
+
   uint16_t blockSize_;
   uint16_t numBlocks_;
   Vector<physicalType> baselines_;
   Vector<uint8_t> bitWidths_;
   Vector<uint32_t> blockOffsets_;
+  uint32_t firstBlockRows_{0};
+  uint32_t lastBlockRows_{0};
   const char* packedData_;
   uint32_t row_ = 0;
   velox::BufferPtr uncompressedData_;
@@ -226,17 +534,20 @@ std::optional<uint64_t> BlockBitPackingEncoding<T>::estimateSize(
     const auto end = std::min<uint32_t>(start + blockSize, rowCount);
     packedSize += makeBlockInfo(values, start, end - start).packedSize;
   }
-  // Per-block metadata (baselines, bit widths, data offsets) is stored as
-  // nested encodings; dumping real files shows selection picks Trivial for all
-  // three, so estimate them as Trivial sub-encodings -- mirroring how
-  // Dictionary estimates its alphabet child. This is an approximation (the
-  // actual nested encoding is data-dependent); the estimate-vs-actual test
-  // allows a 2x band.
-  const uint64_t metadataSize = kMetadataHeaderSize +
-      TrivialEncoding<physicalType>::estimateSize(numBlocks) +
-      TrivialEncoding<uint8_t>::estimateSize(numBlocks) +
-      TrivialEncoding<uint32_t>::estimateSize(numBlocks);
-  return EncodingPrefix::kFixedPrefixSize + metadataSize + packedSize;
+  const auto baselinesSize = estimateMetadataSize<physicalType>(numBlocks);
+  const auto bitWidthsSize = estimateMetadataSize<uint8_t>(numBlocks);
+  const auto offsetsSize = estimateMetadataSize<uint32_t>(numBlocks);
+  const auto firstBlockRows = std::min<uint32_t>(blockSize, rowCount);
+  const uint64_t metadataSize = headerSize(
+                                    blockSize,
+                                    numBlocks,
+                                    static_cast<uint32_t>(baselinesSize),
+                                    static_cast<uint32_t>(bitWidthsSize),
+                                    static_cast<uint32_t>(offsetsSize),
+                                    firstBlockRows) +
+      baselinesSize + bitWidthsSize + offsetsSize;
+  return EncodingPrefix::serializedSize(rowCount, /*useVarint=*/false) +
+      metadataSize + packedSize;
 }
 
 template <typename T>
@@ -277,6 +588,78 @@ BlockBitPackingEncoding<T>::makeBlockInfo(
 }
 
 template <typename T>
+void BlockBitPackingEncoding<T>::writeBlockSlicesPayload(
+    const SourceHeader& source,
+    std::string_view packedData,
+    std::span<const BlockSliceInfo> blockSlices,
+    std::span<const uint32_t> sliceOffsets,
+    uint32_t totalPackedSize,
+    char*& pos) {
+  std::memset(pos, 0, totalPackedSize);
+  uint32_t dataOffset{0};
+  const auto needsBitCopy = [&](const BlockSliceInfo& blockSlice) {
+    return !blockSlice.skipEncoding && blockSlice.bitWidth != 0 &&
+        (blockSlice.rowOffset != 0 ||
+         blockSlice.rowCount != blockRowCount(source, blockSlice.blockIndex));
+  };
+  const auto copyBlockBitsRange = [&](uint32_t blockIndex) {
+    const auto& blockSlice = blockSlices[blockIndex];
+
+    const auto sourceBitOffset =
+        static_cast<uint64_t>(blockSlice.rowOffset) * blockSlice.bitWidth;
+    const auto sliceBits =
+        static_cast<uint64_t>(blockSlice.rowCount) * blockSlice.bitWidth;
+    if (sourceBitOffset % 8 == 0 && sliceBits % 8 == 0) {
+      std::memcpy(
+          pos + dataOffset,
+          packedData.data() + blockSlice.packedOffset + sourceBitOffset / 8,
+          blockSlice.packedSize);
+    } else {
+      velox::bits::copyBits(
+          reinterpret_cast<const uint64_t*>(
+              packedData.data() + blockSlice.packedOffset),
+          sourceBitOffset,
+          reinterpret_cast<uint64_t*>(pos + dataOffset),
+          /*targetOffset=*/0,
+          sliceBits);
+    }
+    dataOffset += blockSlice.packedSize;
+  };
+
+  const auto numBlocks = static_cast<uint32_t>(blockSlices.size());
+  const bool firstNeedsBitCopy = needsBitCopy(blockSlices[0]);
+  const bool lastNeedsBitCopy =
+      numBlocks > 1 && needsBitCopy(blockSlices[numBlocks - 1]);
+  if (firstNeedsBitCopy) {
+    copyBlockBitsRange(/*blockIndex=*/0);
+  }
+
+  uint32_t packedBegin = firstNeedsBitCopy ? 1 : 0;
+  const uint32_t packedEnd = lastNeedsBitCopy ? numBlocks - 1 : numBlocks;
+  // Constant blocks have rows but no packed payload (bit width 0). They still
+  // participate in slice offsets, but cannot anchor the source byte range for
+  // the coalesced copy.
+  while (packedBegin < packedEnd && blockSlices[packedBegin].packedSize == 0) {
+    ++packedBegin;
+  }
+  if (packedBegin < packedEnd) {
+    NIMBLE_CHECK_EQ(dataOffset, sliceOffsets[packedBegin]);
+    const auto packedEndOffset = sliceOffsets[packedEnd];
+    const auto packedBytes = packedEndOffset - sliceOffsets[packedBegin];
+    std::memcpy(
+        pos + dataOffset,
+        packedData.data() + blockSlices[packedBegin].packedOffset,
+        packedBytes);
+    dataOffset += packedBytes;
+  }
+
+  if (lastNeedsBitCopy) {
+    copyBlockBitsRange(numBlocks - 1);
+  }
+  pos += totalPackedSize;
+}
+
+template <typename T>
 BlockBitPackingEncoding<T>::BlockBitPackingEncoding(
     velox::memory::MemoryPool& pool,
     std::string_view data,
@@ -288,47 +671,45 @@ BlockBitPackingEncoding<T>::BlockBitPackingEncoding(
       blockOffsets_{this->template getVectorBuffer<uint32_t>()},
       packedData_{nullptr},
       buffer_{&pool} {
-  auto pos = data.data() + this->dataOffset();
-  auto compressionType = static_cast<CompressionType>(encoding::readChar(pos));
-  blockSize_ = encoding::read<const uint16_t>(pos);
-  numBlocks_ = encoding::read<const uint16_t>(pos);
+  const auto source = parseSourceHeader(data, options);
+  blockSize_ = source.blockSize;
+  numBlocks_ = source.numBlocks;
+  firstBlockRows_ = source.firstBlockRows;
+  lastBlockRows_ = source.lastBlockRows;
 
   NIMBLE_CHECK(blockSize_ > 0 && blockSize_ <= kMaxBlockSize);
-  NIMBLE_CHECK_EQ(numBlocks_, (this->rowCount() + blockSize_ - 1) / blockSize_);
 
   baselines_.resize(numBlocks_);
   bitWidths_.resize(numBlocks_);
   blockOffsets_.resize(numBlocks_);
 
-  // BlockBitPacking stores the per-block metadata (baselines, bit widths, data
-  // offsets) as self-describing nested encodings, letting Nimble's recursive
-  // encoding selection pick the best encoding for each metadata stream. The
-  // packed block data stays raw.
-  // Each metadata stream: read its 4-byte size, decode the nested sub-encoding
-  // into the target, then advance past it.
-  auto readMetadataStream = [&](auto& subStream) {
-    const uint32_t size = encoding::readUint32(pos);
-    EncodingFactory(options)
-        .create(pool, {pos, size}, stringBufferFactory)
-        ->materialize(numBlocks_, subStream.data());
-    pos += size;
-  };
-  readMetadataStream(baselines_); // per-block baselines
-  readMetadataStream(bitWidths_); // per-block bit widths
-  readMetadataStream(blockOffsets_); // per-block data offsets
+  readMetadataStream(
+      source.encodedBaselines, baselines_, pool, stringBufferFactory, options);
+  readMetadataStream(
+      source.encodedBitWidths, bitWidths_, pool, stringBufferFactory, options);
+  readMetadataStream(
+      source.encodedBlockOffsets,
+      blockOffsets_,
+      pool,
+      stringBufferFactory,
+      options);
 
-  if (compressionType != CompressionType::Uncompressed) {
-    uncompressedData_ = Compression::uncompress(
-        pool,
-        compressionType,
-        DataType::Undefined,
-        {pos, static_cast<size_t>(data.end() - pos)},
-        options.decompressCounter(),
-        options.bufferPool);
-    packedData_ = uncompressedData_->as<char>();
-  } else {
-    packedData_ = pos;
-  }
+  packedData_ =
+      packedDataSource(source, uncompressedData_, &pool, options).data();
+}
+
+template <typename T>
+template <typename MetadataType>
+void BlockBitPackingEncoding<T>::readMetadataStream(
+    std::string_view encoded,
+    Vector<MetadataType>& output,
+    velox::memory::MemoryPool& pool,
+    const std::function<void*(uint32_t)>& stringBufferFactory,
+    const Encoding::Options& options) const {
+  NIMBLE_CHECK_GT(numBlocks_, 0);
+  EncodingFactory(options)
+      .create(pool, encoded, stringBufferFactory)
+      ->materialize(numBlocks_, output.data());
 }
 
 template <typename T>
@@ -342,17 +723,10 @@ void BlockBitPackingEncoding<T>::skip(uint32_t rowCount) {
 }
 
 template <typename T>
-uint32_t BlockBitPackingEncoding<T>::blockRowCount(uint32_t blockIndex) const {
-  const auto totalRows = this->rowCount();
-  const auto start = static_cast<uint32_t>(blockIndex) * blockSize_;
-  return std::min(static_cast<uint32_t>(blockSize_), totalRows - start);
-}
-
-template <typename T>
 typename BlockBitPackingEncoding<T>::physicalType
 BlockBitPackingEncoding<T>::readSingleValue(uint32_t row) const {
-  const auto blockIndex = row / blockSize_;
-  const auto blockOffset = row % blockSize_;
+  const auto blockIndex = this->blockIndex(row);
+  const auto blockOffset = row - blockRowOffset(blockIndex);
   const auto bitWidth = bitWidths_[blockIndex];
   const auto baseline = baselines_[blockIndex];
   if (bitWidth == kRawBlockBitWidth) {
@@ -488,15 +862,16 @@ void BlockBitPackingEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
   uint32_t currentRow = row_;
 
   while (remaining > 0) {
-    const auto blockIndex = currentRow / blockSize_;
-    const auto blockOffset = currentRow % blockSize_;
-    const auto rowsInBlock = std::min(remaining, blockSize_ - blockOffset);
+    const auto blockIndex = this->blockIndex(currentRow);
+    const auto blockOffset = currentRow - blockRowOffset(blockIndex);
+    const auto blockRows =
+        std::min(remaining, blockRowCount(blockIndex) - blockOffset);
 
-    materializeBlockRange(blockIndex, blockOffset, rowsInBlock, output);
+    materializeBlockRange(blockIndex, blockOffset, blockRows, output);
 
-    output += rowsInBlock;
-    currentRow += rowsInBlock;
-    remaining -= rowsInBlock;
+    output += blockRows;
+    currentRow += blockRows;
+    remaining -= blockRows;
   }
   row_ += rowCount;
 }
@@ -576,11 +951,11 @@ void BlockBitPackingEncoding<T>::bulkScan(
       uint32_t decodedRows = 0;
       uint32_t currentAbsRow = startRow;
       while (decodedRows < static_cast<uint32_t>(numSelected)) {
-        const auto blockIndex = currentAbsRow / blockSize_;
-        const auto blockOffset = currentAbsRow % blockSize_;
+        const auto blockIndex = this->blockIndex(currentAbsRow);
+        const auto blockOffset = currentAbsRow - blockRowOffset(blockIndex);
         const auto toDecode = std::min(
             static_cast<uint32_t>(numSelected) - decodedRows,
-            blockSize_ - blockOffset);
+            blockRowCount(blockIndex) - blockOffset);
         materializeBlockRange(
             blockIndex, blockOffset, toDecode, dst + decodedRows);
         decodedRows += toDecode;
@@ -595,11 +970,11 @@ void BlockBitPackingEncoding<T>::bulkScan(
       uint32_t decodedRows = 0;
       uint32_t currentAbsRow = startRow;
       while (decodedRows < static_cast<uint32_t>(numSelected)) {
-        const auto blockIndex = currentAbsRow / blockSize_;
-        const auto blockOffset = currentAbsRow % blockSize_;
+        const auto blockIndex = this->blockIndex(currentAbsRow);
+        const auto blockOffset = currentAbsRow - blockRowOffset(blockIndex);
         const auto toDecode = std::min(
             static_cast<uint32_t>(numSelected) - decodedRows,
-            blockSize_ - blockOffset);
+            blockRowCount(blockIndex) - blockOffset);
         materializeBlockRange(
             blockIndex, blockOffset, toDecode, rawBuf + decodedRows);
         decodedRows += toDecode;
@@ -621,8 +996,8 @@ void BlockBitPackingEncoding<T>::bulkScan(
     while (i < numSelected) {
       const auto absRow = static_cast<uint32_t>(selectedRows[i]) +
           static_cast<uint32_t>(offset);
-      const auto blockIndex = absRow / blockSize_;
-      const auto blockStart = static_cast<uint32_t>(blockIndex) * blockSize_;
+      const auto blockIndex = this->blockIndex(absRow);
+      const auto blockStart = blockRowOffset(blockIndex);
       const auto bitWidth = bitWidths_[blockIndex];
       const auto baseline = baselines_[blockIndex];
 
@@ -631,7 +1006,7 @@ void BlockBitPackingEncoding<T>::bulkScan(
       while (runEnd < numSelected) {
         const auto nextAbsRow = static_cast<uint32_t>(selectedRows[runEnd]) +
             static_cast<uint32_t>(offset);
-        if (nextAbsRow / blockSize_ != blockIndex) {
+        if (this->blockIndex(nextAbsRow) != blockIndex) {
           break;
         }
         ++runEnd;
@@ -731,20 +1106,20 @@ std::string_view BlockBitPackingEncoding<T>::encode(
     std::span<const physicalType> values,
     Buffer& buffer,
     const Encoding::Options& options) {
-  const bool useVarint = options.useVarintRowCount;
   static_assert(
       std::is_unsigned_v<physicalType>, "Physical type must be unsigned.");
 
+  auto* pool = &buffer.getMemoryPool();
   const uint16_t blockSize = options.blockBitPackingBlockSize;
   const auto rowCount = static_cast<uint32_t>(values.size());
+  NIMBLE_CHECK_GT(rowCount, 0, "BlockBitPacking cannot encode empty streams.");
   const uint32_t numBlocks = velox::bits::divRoundUp(rowCount, blockSize);
   NIMBLE_CHECK_LE(
       numBlocks,
       kMaxBlockCount,
       "Row count too large for BlockBitPacking encoding.");
 
-  Vector<BlockInfo> blocks{&buffer.getMemoryPool()};
-  blocks.resize(numBlocks);
+  ScopedVector<BlockInfo> blocks{numBlocks, pool, options.bufferPool};
 
   uint32_t totalPackedSize = 0;
   for (uint16_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
@@ -758,73 +1133,24 @@ std::string_view BlockBitPackingEncoding<T>::encode(
   // header) >= rawSize, this encoding is not beneficial. The encoding selection
   // policy should avoid selecting it in that case. We still encode correctly so
   // the round-trip contract holds.
-  Vector<char> packedVector{&buffer.getMemoryPool()};
+  ScopedVector<char> packedVector{/*size=*/0, pool, options.bufferPool};
   auto dataCompressionPolicy = selection.compressionPolicy();
   CompressionEncoder<T> compressionEncoder{
-      buffer.getMemoryPool(),
+      *pool,
       *dataCompressionPolicy,
       DataType::Undefined,
       /*bitWidth=*/8,
       /*uncompressedSize=*/totalPackedSize,
       [&]() {
         packedVector.resize(totalPackedSize);
-        return std::span<char>{packedVector};
+        return std::span<char>{packedVector.data(), packedVector.size()};
       },
       [&](char*& pos) {
-        std::memset(pos, 0, totalPackedSize);
-        uint32_t dataOffset = 0;
-        for (uint16_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
-          const auto& block = blocks[blockIndex];
-
-          if (block.skipEncoding) {
-            std::memcpy(
-                pos + dataOffset,
-                values.data() + block.start,
-                block.count * sizeof(physicalType));
-          } else if (block.bitWidth > 0) {
-            if constexpr (sizeof(physicalType) == 4) {
-              constexpr uint32_t kGroupSize = 32;
-              const auto bitWidth = block.bitWidth;
-              const auto baseline32 = static_cast<uint32_t>(block.baseline);
-              auto* dst = reinterpret_cast<uint32_t*>(pos + dataOffset);
-              const auto* src = reinterpret_cast<const uint32_t*>(
-                  values.data() + block.start);
-
-              const auto fullGroups = block.count / kGroupSize;
-              const auto remainder = block.count % kGroupSize;
-
-              uint32_t tmp[kGroupSize];
-              for (uint32_t group = 0; group < fullGroups; ++group) {
-                for (uint32_t i = 0; i < kGroupSize; ++i) {
-                  tmp[i] = src[group * kGroupSize + i] - baseline32;
-                }
-                velox::fastpforlib::fastpack(tmp, dst, bitWidth);
-                dst += bitWidth;
-              }
-              if (remainder > 0) {
-                const auto remainderOffset =
-                    fullGroups * kGroupSize * bitWidth / 8;
-                FixedBitArray fba(
-                    pos + dataOffset + remainderOffset, block.bitWidth);
-                for (uint32_t i = 0; i < remainder; ++i) {
-                  fba.set(
-                      i,
-                      values[block.start + fullGroups * kGroupSize + i] -
-                          block.baseline);
-                }
-              }
-            } else {
-              // 1-, 2-, and 8-byte types: the unified bulk path picks the
-              // optimal packing for the width (4-byte uses SIMD fastpack
-              // above).
-              FixedBitArray fba(pos + dataOffset, block.bitWidth);
-              fba.bulkSetWithBaseline(
-                  0, block.count, values.data() + block.start, block.baseline);
-            }
-          }
-          dataOffset += block.packedSize;
-        }
-        pos += totalPackedSize;
+        writePayload(
+            values,
+            std::span<const BlockInfo>{blocks.data(), blocks.size()},
+            totalPackedSize,
+            pos);
         return pos;
       }};
 
@@ -833,12 +1159,9 @@ std::string_view BlockBitPackingEncoding<T>::encode(
   // encoding for each (e.g. Constant/Delta for correlated baselines, Delta for
   // the ascending offsets). The packed block data stays raw (still optionally
   // Zstd-compressed via the compression encoder).
-  Vector<physicalType> baselines{&buffer.getMemoryPool()};
-  baselines.resize(numBlocks);
-  Vector<uint8_t> bitWidths{&buffer.getMemoryPool()};
-  bitWidths.resize(numBlocks);
-  Vector<uint32_t> blockOffsets{&buffer.getMemoryPool()};
-  blockOffsets.resize(numBlocks);
+  ScopedVector<physicalType> baselines{numBlocks, pool, options.bufferPool};
+  ScopedVector<uint8_t> bitWidths{numBlocks, pool, options.bufferPool};
+  ScopedVector<uint32_t> blockOffsets{numBlocks, pool, options.bufferPool};
   uint32_t runningOffset{0};
   for (uint16_t blockIndex = 0; blockIndex < numBlocks; ++blockIndex) {
     baselines[blockIndex] = blocks[blockIndex].baseline;
@@ -849,32 +1172,39 @@ std::string_view BlockBitPackingEncoding<T>::encode(
     runningOffset += blocks[blockIndex].packedSize;
   }
 
-  ScopedEncodingBuffer tempBuffer{
-      &buffer.getMemoryPool(), options.encodingBufferPool};
-  const std::string_view baselinesEncoded =
+  ScopedEncodingBuffer tempBuffer{pool, options.encodingBufferPool};
+  const std::string_view encodedBaselines =
       selection.template encodeNested<physicalType>(
           EncodingIdentifiers::BlockBitPacking::Baselines,
-          baselines,
+          std::span<const physicalType>{baselines.data(), baselines.size()},
           tempBuffer.get(),
           options);
-  const std::string_view bitWidthsEncoded =
+  const std::string_view encodedBitWidths =
       selection.template encodeNested<uint8_t>(
           EncodingIdentifiers::BlockBitPacking::BitWidths,
-          bitWidths,
+          std::span<const uint8_t>{bitWidths.data(), bitWidths.size()},
           tempBuffer.get(),
           options);
-  const std::string_view offsetsEncoded =
+  const std::string_view encodedOffsets =
       selection.template encodeNested<uint32_t>(
           EncodingIdentifiers::BlockBitPacking::Offsets,
-          blockOffsets,
+          std::span<const uint32_t>{blockOffsets.data(), blockOffsets.size()},
           tempBuffer.get(),
           options);
+  const auto firstBlockRows = std::min<uint32_t>(blockSize, rowCount);
 
-  const uint32_t metaHeaderSize = kMetadataHeaderSize +
-      static_cast<uint32_t>(baselinesEncoded.size() + bitWidthsEncoded.size() +
-                            offsetsEncoded.size());
-  const uint32_t encodingSize =
-      Encoding::serializePrefixSize(rowCount, useVarint) + metaHeaderSize +
+  const uint32_t headerSize = BlockBitPackingEncoding<T>::headerSize(
+      blockSize,
+      numBlocks,
+      static_cast<uint32_t>(encodedBaselines.size()),
+      static_cast<uint32_t>(encodedBitWidths.size()),
+      static_cast<uint32_t>(encodedOffsets.size()),
+      firstBlockRows);
+  const uint32_t encodingSize = Encoding::serializePrefixSize(
+                                    rowCount, options.useVarintRowCount) +
+      headerSize +
+      static_cast<uint32_t>(encodedBaselines.size() + encodedBitWidths.size() +
+                            encodedOffsets.size()) +
       compressionEncoder.getSize();
 
   char* reserved = buffer.reserve(encodingSize);
@@ -883,18 +1213,172 @@ std::string_view BlockBitPackingEncoding<T>::encode(
       EncodingType::BlockBitPacking,
       TypeTraits<T>::dataType,
       rowCount,
-      useVarint,
+      options.useVarintRowCount,
       pos);
   encoding::writeChar(
       static_cast<char>(compressionEncoder.compressionType()), pos);
-  encoding::write(blockSize, pos);
-  encoding::write(static_cast<uint16_t>(numBlocks), pos);
-  encoding::writeString(baselinesEncoded, pos);
-  encoding::writeString(bitWidthsEncoded, pos);
-  encoding::writeString(offsetsEncoded, pos);
+  varint::writeVarint(blockSize, &pos);
+  varint::writeVarint(numBlocks, &pos);
+  writeSizedChild(encodedBaselines, pos);
+  writeSizedChild(encodedBitWidths, pos);
+  writeSizedChild(encodedOffsets, pos);
+  varint::writeVarint(firstBlockRows, &pos);
   compressionEncoder.write(pos);
 
-  NIMBLE_DCHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
+  NIMBLE_CHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string_view BlockBitPackingEncoding<T>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  auto* pool = &buffer.getMemoryPool();
+
+  velox::BufferPtr uncompressedSourceData;
+  SCOPE_EXIT {
+    if (options.bufferPool != nullptr && uncompressedSourceData != nullptr) {
+      options.bufferPool->release(std::move(uncompressedSourceData));
+    }
+  };
+  const auto source = parseSourceHeader(encoded, options);
+  NIMBLE_CHECK_LE(offset, source.rowCount);
+  NIMBLE_CHECK_LE(length, source.rowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+
+  const auto packedData =
+      packedDataSource(source, uncompressedSourceData, pool, options);
+
+  const auto firstBlock = blockIndex(source, offset);
+  const auto lastBlock = blockIndex(source, offset + length - 1);
+  const auto numBlocks = lastBlock - firstBlock + 1;
+  NIMBLE_CHECK_LE(
+      numBlocks,
+      kMaxBlockCount,
+      "Row count too large for BlockBitPacking encoding.");
+
+  ScopedVector<uint32_t> blockOffsets{
+      static_cast<uint64_t>(numBlocks) + 1, pool, options.bufferPool};
+  readBlockOffsets(
+      source,
+      firstBlock,
+      numBlocks,
+      static_cast<uint32_t>(packedData.size()),
+      blockOffsets,
+      pool,
+      options);
+
+  const auto getPackedSize = [&](uint32_t blockIndex) {
+    const auto blockOffset = blockIndex - firstBlock;
+    return blockOffsets[blockOffset + 1] - blockOffsets[blockOffset];
+  };
+  const auto bitWidthView = detail::createTypedEncodingView<uint8_t>(
+      source.encodedBitWidths, pool, options);
+  const auto getBlockBitWidth = [&](uint32_t blockIndex) {
+    return bitWidthView->readAt(blockIndex);
+  };
+
+  ScopedVector<BlockSliceInfo> blockSlices{numBlocks, pool, options.bufferPool};
+  ScopedVector<uint32_t> sliceOffsets{
+      static_cast<uint64_t>(numBlocks) + 1, pool, options.bufferPool};
+  uint32_t totalPackedSize{0};
+  uint32_t curRow{offset};
+  const auto endRow = offset + length;
+  for (uint16_t sliceIndex = 0; sliceIndex < numBlocks; ++sliceIndex) {
+    const auto blockIndex = firstBlock + sliceIndex;
+    const auto blockRowCount =
+        BlockBitPackingEncoding::blockRowCount(source, blockIndex);
+    const auto rowOffset = curRow - blockRowOffset(source, blockIndex);
+    const auto rowCount =
+        std::min<uint32_t>(endRow - curRow, blockRowCount - rowOffset);
+    const auto fullBlock = rowOffset == 0 && rowCount == blockRowCount;
+    const auto bitWidth = fullBlock ? uint8_t{0} : getBlockBitWidth(blockIndex);
+    const auto skipEncoding = bitWidth == kRawBlockBitWidth;
+    const uint32_t packedOffsetAdjustment = skipEncoding
+        ? static_cast<uint32_t>(rowOffset * sizeof(physicalType))
+        : uint32_t{0};
+    blockSlices[sliceIndex] = {
+        .blockIndex = blockIndex,
+        .packedOffset =
+            blockOffsets[blockIndex - firstBlock] + packedOffsetAdjustment,
+        .rowOffset = rowOffset,
+        .packedSize = fullBlock
+            ? getPackedSize(blockIndex)
+            : BlockBitPackingEncoding::getPackedSize(rowCount, bitWidth),
+        .rowCount = rowCount,
+        .bitWidth = skipEncoding ? uint8_t{0} : bitWidth,
+        .skipEncoding = skipEncoding};
+    sliceOffsets[sliceIndex] = totalPackedSize;
+    totalPackedSize += blockSlices[sliceIndex].packedSize;
+    curRow += rowCount;
+  }
+  sliceOffsets[numBlocks] = totalPackedSize;
+  NIMBLE_CHECK_EQ(curRow, endRow);
+
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  const auto encodedBaselines = EncodingFactory::slice(
+      source.encodedBaselines,
+      firstBlock,
+      numBlocks,
+      scopedBuffer.get(),
+      options);
+  const auto encodedBitWidths = EncodingFactory::slice(
+      source.encodedBitWidths,
+      firstBlock,
+      numBlocks,
+      scopedBuffer.get(),
+      options);
+  const auto encodedOffsets =
+      EncodingFactory::encodeWithCapturedLayout<uint32_t>(
+          source.encodedBlockOffsets,
+          std::span<const uint32_t>{sliceOffsets.data(), numBlocks},
+          scopedBuffer.get(),
+          options,
+          "Captured BlockBitPacking offset layout");
+
+  const auto firstBlockRows = blockSlices[0].rowCount;
+  const uint32_t headerSize = BlockBitPackingEncoding<T>::headerSize(
+      source.blockSize,
+      numBlocks,
+      static_cast<uint32_t>(encodedBaselines.size()),
+      static_cast<uint32_t>(encodedBitWidths.size()),
+      static_cast<uint32_t>(encodedOffsets.size()),
+      firstBlockRows);
+  const uint32_t encodingSize = Encoding::serializePrefixSize(
+                                    length, options.useVarintRowCount) +
+      headerSize +
+      static_cast<uint32_t>(encodedBaselines.size() + encodedBitWidths.size() +
+                            encodedOffsets.size()) +
+      totalPackedSize;
+
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::BlockBitPacking,
+      TypeTraits<T>::dataType,
+      length,
+      options.useVarintRowCount,
+      pos);
+  encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
+  varint::writeVarint(source.blockSize, &pos);
+  varint::writeVarint(numBlocks, &pos);
+  writeSizedChild(encodedBaselines, pos);
+  writeSizedChild(encodedBitWidths, pos);
+  writeSizedChild(encodedOffsets, pos);
+  varint::writeVarint(firstBlockRows, &pos);
+
+  writeBlockSlicesPayload(
+      source,
+      packedData,
+      std::span<const BlockSliceInfo>{blockSlices.data(), blockSlices.size()},
+      std::span<const uint32_t>{sliceOffsets.data(), sliceOffsets.size()},
+      totalPackedSize,
+      pos);
+
+  NIMBLE_CHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
   return {reserved, encodingSize};
 }
 

--- a/dwio/nimble/encodings/ConstantEncoding.h
+++ b/dwio/nimble/encodings/ConstantEncoding.h
@@ -209,6 +209,7 @@ class ConstantEncodingBase
         EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
     NIMBLE_CHECK_LE(offset, sourceRowCount);
     NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+    NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
 
     const auto sourcePrefixSize =
         EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);

--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -21,6 +21,7 @@
 
 #include "dwio/nimble/common/NimbleException.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
@@ -75,7 +76,7 @@ std::string_view sliceByMaterializing(
   encoding->materialize(length, physicalValues.data());
 
   return encodeValuesWithLayout<T>(
-      EncodingLayoutCapture::capture(encoded),
+      EncodingLayoutCapture::capture(encoded, options),
       {reinterpret_cast<const T*>(physicalValues.data()),
        physicalValues.size()},
       buffer,
@@ -181,6 +182,20 @@ std::string_view sliceFixedBitWidth(
           encoded, offset, length, buffer, options));
 }
 
+std::string_view sliceBlockBitPacking(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE(
+      dataType,
+      T,
+      BlockBitPackingEncoding<T>::slice(
+          encoded, offset, length, buffer, options));
+}
+
 } // namespace
 
 std::string_view EncodingSliceFactory::slice(
@@ -189,15 +204,16 @@ std::string_view EncodingSliceFactory::slice(
     uint32_t length,
     Buffer& buffer,
     const Encoding::Options& options) {
+  const auto encodingType = EncodingPrefix::encodingType(encoded);
   const auto rowCount =
       EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
   NIMBLE_CHECK_LE(offset, rowCount);
   NIMBLE_CHECK_LE(length, rowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
   if (offset == 0 && length == rowCount) {
     return encoded;
   }
 
-  const auto encodingType = EncodingPrefix::encodingType(encoded);
   const auto dataType = EncodingPrefix::dataType(encoded);
   switch (encodingType) {
     case EncodingType::Constant:
@@ -208,6 +224,9 @@ std::string_view EncodingSliceFactory::slice(
       return sliceRLE(encoded, dataType, offset, length, buffer, options);
     case EncodingType::FixedBitWidth:
       return sliceFixedBitWidth(
+          encoded, dataType, offset, length, buffer, options);
+    case EncodingType::BlockBitPacking:
+      return sliceBlockBitPacking(
           encoded, dataType, offset, length, buffer, options);
     case EncodingType::Nullable:
       return sliceNullable(encoded, dataType, offset, length, buffer, options);

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -422,6 +422,7 @@ std::string_view FixedBitWidthEncoding<T>::slice(
       EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
   NIMBLE_CHECK_LE(offset, sourceRowCount);
   NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
 
   const auto sourcePrefixSize =
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);

--- a/dwio/nimble/encodings/FsstEncoding.cpp
+++ b/dwio/nimble/encodings/FsstEncoding.cpp
@@ -280,7 +280,8 @@ void FsstEncoding::captureNestedEncoding(
     const Encoding::Options& options) {
   children.reserve(1);
   children.emplace_back(
-      EncodingLayoutCapture::capture(lengthsEncoding(encoding, options)));
+      EncodingLayoutCapture::capture(
+          lengthsEncoding(encoding, options), options));
 }
 
 void FsstEncoding::reset() {

--- a/dwio/nimble/encodings/MainlyConstantEncoding.h
+++ b/dwio/nimble/encodings/MainlyConstantEncoding.h
@@ -679,6 +679,7 @@ class MainlyConstantEncodingBase
         EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
     NIMBLE_CHECK_LE(offset, sourceRowCount);
     NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+    NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
 
     const char* pos = encoded.data() +
         EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
@@ -695,6 +696,24 @@ class MainlyConstantEncodingBase
         countCommonForSlice(isCommon, offset, length, buffer, options);
     const auto otherOffset = offset - commonBefore;
     const auto otherCount = length - commonInSlice;
+
+    if (otherCount == 0) {
+      const auto prefixSize =
+          EncodingPrefix::serializedSize(length, options.useVarintRowCount);
+      const auto encodingSize = prefixSize + commonValue.size();
+      char* reserved = buffer.reserve(encodingSize);
+      char* writePos = reserved;
+      EncodingPrefix::serialize(
+          EncodingType::Constant,
+          TypeTraits<T>::dataType,
+          length,
+          options.useVarintRowCount,
+          writePos);
+      encoding::writeBytes(commonValue, writePos);
+      NIMBLE_CHECK_EQ(
+          writePos - reserved, encodingSize, "Encoding size mismatch.");
+      return {reserved, encodingSize};
+    }
 
     auto* pool = &buffer.getMemoryPool();
     ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};

--- a/dwio/nimble/encodings/NullableEncoding.h
+++ b/dwio/nimble/encodings/NullableEncoding.h
@@ -439,6 +439,7 @@ std::string_view NullableEncoding<T>::slice(
       EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
   NIMBLE_CHECK_LE(offset, sourceRowCount);
   NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
 
   const char* pos = encoded.data() +
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);

--- a/dwio/nimble/encodings/RLEEncoding.h
+++ b/dwio/nimble/encodings/RLEEncoding.h
@@ -235,6 +235,7 @@ class RLEEncodingBase
         EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
     NIMBLE_CHECK_LE(offset, sourceRowCount);
     NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+    NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
 
     const auto sourcePrefixSize =
         EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);

--- a/dwio/nimble/encodings/SparseBoolEncoding.cpp
+++ b/dwio/nimble/encodings/SparseBoolEncoding.cpp
@@ -248,6 +248,7 @@ std::string_view SparseBoolEncoding::slice(
       EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
   NIMBLE_CHECK_LE(offset, sourceRowCount);
   NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
 
   const char* readPos = encoded.data() +
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);

--- a/dwio/nimble/encodings/TrivialEncoding.cpp
+++ b/dwio/nimble/encodings/TrivialEncoding.cpp
@@ -240,6 +240,7 @@ std::string_view TrivialEncoding<std::string_view>::slice(
       EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
   NIMBLE_CHECK_LE(offset, sourceRowCount);
   NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
 
   const auto sourcePrefixSize =
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
@@ -435,6 +436,7 @@ std::string_view TrivialEncoding<bool>::slice(
       EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
   NIMBLE_CHECK_LE(offset, sourceRowCount);
   NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
 
   const auto sourcePrefixSize =
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);

--- a/dwio/nimble/encodings/TrivialEncoding.h
+++ b/dwio/nimble/encodings/TrivialEncoding.h
@@ -340,6 +340,7 @@ std::string_view TrivialEncoding<T>::slice(
       EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
   NIMBLE_CHECK_LE(offset, sourceRowCount);
   NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
 
   const auto sourcePrefixSize =
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);

--- a/dwio/nimble/encodings/benchmarks/BlockBitPackingEncodingBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/BlockBitPackingEncodingBenchmark.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "folly/Benchmark.h"
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+
+namespace {
+
+constexpr uint32_t kRowCount = kNumElements;
+
+Vector<uint32_t> makeNarrowBlocks() {
+  auto& pool = benchmarkPool();
+  Vector<uint32_t> data{pool.get()};
+  data.resize(kRowCount);
+  for (uint32_t i = 0; i < kRowCount; ++i) {
+    const auto block = i / kBlockBitPackingBlockSize;
+    data[i] = block * 1000 + (i % 16);
+  }
+  return data;
+}
+
+#define BBP_BENCH(Pattern, DataExpr)                           \
+  BENCHMARK(BBP_Encode_##Pattern, iters) {                     \
+    Vector<uint32_t> data{benchmarkPool().get()};              \
+    BENCHMARK_SUSPEND {                                        \
+      data = DataExpr;                                         \
+    }                                                          \
+    encodeBenchmark<BlockBitPackingEncoding<uint32_t>>(        \
+        EncodingType::BlockBitPacking, data, iters);           \
+  }                                                            \
+  BENCHMARK(BBP_Decode_##Pattern, iters) {                     \
+    std::string encoded;                                       \
+    BENCHMARK_SUSPEND {                                        \
+      auto data = DataExpr;                                    \
+      encoded = encodeData<BlockBitPackingEncoding<uint32_t>>( \
+          EncodingType::BlockBitPacking, data);                \
+    }                                                          \
+    decodeBenchmark<uint32_t>(encoded, kRowCount, iters);      \
+  }                                                            \
+  BENCHMARK_DRAW_LINE()
+
+BBP_BENCH(NarrowBlocks, makeNarrowBlocks());
+BBP_BENCH(Narrow8bit, makeNarrow<uint32_t>(8, kRowCount));
+BBP_BENCH(Uniform20bit, makeNarrow<uint32_t>(20, kRowCount));
+BBP_BENCH(Constant, makeConstant<uint32_t>(42, kRowCount));
+BBP_BENCH(Increasing, makeIncreasing<uint32_t>(kRowCount));
+
+#undef BBP_BENCH
+
+} // namespace
+
+int main() {
+  facebook::velox::memory::MemoryManager::initialize({});
+  folly::runBenchmarks();
+}

--- a/dwio/nimble/encodings/benchmarks/CMakeLists.txt
+++ b/dwio/nimble/encodings/benchmarks/CMakeLists.txt
@@ -23,6 +23,21 @@ target_link_libraries(
 )
 
 add_executable(
+  nimble_block_bit_packing_encoding_benchmark
+  BlockBitPackingEncodingBenchmark.cpp
+)
+
+target_link_libraries(
+  nimble_block_bit_packing_encoding_benchmark
+  nimble_encodings_tests_utils
+  nimble_encodings
+  nimble_common
+  Folly::follybenchmark
+  Folly::folly
+  velox_memory
+)
+
+add_executable(
   nimble_exact_bit_width_storage_benchmark
   ExactBitWidthStorageBenchmark.cpp
 )

--- a/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
@@ -29,15 +30,46 @@ namespace {
 
 constexpr uint32_t kSliceOffset = 12345;
 constexpr uint32_t kSliceLength = 4096;
+constexpr uint32_t kPartialBlockSliceOffset = 12345;
+constexpr uint32_t kPartialBlockSliceLength = 256;
 
-void sliceBenchmark(const std::string& encoded, uint32_t iters) {
+void sliceBenchmark(
+    const std::string& encoded,
+    uint32_t offset,
+    uint32_t length,
+    uint32_t iters) {
   Buffer buffer{*benchmarkPool()};
   while (iters--) {
     buffer.reset();
-    const auto sliced =
-        EncodingFactory::slice(encoded, kSliceOffset, kSliceLength, buffer);
+    const auto sliced = EncodingFactory::slice(encoded, offset, length, buffer);
     folly::doNotOptimizeAway(sliced.data());
     folly::doNotOptimizeAway(sliced.size());
+  }
+}
+
+void sliceBenchmark(const std::string& encoded, uint32_t iters) {
+  sliceBenchmark(encoded, kSliceOffset, kSliceLength, iters);
+}
+
+template <typename EncodingT, typename T>
+void materializeEncodeBenchmark(
+    const std::string& encoded,
+    EncodingType encodingType,
+    uint32_t offset,
+    uint32_t length,
+    uint32_t iters) {
+  while (iters--) {
+    auto encoding =
+        EncodingFactory{}.create(*benchmarkPool(), encoded, nullFactory());
+    encoding->skip(offset);
+
+    Vector<T> values{benchmarkPool().get(), length};
+    encoding->materialize(length, values.data());
+
+    const auto materialized =
+        encodeData<EncodingT>(encodingType, values, Encoding::Options{});
+    folly::doNotOptimizeAway(materialized.data());
+    folly::doNotOptimizeAway(materialized.size());
   }
 }
 
@@ -46,19 +78,8 @@ void materializeEncodeBenchmark(
     const std::string& encoded,
     EncodingType encodingType,
     uint32_t iters) {
-  while (iters--) {
-    auto encoding =
-        EncodingFactory{}.create(*benchmarkPool(), encoded, nullFactory());
-    encoding->skip(kSliceOffset);
-
-    Vector<T> values{benchmarkPool().get(), kSliceLength};
-    encoding->materialize(kSliceLength, values.data());
-
-    const auto materialized =
-        encodeData<EncodingT>(encodingType, values, Encoding::Options{});
-    folly::doNotOptimizeAway(materialized.data());
-    folly::doNotOptimizeAway(materialized.size());
-  }
+  materializeEncodeBenchmark<EncodingT, T>(
+      encoded, encodingType, kSliceOffset, kSliceLength, iters);
 }
 
 template <typename T>
@@ -135,6 +156,37 @@ SLICE_BENCHMARKS(
     FixedBitWidthEncoding<uint32_t>,
     EncodingType::FixedBitWidth,
     makeNarrow<uint32_t>(12));
+SLICE_BENCHMARKS(
+    BlockBitPackingUint32,
+    BlockBitPackingEncoding<uint32_t>,
+    EncodingType::BlockBitPacking,
+    makeIncreasing<uint32_t>());
+
+BENCHMARK(Slice_BlockBitPackingUint32PartialBlock, iters) {
+  std::string encoded;
+  BENCHMARK_SUSPEND {
+    const auto data = makeIncreasing<uint32_t>();
+    encoded = encodeData<BlockBitPackingEncoding<uint32_t>>(
+        EncodingType::BlockBitPacking, data);
+  }
+  sliceBenchmark(
+      encoded, kPartialBlockSliceOffset, kPartialBlockSliceLength, iters);
+}
+BENCHMARK_RELATIVE(MaterializeEncode_BlockBitPackingUint32PartialBlock, iters) {
+  std::string encoded;
+  BENCHMARK_SUSPEND {
+    const auto data = makeIncreasing<uint32_t>();
+    encoded = encodeData<BlockBitPackingEncoding<uint32_t>>(
+        EncodingType::BlockBitPacking, data);
+  }
+  materializeEncodeBenchmark<BlockBitPackingEncoding<uint32_t>, uint32_t>(
+      encoded,
+      EncodingType::BlockBitPacking,
+      kPartialBlockSliceOffset,
+      kPartialBlockSliceLength,
+      iters);
+}
+BENCHMARK_DRAW_LINE();
 
 SLICE_MATERIALIZE_BENCHMARKS(
     TrivialUint32,

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -202,7 +202,7 @@ std::string_view EncodingFactory::encodeWithCapturedLayout(
     const Encoding::Options& options,
     std::string_view missingChildContext) {
   auto policy = std::make_unique<ReplayedEncodingSelectionPolicy<T>>(
-      EncodingLayoutCapture::capture(encodedLayoutSource),
+      EncodingLayoutCapture::capture(encodedLayoutSource, options),
       CompressionOptions{},
       [missingChildContext](
           DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 
@@ -29,18 +30,19 @@ namespace facebook::nimble {
 namespace {
 constexpr uint32_t kMinEncodingLayoutBufferSize = 5;
 
-// Captures one size-prefixed nested sub-stream into `children` (nullopt when
-// the sub-stream is empty)
-void captureSizedChild(
+void captureChild(
     std::vector<std::optional<const EncodingLayout>>& children,
-    const char*& cursor) {
-  const uint32_t size = encoding::readUint32(cursor);
+    const char*& cursor,
+    uint32_t size,
+    const Encoding::Options& childOptions) {
   children.emplace_back(
-      size > 0 ? std::optional<const EncodingLayout>(
-                     EncodingLayoutCapture::capture({cursor, size}))
-               : std::nullopt);
+      size > 0
+          ? std::optional<const EncodingLayout>(
+                EncodingLayoutCapture::capture({cursor, size}, childOptions))
+          : std::nullopt);
   cursor += size;
 }
+
 } // namespace
 
 std::optional<std::string> EncodingLayout::Config::get(
@@ -165,24 +167,23 @@ const EncodingLayout::Config& EncodingLayout::config() const {
   return encodingConfig_;
 }
 
-namespace {
-
-constexpr uint32_t kEncodingPrefixSize = 6;
-
-} // namespace
-
-EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
+EncodingLayout EncodingLayoutCapture::capture(
+    std::string_view encoding,
+    const Encoding::Options& options) {
   NIMBLE_CHECK_GE(
-      encoding.size(), kEncodingPrefixSize, "Encoding size too small.");
-
-  const auto encodingType =
-      encoding::peek<uint8_t, EncodingType>(encoding.data());
+      encoding.size(),
+      EncodingPrefix::kRowCountOffset,
+      "Encoding size too small.");
+  const auto encodingType = EncodingPrefix::encodingType(encoding);
+  const auto prefixSize =
+      EncodingPrefix::prefixSize(encoding, options.useVarintRowCount);
   CompressionType compressionType = CompressionType::Uncompressed;
 
   if (encodingType == EncodingType::FixedBitWidth ||
-      encodingType == EncodingType::Trivial) {
-    compressionType = encoding::peek<uint8_t, CompressionType>(
-        encoding.data() + kEncodingPrefixSize);
+      encodingType == EncodingType::Trivial ||
+      encodingType == EncodingType::BlockBitPacking) {
+    compressionType =
+        encoding::peek<uint8_t, CompressionType>(encoding.data() + prefixSize);
   }
 
   std::vector<std::optional<const EncodingLayout>> children;
@@ -200,7 +201,7 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
       // Non nested encodings have zero children
       break;
     case EncodingType::ALP: {
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const auto header = detail::alp::readHeader(pos);
       if (header.hasExceptions) {
         varint::readVarint32(&pos); // exceptionCount
@@ -209,89 +210,94 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
 
       children.reserve(1);
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, encodedValuesBytes}));
+          EncodingLayoutCapture::capture({pos, encodedValuesBytes}, options));
       break;
     }
     case EncodingType::PFOR: {
       const auto dataType =
           encoding::peek<uint8_t, DataType>(encoding.data() + 1);
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       pos += detail::dataTypeSize(dataType); // baseline
       encoding::readChar(pos); // baseBitWidth
       encoding::readUint32(pos); // numExceptions
 
       children.reserve(2);
-      captureSizedChild(children, pos); // exception positions
-      captureSizedChild(children, pos); // exception values
+      const auto positionsBytes = encoding::readUint32(pos);
+      captureChild(children, pos, positionsBytes, options);
+      const auto valuesBytes = encoding::readUint32(pos);
+      captureChild(children, pos, valuesBytes, options);
       break;
     }
     case EncodingType::BlockBitPacking: {
       // BlockBitPacking nests three per-block metadata sub-streams: baselines,
       // bit widths, and data offsets.
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       encoding::readChar(pos); // compressionType
-      encoding::read<uint16_t>(pos); // blockSize
-      encoding::read<uint16_t>(pos); // numBlocks
+      varint::readVarint32(&pos); // blockSize
+      varint::readVarint32(&pos); // numBlocks
 
       children.reserve(3);
-      captureSizedChild(children, pos); // baselines
-      captureSizedChild(children, pos); // bit widths
-      captureSizedChild(children, pos); // data offsets
+      const auto baselinesBytes = varint::readVarint32(&pos);
+      captureChild(children, pos, baselinesBytes, options);
+      const auto bitWidthsBytes = varint::readVarint32(&pos);
+      captureChild(children, pos, bitWidthsBytes, options);
+      const auto dataOffsetsBytes = varint::readVarint32(&pos);
+      captureChild(children, pos, dataOffsetsBytes, options);
       break;
     }
     case EncodingType::Trivial: {
       const auto dataType =
           encoding::peek<uint8_t, DataType>(encoding.data() + 1);
       if (dataType == DataType::String) {
-        const char* pos = encoding.data() + kEncodingPrefixSize + 1;
+        const char* pos = encoding.data() + prefixSize + 1;
         const uint32_t lengthsBytes = encoding::readUint32(pos);
 
         children.reserve(1);
         children.emplace_back(
-            EncodingLayoutCapture::capture({pos, lengthsBytes}));
+            EncodingLayoutCapture::capture({pos, lengthsBytes}, options));
       }
       break;
     }
     case EncodingType::Fsst: {
-      FsstEncoding::captureNestedEncoding(encoding, children);
+      FsstEncoding::captureNestedEncoding(encoding, children, options);
       break;
     }
     case EncodingType::SparseBool: {
       children.reserve(1);
       children.emplace_back(
           EncodingLayoutCapture::capture(
-              encoding.substr(kEncodingPrefixSize + 1)));
+              encoding.substr(prefixSize + 1), options));
       break;
     }
     case EncodingType::MainlyConstant: {
       children.reserve(2);
 
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const uint32_t isCommonBytes = encoding::readUint32(pos);
 
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, isCommonBytes}));
+          EncodingLayoutCapture::capture({pos, isCommonBytes}, options));
 
       pos += isCommonBytes;
       const uint32_t otherValuesBytes = encoding::readUint32(pos);
 
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, otherValuesBytes}));
+          EncodingLayoutCapture::capture({pos, otherValuesBytes}, options));
       break;
     }
     case EncodingType::Dictionary: {
       children.reserve(2);
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const uint32_t alphabetBytes = encoding::readUint32(pos);
 
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, alphabetBytes}));
+          EncodingLayoutCapture::capture({pos, alphabetBytes}, options));
 
       pos += alphabetBytes;
 
       children.emplace_back(
           EncodingLayoutCapture::capture(
-              {pos, encoding.size() - (pos - encoding.data())}));
+              {pos, encoding.size() - (pos - encoding.data())}, options));
       break;
     }
     case EncodingType::RLE: {
@@ -300,55 +306,56 @@ EncodingLayout EncodingLayoutCapture::capture(std::string_view encoding) {
 
       children.reserve(dataType == DataType::Bool ? 1 : 2);
 
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const uint32_t runLengthBytes = encoding::readUint32(pos);
 
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, runLengthBytes}));
+          EncodingLayoutCapture::capture({pos, runLengthBytes}, options));
 
       if (dataType != DataType::Bool) {
         pos += runLengthBytes;
 
         children.emplace_back(
             EncodingLayoutCapture::capture(
-                {pos, encoding.size() - (pos - encoding.data())}));
+                {pos, encoding.size() - (pos - encoding.data())}, options));
       }
       break;
     }
     case EncodingType::Delta: {
       children.reserve(3);
 
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const uint32_t deltaBytes = encoding::readUint32(pos);
       const uint32_t restatementBytes = encoding::readUint32(pos);
 
-      children.emplace_back(EncodingLayoutCapture::capture({pos, deltaBytes}));
+      children.emplace_back(
+          EncodingLayoutCapture::capture({pos, deltaBytes}, options));
 
       pos += deltaBytes;
 
       children.emplace_back(
-          EncodingLayoutCapture::capture({pos, restatementBytes}));
+          EncodingLayoutCapture::capture({pos, restatementBytes}, options));
 
       pos += restatementBytes;
 
       children.emplace_back(
           EncodingLayoutCapture::capture(
-              {pos, encoding.size() - (pos - encoding.data())}));
+              {pos, encoding.size() - (pos - encoding.data())}, options));
       break;
     }
     case EncodingType::Nullable: {
-      const char* pos = encoding.data() + kEncodingPrefixSize;
+      const char* pos = encoding.data() + prefixSize;
       const uint32_t dataBytes = encoding::readUint32(pos);
 
       // For nullable encodings we only capture the data encoding part, so we
       // are "overwriting" the current captured node with the nested data node.
-      return EncodingLayoutCapture::capture({pos, dataBytes});
+      return EncodingLayoutCapture::capture({pos, dataBytes}, options);
     }
     case EncodingType::Sentinel: {
       // For sentinel encodings we only capture the data encoding part, so we
       // are "overwriting" the current captured node with the nested data node.
       return EncodingLayoutCapture::capture(
-          encoding.substr(kEncodingPrefixSize + 8));
+          encoding.substr(prefixSize + 8), options);
     }
   }
 

--- a/dwio/nimble/encodings/common/EncodingLayout.h
+++ b/dwio/nimble/encodings/common/EncodingLayout.h
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
 
 namespace facebook::nimble {
@@ -85,7 +86,9 @@ class EncodingLayoutCapture {
   /// It traverses the encoding headers in the stream and produces a serialized
   /// encoding tree layout.
   /// |encoding| - The serialized encoding
-  static EncodingLayout capture(std::string_view encoding);
+  static EncodingLayout capture(
+      std::string_view encoding,
+      const Encoding::Options& options);
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/BlockBitPackingEncodingTest.cpp
@@ -15,10 +15,12 @@
  */
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include <gtest/gtest.h>
+#include <algorithm>
 #include <random>
 #include <vector>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
@@ -295,6 +297,262 @@ TEST_F(BlockBitPackingEncodingTest, compressionRoundTrip) {
   std::vector<uint32_t> output(count);
   encoding->materialize(count, output.data());
   ASSERT_EQ(values, output);
+}
+
+TEST_F(BlockBitPackingEncodingTest, slice) {
+  using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
+  constexpr uint32_t blockSize = Enc::kMaxBlockSize;
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  std::vector<uint32_t> input(blockSize * 3 + 137);
+  for (uint32_t i = 0; i < input.size(); ++i) {
+    if (i < blockSize) {
+      input[i] = 1000 + i % 4;
+    } else if (i < blockSize * 2) {
+      input[i] = i % 256;
+    } else {
+      input[i] = 50000 + i % 17;
+    }
+  }
+
+  const auto values = toVector(input);
+  const auto encoded = nimble::test::Encoder<Enc>::encode(*buffer_, values);
+
+  for (const auto range :
+       {Range{/*offset=*/0, /*length=*/128},
+        Range{/*offset=*/blockSize - 13, /*length=*/64},
+        Range{/*offset=*/blockSize + 17, /*length=*/blockSize + 29},
+        Range{/*offset=*/static_cast<uint32_t>(input.size() - 137),
+              /*length=*/137}}) {
+    SCOPED_TRACE(
+        testing::Message() << "offset=" << range.offset
+                           << " length=" << range.length);
+    nimble::Buffer sliceBuffer{*pool_};
+    const auto sliced = nimble::EncodingFactory::slice(
+        encoded, range.offset, range.length, sliceBuffer);
+
+    EXPECT_EQ(
+        nimble::EncodingPrefix::encodingType(sliced),
+        nimble::EncodingType::BlockBitPacking);
+    EXPECT_EQ(
+        nimble::EncodingPrefix::readRowCount(sliced, /*useVarint=*/false),
+        range.length);
+
+    auto encoding = nimble::EncodingFactory{}.create(*pool_, sliced, nullptr);
+    std::vector<uint32_t> output(range.length);
+    encoding->materialize(range.length, output.data());
+    const std::vector<uint32_t> expected{
+        input.begin() + range.offset,
+        input.begin() + range.offset + range.length};
+    EXPECT_EQ(output, expected);
+  }
+}
+
+TEST_F(BlockBitPackingEncodingTest, rejectsZeroLengthSlice) {
+  using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
+  constexpr uint32_t blockSize = Enc::kMaxBlockSize;
+  std::vector<uint32_t> input(blockSize + 17);
+  for (uint32_t i = 0; i < input.size(); ++i) {
+    input[i] = 1000 + i % 64;
+  }
+
+  const auto values = toVector(input);
+  const auto encoded = nimble::test::Encoder<Enc>::encode(*buffer_, values);
+
+  nimble::Buffer sliceBuffer{*pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::EncodingFactory::slice(
+          encoded,
+          /*offset=*/0,
+          /*length=*/0,
+          sliceBuffer),
+      "");
+}
+
+TEST_F(BlockBitPackingEncodingTest, sliceRandomRanges) {
+  using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
+  constexpr uint32_t blockSize = Enc::kMaxBlockSize;
+  constexpr uint32_t rowCount = blockSize * 5 + 333;
+  constexpr uint32_t iterations = 100;
+
+  std::mt19937 rng{12345};
+  std::vector<uint32_t> input(rowCount);
+  for (uint32_t block = 0; block * blockSize < rowCount; ++block) {
+    const auto begin = block * blockSize;
+    const auto end = std::min<uint32_t>(begin + blockSize, rowCount);
+    const auto base = static_cast<uint32_t>(rng() % 1'000'000);
+    switch (block % 4) {
+      case 0:
+        std::fill(input.begin() + begin, input.begin() + end, base);
+        break;
+      case 1:
+        for (uint32_t i = begin; i < end; ++i) {
+          input[i] = base + static_cast<uint32_t>(rng() % 8);
+        }
+        break;
+      case 2:
+        for (uint32_t i = begin; i < end; ++i) {
+          input[i] = base + static_cast<uint32_t>(rng() % 1024);
+        }
+        break;
+      default:
+        for (uint32_t i = begin; i < end; ++i) {
+          input[i] = rng();
+        }
+        break;
+    }
+  }
+
+  const auto values = toVector(input);
+  const auto encoded = nimble::test::Encoder<Enc>::encode(*buffer_, values);
+  auto sourceEncoding =
+      nimble::EncodingFactory{}.create(*pool_, encoded, nullptr);
+  std::vector<uint32_t> sourceOutput(rowCount);
+  sourceEncoding->materialize(rowCount, sourceOutput.data());
+  ASSERT_EQ(sourceOutput, input);
+
+  std::uniform_int_distribution<uint32_t> offsetDistribution{0, rowCount};
+
+  for (uint32_t iteration = 0; iteration < iterations; ++iteration) {
+    const auto offset = offsetDistribution(rng);
+    std::uniform_int_distribution<uint32_t> lengthDistribution{
+        0, rowCount - offset};
+    const auto length = lengthDistribution(rng);
+    SCOPED_TRACE(
+        testing::Message() << "iteration=" << iteration << " offset=" << offset
+                           << " length=" << length);
+
+    nimble::Buffer sliceBuffer{*pool_};
+    const auto sliced =
+        nimble::EncodingFactory::slice(encoded, offset, length, sliceBuffer);
+
+    auto encoding = nimble::EncodingFactory{}.create(*pool_, sliced, nullptr);
+    std::vector<uint32_t> output(length);
+    encoding->materialize(length, output.data());
+    const std::vector<uint32_t> expected{
+        input.begin() + offset, input.begin() + offset + length};
+    ASSERT_EQ(output.size(), expected.size());
+    for (uint32_t i = 0; i < length; ++i) {
+      ASSERT_EQ(output[i], expected[i]) << "sliceRow=" << i;
+    }
+  }
+}
+
+TEST_F(BlockBitPackingEncodingTest, sliceInterleavedConstantAndPayloadBlocks) {
+  using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
+  constexpr uint32_t blockSize = Enc::kMaxBlockSize;
+  constexpr uint32_t rowCount = blockSize * 5;
+
+  std::vector<uint32_t> input(rowCount);
+  for (uint32_t i = 0; i < blockSize; ++i) {
+    input[i] = i % 31;
+  }
+  std::fill(input.begin() + blockSize, input.begin() + blockSize * 2, 7);
+  for (uint32_t i = blockSize * 2; i < blockSize * 3; ++i) {
+    input[i] = 1000 + i % 8;
+  }
+  std::fill(input.begin() + blockSize * 3, input.begin() + blockSize * 4, 11);
+  for (uint32_t i = blockSize * 4; i < blockSize * 5; ++i) {
+    input[i] = 50000 + i % 1024;
+  }
+
+  const auto values = toVector(input);
+  const auto encoded = nimble::test::Encoder<Enc>::encode(*buffer_, values);
+
+  constexpr uint32_t offset{blockSize + 7};
+  constexpr uint32_t length{blockSize * 3 + 19};
+  nimble::Buffer sliceBuffer{*pool_};
+  const auto sliced =
+      nimble::EncodingFactory::slice(encoded, offset, length, sliceBuffer);
+
+  auto encoding = nimble::EncodingFactory{}.create(*pool_, sliced, nullptr);
+  std::vector<uint32_t> output(length);
+  encoding->materialize(length, output.data());
+  const std::vector<uint32_t> expected{
+      input.begin() + offset, input.begin() + offset + length};
+  EXPECT_EQ(output, expected);
+}
+
+TEST_F(BlockBitPackingEncodingTest, sliceCompressedSource) {
+  using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
+  constexpr uint32_t blockSize = Enc::kMaxBlockSize;
+
+  std::vector<uint32_t> input(blockSize * 2);
+  for (uint32_t i = 0; i < input.size(); ++i) {
+    input[i] = 7000 + i % 32;
+  }
+
+  const auto values = toVector(input);
+  const auto encoded = nimble::test::Encoder<Enc>::encode(
+      *buffer_, values, nimble::CompressionType::Zstd);
+
+  constexpr uint32_t kOffset{31};
+  constexpr uint32_t kLength{blockSize + 7};
+  nimble::Buffer sliceBuffer{*pool_};
+  const auto sliced =
+      nimble::EncodingFactory::slice(encoded, kOffset, kLength, sliceBuffer);
+
+  const auto prefixSize = nimble::EncodingPrefix::prefixSize(
+      sliced,
+      /*useVarint=*/false);
+  EXPECT_EQ(
+      static_cast<nimble::CompressionType>(
+          static_cast<uint8_t>(sliced[prefixSize])),
+      nimble::CompressionType::Uncompressed);
+
+  auto encoding = nimble::EncodingFactory{}.create(*pool_, sliced, nullptr);
+  std::vector<uint32_t> output(kLength);
+  encoding->materialize(kLength, output.data());
+  const std::vector<uint32_t> expected{
+      input.begin() + kOffset, input.begin() + kOffset + kLength};
+  EXPECT_EQ(output, expected);
+}
+
+TEST_F(BlockBitPackingEncodingTest, sliceAlignedPartialRawAndConstantPrefixes) {
+  using Enc = nimble::BlockBitPackingEncoding<uint32_t>;
+  constexpr uint32_t blockSize = Enc::kMaxBlockSize;
+
+  auto verifySlice = [&](const std::vector<uint32_t>& input) {
+    const auto values = toVector(input);
+    const auto encoded = nimble::test::Encoder<Enc>::encode(*buffer_, values);
+
+    constexpr uint32_t offset{blockSize};
+    constexpr uint32_t length{17};
+    nimble::Buffer sliceBuffer{*pool_};
+    const auto sliced =
+        nimble::EncodingFactory::slice(encoded, offset, length, sliceBuffer);
+
+    auto encoding = nimble::EncodingFactory{}.create(*pool_, sliced, nullptr);
+    std::vector<uint32_t> output(length);
+    encoding->materialize(length, output.data());
+    const std::vector<uint32_t> expected{
+        input.begin() + offset, input.begin() + offset + length};
+    EXPECT_EQ(output, expected);
+  };
+
+  {
+    SCOPED_TRACE("raw block prefix");
+    std::vector<uint32_t> input(blockSize * 2);
+    std::fill(input.begin(), input.begin() + blockSize, 42);
+    for (uint32_t i = blockSize; i < input.size(); ++i) {
+      input[i] = i - blockSize;
+    }
+    input[blockSize + 1] = std::numeric_limits<uint32_t>::max();
+    verifySlice(input);
+  }
+
+  {
+    SCOPED_TRACE("constant block prefix");
+    std::vector<uint32_t> input(blockSize * 2);
+    for (uint32_t i = 0; i < blockSize; ++i) {
+      input[i] = i % 31;
+    }
+    std::fill(input.begin() + blockSize, input.end(), 777);
+    verifySlice(input);
+  }
 }
 
 TEST_F(BlockBitPackingEncodingTest, uint64MultiChunk) {

--- a/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ConstantEncodingTest.cpp
@@ -291,8 +291,7 @@ TYPED_TEST(ConstantEncodingTest, slice) {
           options);
 
   for (const auto range :
-       {Range{/*offset=*/0, /*length=*/0},
-        Range{/*offset=*/0, /*length=*/1},
+       {Range{/*offset=*/0, /*length=*/1},
         Range{/*offset=*/1, /*length=*/2},
         Range{/*offset=*/0, /*length=*/3},
         Range{/*offset=*/3, /*length=*/1}}) {
@@ -338,6 +337,14 @@ TYPED_TEST(ConstantEncodingTest, invalidSliceRange) {
           options);
 
   nimble::Buffer invalidSliceBuffer{*this->pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::ConstantEncoding<DataType>::slice(
+          encoded,
+          /*offset=*/0,
+          /*length=*/0,
+          invalidSliceBuffer,
+          options),
+      "");
   NIMBLE_ASSERT_THROW(
       nimble::ConstantEncoding<DataType>::slice(
           encoded,
@@ -394,8 +401,7 @@ TEST_F(ConstantEncodingStringTest, slice) {
             *buffer_, values, nimble::CompressionType::Uncompressed, options);
 
     for (const auto range :
-         {Range{/*offset=*/0, /*length=*/0},
-          Range{/*offset=*/1, /*length=*/2},
+         {Range{/*offset=*/1, /*length=*/2},
           Range{/*offset=*/0, /*length=*/3}}) {
       SCOPED_TRACE(
           testing::Message()
@@ -422,5 +428,39 @@ TEST_F(ConstantEncodingStringTest, slice) {
         EXPECT_EQ(result[i], values[range.offset + i]);
       }
     }
+  }
+}
+
+TEST_F(ConstantEncodingStringTest, invalidSliceRange) {
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    const std::string value{"constant-value"};
+    nimble::Vector<std::string_view> values{pool_.get()};
+    for (uint32_t i = 0; i < 4; ++i) {
+      values.push_back(value);
+    }
+
+    const auto encoded = nimble::test::
+        Encoder<nimble::ConstantEncoding<std::string_view>>::encode(
+            *buffer_, values, nimble::CompressionType::Uncompressed, options);
+
+    nimble::Buffer invalidSliceBuffer{*pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::ConstantEncoding<std::string_view>::slice(
+            encoded,
+            /*offset=*/0,
+            /*length=*/0,
+            invalidSliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::ConstantEncoding<std::string_view>::slice(
+            encoded,
+            /*offset=*/3,
+            /*length=*/2,
+            invalidSliceBuffer,
+            options),
+        "");
   }
 }

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -16,7 +16,7 @@
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include <gtest/gtest.h>
 #include "dwio/nimble/common/Buffer.h"
-#include "dwio/nimble/common/Exceptions.h"
+
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 #include "dwio/nimble/encodings/SubIntSplitConfig.h"
@@ -104,7 +104,8 @@ nimble::EncodingLayout encodeAndCapture(
       data,
       buffer);
 
-  return nimble::EncodingLayoutCapture::capture(encoding);
+  return nimble::EncodingLayoutCapture::capture(
+      encoding, nimble::Encoding::Options{});
 }
 
 template <typename T, typename TCollection = std::vector<T>>
@@ -543,7 +544,8 @@ TEST(EncodingLayoutTests, Nullable) {
 
   std::string output;
   output.resize(1024);
-  auto captured = nimble::EncodingLayoutCapture::capture(encoding);
+  auto captured = nimble::EncodingLayoutCapture::capture(
+      encoding, nimble::Encoding::Options{});
   auto size = captured.serialize(output);
 
   auto actual = nimble::EncodingLayout::create(
@@ -642,7 +644,8 @@ TEST(EncodingLayoutTests, SubIntSplitCapture) {
       std::make_unique<ForceSubIntSplitPolicy<int64_t>>(), data, buffer);
 
   // Capture must succeed and not throw.
-  auto captured = nimble::EncodingLayoutCapture::capture(encoding);
+  auto captured = nimble::EncodingLayoutCapture::capture(
+      encoding, nimble::Encoding::Options{});
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
   ASSERT_GT(captured.childrenCount(), 0u);
   EXPECT_EQ(
@@ -748,7 +751,8 @@ TEST(EncodingLayoutTests, SubIntSplitPreserveBoundariesReplay) {
       data,
       buffer);
 
-  auto captured = nimble::EncodingLayoutCapture::capture(encoding);
+  auto captured = nimble::EncodingLayoutCapture::capture(
+      encoding, nimble::Encoding::Options{});
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
   auto replayedMode = captured.config().get(
       std::string(nimble::detail::subintsplit::kSplitModeConfigKey));

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -1441,7 +1441,8 @@ TEST(ManualEncodingSelectionPolicyTest, nestedEncodingCompressionType) {
 
     // Capture the encoding layout tree from the encoded output and verify
     // compression types at each level.
-    auto capturedLayout = nimble::EncodingLayoutCapture::capture(encoded);
+    auto capturedLayout = nimble::EncodingLayoutCapture::capture(
+        encoded, nimble::Encoding::Options{});
 
     // Verify leaf compression types in the captured tree.
     // Walk through all children and check leaf nodes.
@@ -1536,7 +1537,8 @@ TEST(ReplayedEncodingSelectionPolicyTest, nestedEncodingCompressionType) {
         std::move(policy), std::span<const uint32_t>(data), buffer);
 
     // Capture the encoding layout tree and verify compression types.
-    auto capturedLayout = nimble::EncodingLayoutCapture::capture(encoded);
+    auto capturedLayout = nimble::EncodingLayoutCapture::capture(
+        encoded, nimble::Encoding::Options{});
     EXPECT_EQ(capturedLayout.encodingType(), nimble::EncodingType::Dictionary);
 
     // Verify leaf compression types in the captured tree.

--- a/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FixedBitWidthEncodingTest.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrefix.h"
@@ -234,8 +235,7 @@ TYPED_TEST(FixedBitWidthEncodingTest, slice) {
             options);
 
     for (const auto range :
-         {Range{/*offset=*/0, /*length=*/0},
-          Range{/*offset=*/0, /*length=*/5},
+         {Range{/*offset=*/0, /*length=*/5},
           Range{/*offset=*/1, /*length=*/7},
           Range{/*offset=*/4, /*length=*/8},
           Range{/*offset=*/27, /*length=*/5}}) {
@@ -265,6 +265,31 @@ TYPED_TEST(FixedBitWidthEncodingTest, slice) {
       EXPECT_EQ(result, expected);
     }
   }
+}
+
+TYPED_TEST(FixedBitWidthEncodingTest, rejectsZeroLengthSlice) {
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+
+  nimble::Vector<uint32_t> values{this->pool_.get()};
+  for (uint32_t i = 0; i < 32; ++i) {
+    values.push_back(1000 + i);
+  }
+
+  nimble::Buffer sourceBuffer{*this->pool_};
+  const auto encoded =
+      nimble::test::Encoder<nimble::FixedBitWidthEncoding<uint32_t>>::encode(
+          sourceBuffer, values, nimble::CompressionType::Uncompressed, options);
+
+  nimble::Buffer sliceBuffer{*this->pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::EncodingFactory::slice(
+          encoded,
+          /*offset=*/0,
+          /*length=*/0,
+          sliceBuffer,
+          options),
+      "");
 }
 
 TYPED_TEST(FixedBitWidthEncodingTest, sliceCompressedSource) {

--- a/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/MainlyConstantEncodingTest.cpp
@@ -20,6 +20,7 @@
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/NimbleCompare.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
@@ -218,8 +219,7 @@ TYPED_TEST(MainlyConstantEncodingTest, slice) {
     uint32_t length;
   };
   for (const auto range :
-       {Range{/*offset=*/0, /*length=*/0},
-        Range{/*offset=*/0, /*length=*/4},
+       {Range{/*offset=*/0, /*length=*/4},
         Range{/*offset=*/2, /*length=*/6},
         Range{/*offset=*/6, /*length=*/4}}) {
     SCOPED_TRACE(
@@ -247,6 +247,43 @@ TYPED_TEST(MainlyConstantEncodingTest, slice) {
   }
 }
 
+TYPED_TEST(MainlyConstantEncodingTest, sliceAllCommonRowsReturnsConstant) {
+  using DataType = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint};
+  const auto values = this->template toVector<DataType>(
+      {static_cast<DataType>(7),
+       static_cast<DataType>(7),
+       static_cast<DataType>(20),
+       static_cast<DataType>(7),
+       static_cast<DataType>(40),
+       static_cast<DataType>(7)});
+  const auto encoded =
+      nimble::test::Encoder<nimble::MainlyConstantEncoding<DataType>>::encode(
+          *this->buffer_,
+          values,
+          nimble::CompressionType::Uncompressed,
+          options);
+
+  nimble::Buffer sliceBuffer{*this->pool_};
+  const auto sliced = nimble::MainlyConstantEncoding<DataType>::slice(
+      encoded, /*offset=*/0, /*length=*/2, sliceBuffer, options);
+  auto encoding = nimble::EncodingFactory{options}.create(
+      *this->pool_, sliced, [](uint32_t /*totalLength*/) -> void* {
+        return nullptr;
+      });
+
+  EXPECT_EQ(encoding->encodingType(), nimble::EncodingType::Constant);
+  EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<DataType>::dataType);
+  EXPECT_EQ(encoding->rowCount(), 2);
+
+  nimble::Vector<DataType> result(this->pool_.get(), 2);
+  encoding->materialize(2, result.data());
+  for (uint32_t i = 0; i < result.size(); ++i) {
+    EXPECT_TRUE(nimble::NimbleCompare<DataType>::equals(result[i], values[i]));
+  }
+}
+
 TYPED_TEST(MainlyConstantEncodingTest, invalidSliceRange) {
   using DataType = typename TypeParam::data_type;
   const nimble::Encoding::Options options{
@@ -264,6 +301,14 @@ TYPED_TEST(MainlyConstantEncodingTest, invalidSliceRange) {
           options);
 
   nimble::Buffer invalidSliceBuffer{*this->pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::MainlyConstantEncoding<DataType>::slice(
+          encoded,
+          /*offset=*/0,
+          /*length=*/0,
+          invalidSliceBuffer,
+          options),
+      "");
   NIMBLE_ASSERT_THROW(
       nimble::MainlyConstantEncoding<DataType>::slice(
           encoded,

--- a/dwio/nimble/encodings/tests/NullableEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/NullableEncodingTest.cpp
@@ -334,6 +334,14 @@ TEST_F(NullableEncodingSliceTest, invalidSliceRange) {
     NIMBLE_ASSERT_THROW(
         nimble::NullableEncoding<int32_t>::slice(
             encoded,
+            /*offset=*/0,
+            /*length=*/0,
+            invalidSliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::NullableEncoding<int32_t>::slice(
+            encoded,
             /*offset=*/8,
             /*length=*/0,
             invalidSliceBuffer,

--- a/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/RLEEncodingTest.cpp
@@ -398,6 +398,14 @@ TYPED_TEST(RleEncodingTest, invalidSliceRange) {
   NIMBLE_ASSERT_THROW(
       nimble::RLEEncoding<DataType>::slice(
           encoded,
+          /*offset=*/0,
+          /*length=*/0,
+          invalidSliceBuffer,
+          options),
+      "");
+  NIMBLE_ASSERT_THROW(
+      nimble::RLEEncoding<DataType>::slice(
+          encoded,
           /*offset=*/5,
           /*length=*/0,
           invalidSliceBuffer,

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -323,7 +323,8 @@ class ReadWithVisitorTest : public ::testing::TestWithParam<bool>,
     if (!chunkedStream.hasNext()) {
       return std::nullopt;
     }
-    return EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+    return EncodingLayoutCapture::capture(
+        chunkedStream.nextChunk(), Encoding::Options{});
   }
 
   template <typename T>

--- a/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -253,9 +253,22 @@ class SliceEncodingTest : public ::testing::Test {
     const auto sliced = slice(encoded, offset, length);
     auto encoding = createEncoding(sliced);
 
-    EXPECT_EQ(
-        encoding->encodingType(),
-        nimble::test::Encoder<EncodingType>::encodingType());
+    auto expectedEncodingType =
+        nimble::test::Encoder<EncodingType>::encodingType();
+    if constexpr (std::is_same_v<
+                      EncodingType,
+                      nimble::MainlyConstantEncoding<T>>) {
+      const auto fullRange = offset == 0 && length == values.size();
+      bool onlyCommonRows{true};
+      for (uint32_t row = offset; row < offset + length; ++row) {
+        onlyCommonRows &= row % 5 != 2;
+      }
+      if (!fullRange && onlyCommonRows) {
+        expectedEncodingType = nimble::EncodingType::Constant;
+      }
+    }
+
+    EXPECT_EQ(encoding->encodingType(), expectedEncodingType);
     EXPECT_EQ(encoding->dataType(), nimble::TypeTraits<T>::dataType);
     EXPECT_EQ(encoding->rowCount(), length);
 
@@ -338,6 +351,15 @@ TYPED_TEST(SliceEncodingTypedTest, materializesRange) {
       values,
       offset,
       length);
+}
+
+TYPED_TEST(SliceEncodingTypedTest, rejectsZeroLengthRange) {
+  using EncodingType = typename TypeParam::EncodingType;
+  const auto values = this->template makeValuesForEncoding<EncodingType>();
+  const auto encoded =
+      nimble::test::Encoder<EncodingType>::encode(*this->buffer_, values);
+
+  NIMBLE_ASSERT_THROW(this->slice(encoded, /*offset=*/0, /*length=*/0), "");
 }
 
 TYPED_TEST(SliceEncodingTypedTest, materializesRandomRanges) {

--- a/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SparseBoolEncodingTest.cpp
@@ -319,6 +319,14 @@ TYPED_TEST(SparseBoolEncodingTest, invalidSliceRange) {
   NIMBLE_ASSERT_THROW(
       nimble::SparseBoolEncoding::slice(
           encoded,
+          /*offset=*/0,
+          /*length=*/0,
+          invalidSliceBuffer,
+          options),
+      "");
+  NIMBLE_ASSERT_THROW(
+      nimble::SparseBoolEncoding::slice(
+          encoded,
           /*offset=*/11,
           /*length=*/0,
           invalidSliceBuffer,

--- a/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SubIntSplitEncodingTest.cpp
@@ -288,7 +288,8 @@ TYPED_TEST(SubIntSplitEncodingTest, RecomputeRoundTripAndReplay) {
 
   const auto encoded =
       encodeWithNonRecursiveSubIntSplit<T>(values, *this->buffer_);
-  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+  const auto captured = nimble::EncodingLayoutCapture::capture(
+      encoded, nimble::Encoding::Options{});
 
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
   ASSERT_GT(captured.childrenCount(), 1u);
@@ -307,7 +308,8 @@ TYPED_TEST(SubIntSplitEncodingTest, RecomputeRoundTripAndReplay) {
 
   const auto replayed =
       encodeWithReplayLayout<T>(captured, values, *this->buffer_);
-  const auto replayCaptured = nimble::EncodingLayoutCapture::capture(replayed);
+  const auto replayCaptured = nimble::EncodingLayoutCapture::capture(
+      replayed, nimble::Encoding::Options{});
   expectSameLayout(captured, replayCaptured);
 
   auto encoding = decodeEncoding<T>(replayed, *this->pool_);
@@ -335,7 +337,8 @@ TYPED_TEST(SubIntSplitEncodingTest, PreserveRoundTripExplicitBoundaries) {
 
   const auto encoded =
       encodeWithReplayLayout<T>(layout, values, *this->buffer_);
-  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+  const auto captured = nimble::EncodingLayoutCapture::capture(
+      encoded, nimble::Encoding::Options{});
 
   ASSERT_EQ(captured.encodingType(), nimble::EncodingType::SubIntSplit);
   ASSERT_EQ(captured.childrenCount(), segments.size());
@@ -393,7 +396,8 @@ TEST(SubIntSplitEncodingTests, FullWidthSingleSectionRoundTrip) {
   auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
   nimble::Buffer buffer{*pool};
   const auto encoded = encodeWithReplayLayout<uint64_t>(layout, values, buffer);
-  const auto captured = nimble::EncodingLayoutCapture::capture(encoded);
+  const auto captured = nimble::EncodingLayoutCapture::capture(
+      encoded, nimble::Encoding::Options{});
 
   ASSERT_EQ(captured.childrenCount(), 1u);
   const auto capturedBoundaries = captured.config().get(

--- a/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/TrivialEncodingTest.cpp
@@ -114,9 +114,6 @@ class TrivialEncodingTest : public ::testing::Test {
         Range{/*name=*/"singleEnd",
               /*offset=*/valueCount - 1,
               /*length=*/1},
-        Range{/*name=*/"emptyStart", /*offset=*/0, /*length=*/0},
-        Range{/*name=*/"emptyMiddle", /*offset=*/2048, /*length=*/0},
-        Range{/*name=*/"emptyEnd", /*offset=*/valueCount, /*length=*/0},
     };
   }
 
@@ -245,6 +242,14 @@ TEST_F(TrivialEncodingTest, invalidSliceRange) {
     NIMBLE_ASSERT_THROW(
         nimble::TrivialEncoding<uint32_t>::slice(
             uint32Encoded,
+            /*offset=*/0,
+            /*length=*/0,
+            uint32SliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<uint32_t>::slice(
+            uint32Encoded,
             /*offset=*/4,
             /*length=*/0,
             uint32SliceBuffer,
@@ -267,6 +272,14 @@ TEST_F(TrivialEncodingTest, invalidSliceRange) {
             nimble::CompressionType::Uncompressed,
             options);
     nimble::Buffer boolSliceBuffer{*pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<bool>::slice(
+            boolEncoded,
+            /*offset=*/0,
+            /*length=*/0,
+            boolSliceBuffer,
+            options),
+        "");
     NIMBLE_ASSERT_THROW(
         nimble::TrivialEncoding<bool>::slice(
             boolEncoded,
@@ -293,6 +306,14 @@ TEST_F(TrivialEncodingTest, invalidSliceRange) {
             nimble::CompressionType::Uncompressed,
             options);
     nimble::Buffer stringSliceBuffer{*pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::TrivialEncoding<std::string_view>::slice(
+            stringEncoded,
+            /*offset=*/0,
+            /*length=*/0,
+            stringSliceBuffer,
+            options),
+        "");
     NIMBLE_ASSERT_THROW(
         nimble::TrivialEncoding<std::string_view>::slice(
             stringEncoded,

--- a/dwio/nimble/encodings/views/BlockBitPackingEncodingView.h
+++ b/dwio/nimble/encodings/views/BlockBitPackingEncodingView.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
@@ -41,75 +42,80 @@ class BlockBitPackingEncodingView final : public TypedEncodingView<T> {
       velox::memory::MemoryPool* pool,
       const Encoding::Options& options)
       : TypedEncodingView<T>{data, pool, options},
-        blocks_{this->template getVectorBuffer<BlockMeta>()} {
+        blocks_{this->template getVectorBuffer<BlockMeta>()},
+        blockRowOffsets_{this->template getVectorBuffer<uint32_t>()} {
     NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::BlockBitPacking);
-    const char* pos = data.data() + this->dataOffset_;
-    const auto compressionType =
-        static_cast<CompressionType>(encoding::readChar(pos));
+    const auto source =
+        BlockBitPackingEncoding<T>::parseSourceHeader(data, options);
     NIMBLE_CHECK_EQ(
-        compressionType,
+        source.compressionType,
         CompressionType::Uncompressed,
         "EncodingView does not support compressed BlockBitPacking streams.");
-    blockSize_ = encoding::read<const uint16_t>(pos);
-    numBlocks_ = encoding::read<const uint16_t>(pos);
-    NIMBLE_CHECK_GT(blockSize_, 0);
-    NIMBLE_CHECK_EQ(
-        numBlocks_, velox::bits::divRoundUp(this->rowCount_, blockSize_));
+    NIMBLE_CHECK_GT(source.blockSize, 0);
+    NIMBLE_CHECK_GT(source.numBlocks, 0);
+    blockSize_ = source.blockSize;
+    firstBlockRows_ = source.firstBlockRows;
+    numBlocks_ = source.numBlocks;
 
-    const auto baselinesSize = encoding::readUint32(pos);
     auto noStringBufferFactory = [](uint32_t) -> void* { return nullptr; };
     auto baselinesEncoding = EncodingFactory(options).create(
-        *this->pool_, {pos, baselinesSize}, noStringBufferFactory);
+        *this->pool_, source.encodedBaselines, noStringBufferFactory);
     NIMBLE_CHECK_NOT_NULL(baselinesEncoding);
     auto baselines = this->template getVectorBuffer<physicalType>();
-    baselines.resize(numBlocks_);
-    baselinesEncoding->materialize(numBlocks_, baselines.data());
-    pos += baselinesSize;
+    baselines.resize(source.numBlocks);
+    baselinesEncoding->materialize(source.numBlocks, baselines.data());
 
-    const auto bitWidthsSize = encoding::readUint32(pos);
     auto bitWidthsEncoding = EncodingFactory(options).create(
-        *this->pool_, {pos, bitWidthsSize}, noStringBufferFactory);
+        *this->pool_, source.encodedBitWidths, noStringBufferFactory);
     NIMBLE_CHECK_NOT_NULL(bitWidthsEncoding);
     auto bitWidths = this->template getVectorBuffer<uint8_t>();
-    bitWidths.resize(numBlocks_);
-    bitWidthsEncoding->materialize(numBlocks_, bitWidths.data());
-    pos += bitWidthsSize;
+    bitWidths.resize(source.numBlocks);
+    bitWidthsEncoding->materialize(source.numBlocks, bitWidths.data());
 
-    const auto offsetsSize = encoding::readUint32(pos);
     auto offsetsEncoding = EncodingFactory(options).create(
-        *this->pool_, {pos, offsetsSize}, noStringBufferFactory);
+        *this->pool_, source.encodedBlockOffsets, noStringBufferFactory);
     NIMBLE_CHECK_NOT_NULL(offsetsEncoding);
     auto offsets = this->template getVectorBuffer<uint32_t>();
-    offsets.resize(numBlocks_);
-    offsetsEncoding->materialize(numBlocks_, offsets.data());
-    pos += offsetsSize;
+    offsets.resize(source.numBlocks);
+    offsetsEncoding->materialize(source.numBlocks, offsets.data());
 
-    blocks_.reserve(numBlocks_);
-    for (uint16_t i = 0; i < numBlocks_; ++i) {
+    blockRowOffsets_.resize(source.numBlocks + 1);
+    uint32_t rowOffset{0};
+    blocks_.reserve(source.numBlocks);
+    for (uint16_t i = 0; i < source.numBlocks; ++i) {
+      blockRowOffsets_[i] = rowOffset;
+      const auto rowCount =
+          BlockBitPackingEncoding<T>::blockRowCount(source, /*blockIndex=*/i);
+      NIMBLE_CHECK_LE(rowCount, source.blockSize);
+      rowOffset += rowCount;
       const auto bitWidth = bitWidths[i];
       blocks_.push_back(
           BlockMeta{
               .baseline = baselines[i],
               .bitWidth = bitWidth,
               .offset = offsets[i],
+              .rowCount = rowCount,
           });
     }
+    blockRowOffsets_[source.numBlocks] = rowOffset;
+    NIMBLE_CHECK_EQ(rowOffset, this->rowCount_);
     this->releaseVectorBuffer(offsets);
     this->releaseVectorBuffer(bitWidths);
     this->releaseVectorBuffer(baselines);
-    packedData_ = pos;
+    packedData_ = source.packedData.data();
   }
 
   ~BlockBitPackingEncodingView() override {
+    this->releaseVectorBuffer(blockRowOffsets_);
     this->releaseVectorBuffer(blocks_);
   }
 
  private:
   T readTypedAt(uint32_t index) const final {
     NIMBLE_CHECK_LT(index, this->rowCount_);
-    const auto blockIndex = index / blockSize_;
-    const auto blockOffset = index % blockSize_;
-    const auto& block = blocks_[blockIndex];
+    const auto indexBlock = blockIndex(index);
+    const auto blockOffset = index - blockRowOffsets_[indexBlock];
+    const auto& block = blocks_[indexBlock];
     if (block.bitWidth == BlockBitPackingEncoding<T>::kRawBlockBitWidth) {
       const auto* values =
           reinterpret_cast<const physicalType*>(packedData_ + block.offset);
@@ -118,7 +124,7 @@ class BlockBitPackingEncodingView final : public TypedEncodingView<T> {
     if (block.bitWidth == 0) {
       return detail::castFromPhysicalType<T>(block.baseline);
     }
-    const auto numRows = blockRowCount(blockIndex);
+    const auto numRows = blockRowCount(indexBlock);
     FixedBitArray fba{
         {packedData_ + block.offset,
          FixedBitArray::bufferSize(numRows, block.bitWidth)},
@@ -132,19 +138,27 @@ class BlockBitPackingEncodingView final : public TypedEncodingView<T> {
     this->checkReadRange(offset, length);
     uint32_t outputOffset{0};
     while (outputOffset < length) {
-      const auto blockIndex = offset / blockSize_;
-      const auto blockOffset = offset % blockSize_;
-      const auto count =
-          std::min<uint32_t>(length - outputOffset, blockSize_ - blockOffset);
-      readBlockRange(blockIndex, blockOffset, count, output + outputOffset);
+      const auto indexBlock = blockIndex(offset);
+      const auto blockOffset = offset - blockRowOffsets_[indexBlock];
+      const auto count = std::min<uint32_t>(
+          length - outputOffset, blocks_[indexBlock].rowCount - blockOffset);
+      readBlockRange(indexBlock, blockOffset, count, output + outputOffset);
       outputOffset += count;
       offset += count;
     }
   }
 
   uint32_t blockRowCount(uint32_t blockIndex) const {
-    const auto start = blockIndex * blockSize_;
-    return std::min<uint32_t>(blockSize_, this->rowCount_ - start);
+    return blocks_[blockIndex].rowCount;
+  }
+
+  uint32_t blockIndex(uint32_t row) const {
+    if (row < firstBlockRows_) {
+      return 0;
+    }
+    const auto blockIndex = 1 + (row - firstBlockRows_) / blockSize_;
+    NIMBLE_CHECK_LT(blockIndex, numBlocks_);
+    return blockIndex;
   }
 
   void readBlockRange(
@@ -271,12 +285,15 @@ class BlockBitPackingEncodingView final : public TypedEncodingView<T> {
     physicalType baseline;
     uint8_t bitWidth;
     uint32_t offset;
+    uint32_t rowCount;
   };
 
+  Vector<BlockMeta> blocks_;
+  Vector<uint32_t> blockRowOffsets_;
+  const char* packedData_{nullptr};
   uint16_t blockSize_{0};
   uint16_t numBlocks_{0};
-  Vector<BlockMeta> blocks_;
-  const char* packedData_{nullptr};
+  uint32_t firstBlockRows_{0};
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/tests/SerializerImplTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerImplTest.cpp
@@ -1550,7 +1550,8 @@ TEST_F(EncodeTypedCompressionTest, withEncodingLayout) {
     EXPECT_EQ(decoded, data);
 
     // Verify compression type in the encoded output.
-    auto capturedLayout = EncodingLayoutCapture::capture(encoded);
+    auto capturedLayout =
+        EncodingLayoutCapture::capture(encoded, Encoding::Options{});
     if (!testData.compressionOptions.has_value()) {
       verifyLeafCompression(capturedLayout, CompressionType::Uncompressed);
     }
@@ -1584,7 +1585,8 @@ TEST_F(EncodeTypedCompressionTest, withoutEncodingLayout) {
       /*encodingLayout=*/nullptr,
       /*compressionOptions=*/CompressionOptions{});
 
-  auto capturedLayout = EncodingLayoutCapture::capture(encoded);
+  auto capturedLayout =
+      EncodingLayoutCapture::capture(encoded, Encoding::Options{});
   verifyLeafCompression(capturedLayout, CompressionType::Uncompressed);
 
   // Verify round-trip.

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -17,16 +17,24 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 
 namespace facebook::nimble::tools {
 namespace {
-constexpr uint32_t kEncodingPrefixSize = 6;
+uint32_t prefixSize(std::string_view stream, bool useVarintRowCount = false) {
+  NIMBLE_CHECK_GE(
+      stream.size(),
+      EncodingPrefix::kRowCountOffset + 1,
+      "Unexpected end of stream.");
+  return EncodingPrefix::prefixSize(stream, useVarintRowCount);
+}
 
 void extractCompressionType(
     EncodingType encodingType,
     DataType /* dataType */,
     std::string_view stream,
+    bool useVarintRowCount,
     std::unordered_map<EncodingPropertyType, EncodingProperty>& properties) {
   switch (encodingType) {
     // Compression type is the byte right after the encoding header for both
@@ -34,7 +42,7 @@ void extractCompressionType(
     case EncodingType::Trivial:
     case EncodingType::FixedBitWidth:
     case EncodingType::BlockBitPacking: {
-      auto pos = stream.data() + kEncodingPrefixSize;
+      auto pos = stream.data() + prefixSize(stream, useVarintRowCount);
       properties.insert(
           {EncodingPropertyType::Compression,
            EncodingProperty{
@@ -72,9 +80,11 @@ std::unordered_map<EncodingPropertyType, EncodingProperty>
 extractEncodingProperties(
     EncodingType encodingType,
     DataType dataType,
-    std::string_view stream) {
+    std::string_view stream,
+    bool useVarintRowCount) {
   std::unordered_map<EncodingPropertyType, EncodingProperty> properties{};
-  extractCompressionType(encodingType, dataType, stream, properties);
+  extractCompressionType(
+      encodingType, dataType, stream, useVarintRowCount, properties);
   properties.insert(
       {EncodingPropertyType::EncodedSize,
        {.value = folly::to<std::string>(stream.size())}});
@@ -86,6 +96,7 @@ void traverseEncodings(
     uint32_t level,
     uint32_t index,
     const std::string& nestedEncodingName,
+    bool useVarintRowCount,
     std::function<bool(
         EncodingType,
         DataType,
@@ -96,17 +107,21 @@ void traverseEncodings(
             EncodingPropertyType,
             EncodingProperty> /* properties */)> visitor) {
   NIMBLE_CHECK_GE(
-      stream.size(), kEncodingPrefixSize, "Unexpected end of stream.");
+      stream.size(),
+      EncodingPrefix::kRowCountOffset + 1,
+      "Unexpected end of stream.");
 
-  const EncodingType encodingType = static_cast<EncodingType>(stream[0]);
-  auto dataType = static_cast<DataType>(stream[1]);
+  const EncodingType encodingType = EncodingPrefix::encodingType(stream);
+  auto dataType = EncodingPrefix::dataType(stream);
+  const auto dataOffset = prefixSize(stream, useVarintRowCount);
   bool continueTraversal = visitor(
       encodingType,
       dataType,
       level,
       index,
       nestedEncodingName,
-      extractEncodingProperties(encodingType, dataType, stream));
+      extractEncodingProperties(
+          encodingType, dataType, stream, useVarintRowCount));
 
   if (!continueTraversal) {
     return;
@@ -126,41 +141,61 @@ void traverseEncodings(
       break;
     }
     case EncodingType::ALP: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + dataOffset;
       const auto header = detail::alp::readHeader(pos);
       if (header.hasExceptions) {
         varint::readVarint32(&pos); // exceptionCount
       }
       const uint32_t encodedValuesSize = varint::readVarint32(&pos);
       traverseEncodings(
-          {pos, encodedValuesSize}, level + 1, 0, "EncodedValues", visitor);
+          {pos, encodedValuesSize},
+          level + 1,
+          0,
+          "EncodedValues",
+          useVarintRowCount,
+          visitor);
       break;
     }
     case EncodingType::BlockBitPacking: {
       // Layout after the common prefix: compressionType [1 byte], blockSize
-      // [2 bytes], numBlocks [2 bytes], then three self-describing nested
-      // metadata sub-streams, each preceded by a 4-byte size: the per-block
+      // [varint], numBlocks [varint], then three self-describing nested
+      // metadata sub-streams, each preceded by a varint size: the per-block
       // baselines, bit widths, and data offsets.
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + dataOffset;
       encoding::readChar(pos); // compressionType
-      encoding::read<uint16_t>(pos); // blockSize
-      encoding::read<uint16_t>(pos); // numBlocks
-      const uint32_t baselinesSize = encoding::readUint32(pos);
+      varint::readVarint32(&pos); // blockSize
+      varint::readVarint32(&pos); // numBlocks
+      const uint32_t baselinesSize = varint::readVarint32(&pos);
       if (baselinesSize > 0) {
         traverseEncodings(
-            {pos, baselinesSize}, level + 1, 0, "Baselines", visitor);
+            {pos, baselinesSize},
+            level + 1,
+            0,
+            "Baselines",
+            useVarintRowCount,
+            visitor);
       }
       pos += baselinesSize;
-      const uint32_t bitWidthsSize = encoding::readUint32(pos);
+      const uint32_t bitWidthsSize = varint::readVarint32(&pos);
       if (bitWidthsSize > 0) {
         traverseEncodings(
-            {pos, bitWidthsSize}, level + 1, 1, "BitWidths", visitor);
+            {pos, bitWidthsSize},
+            level + 1,
+            1,
+            "BitWidths",
+            useVarintRowCount,
+            visitor);
       }
       pos += bitWidthsSize;
-      const uint32_t offsetsSize = encoding::readUint32(pos);
+      const uint32_t offsetsSize = varint::readVarint32(&pos);
       if (offsetsSize > 0) {
         traverseEncodings(
-            {pos, offsetsSize}, level + 1, 2, "DataOffsets", visitor);
+            {pos, offsetsSize},
+            level + 1,
+            2,
+            "DataOffsets",
+            useVarintRowCount,
+            visitor);
       }
       break;
     }
@@ -169,29 +204,44 @@ void traverseEncodings(
       // baseBitWidth [1 byte], numExceptions [4 bytes], then two
       // self-describing nested sub-streams, each preceded by a 4-byte size:
       // the exception positions and the exception residual values.
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + dataOffset;
       pos += detail::dataTypeSize(dataType); // baseline
       encoding::readChar(pos); // baseBitWidth
       encoding::readUint32(pos); // numExceptions
       const uint32_t positionsSize = encoding::readUint32(pos);
       if (positionsSize > 0) {
         traverseEncodings(
-            {pos, positionsSize}, level + 1, 0, "ExceptionPositions", visitor);
+            {pos, positionsSize},
+            level + 1,
+            0,
+            "ExceptionPositions",
+            useVarintRowCount,
+            visitor);
       }
       pos += positionsSize;
       const uint32_t valuesSize = encoding::readUint32(pos);
       if (valuesSize > 0) {
         traverseEncodings(
-            {pos, valuesSize}, level + 1, 1, "ExceptionValues", visitor);
+            {pos, valuesSize},
+            level + 1,
+            1,
+            "ExceptionValues",
+            useVarintRowCount,
+            visitor);
       }
       break;
     }
     case EncodingType::Trivial: {
       if (dataType == DataType::String) {
-        const char* pos = stream.data() + kEncodingPrefixSize + 1;
+        const char* pos = stream.data() + dataOffset + 1;
         const uint32_t lengthsBytes = encoding::readUint32(pos);
         traverseEncodings(
-            {pos, lengthsBytes}, level + 1, 0, "Lengths", visitor);
+            {pos, lengthsBytes},
+            level + 1,
+            0,
+            "Lengths",
+            useVarintRowCount,
+            visitor);
       }
       break;
     }
@@ -201,49 +251,72 @@ void traverseEncodings(
           level + 1,
           0,
           "Lengths",
+          useVarintRowCount,
           visitor);
       break;
     }
     case EncodingType::SparseBool: {
-      const char* pos = stream.data() + kEncodingPrefixSize + 1;
+      const char* pos = stream.data() + dataOffset + 1;
       traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
           level + 1,
           0,
           "Indices",
+          useVarintRowCount,
           visitor);
       break;
     }
     case EncodingType::MainlyConstant: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + dataOffset;
       const uint32_t isCommonBytes = encoding::readUint32(pos);
       traverseEncodings(
-          {pos, isCommonBytes}, level + 1, 0, "IsCommon", visitor);
+          {pos, isCommonBytes},
+          level + 1,
+          0,
+          "IsCommon",
+          useVarintRowCount,
+          visitor);
       pos += isCommonBytes;
       const uint32_t otherValueBytes = encoding::readUint32(pos);
       traverseEncodings(
-          {pos, otherValueBytes}, level + 1, 1, "OtherValues", visitor);
+          {pos, otherValueBytes},
+          level + 1,
+          1,
+          "OtherValues",
+          useVarintRowCount,
+          visitor);
       break;
     }
     case EncodingType::Dictionary: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + dataOffset;
       const uint32_t alphabetBytes = encoding::readUint32(pos);
       traverseEncodings(
-          {pos, alphabetBytes}, level + 1, 0, "Alphabet", visitor);
+          {pos, alphabetBytes},
+          level + 1,
+          0,
+          "Alphabet",
+          useVarintRowCount,
+          visitor);
       pos += alphabetBytes;
       traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
           level + 1,
           1,
           "Indices",
+          useVarintRowCount,
           visitor);
       break;
     }
     case EncodingType::RLE: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + dataOffset;
       const uint32_t runLengthBytes = encoding::readUint32(pos);
       traverseEncodings(
-          {pos, runLengthBytes}, level + 1, 0, "Lengths", visitor);
+          {pos, runLengthBytes},
+          level + 1,
+          0,
+          "Lengths",
+          useVarintRowCount,
+          visitor);
       if (dataType != DataType::Bool) {
         pos += runLengthBytes;
         traverseEncodings(
@@ -251,47 +324,63 @@ void traverseEncodings(
             level + 1,
             1,
             "Values",
+            useVarintRowCount,
             visitor);
       }
       break;
     }
     case EncodingType::Delta: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + dataOffset;
       const uint32_t deltaBytes = encoding::readUint32(pos);
       const uint32_t restatementBytes = encoding::readUint32(pos);
-      traverseEncodings({pos, deltaBytes}, level + 1, 0, "Deltas", visitor);
+      traverseEncodings(
+          {pos, deltaBytes},
+          level + 1,
+          0,
+          "Deltas",
+          useVarintRowCount,
+          visitor);
       pos += deltaBytes;
       traverseEncodings(
-          {pos, restatementBytes}, level + 1, 1, "Restatements", visitor);
+          {pos, restatementBytes},
+          level + 1,
+          1,
+          "Restatements",
+          useVarintRowCount,
+          visitor);
       pos += restatementBytes;
       traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
           level + 1,
           2,
           "IsRestatements",
+          useVarintRowCount,
           visitor);
       break;
     }
     case EncodingType::Nullable: {
-      const char* pos = stream.data() + kEncodingPrefixSize;
+      const char* pos = stream.data() + dataOffset;
       const uint32_t dataBytes = encoding::readUint32(pos);
-      traverseEncodings({pos, dataBytes}, level + 1, 0, "Data", visitor);
+      traverseEncodings(
+          {pos, dataBytes}, level + 1, 0, "Data", useVarintRowCount, visitor);
       pos += dataBytes;
       traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
           level + 1,
           1,
           "Nulls",
+          useVarintRowCount,
           visitor);
       break;
     }
     case EncodingType::Sentinel: {
-      const char* pos = stream.data() + kEncodingPrefixSize + 8;
+      const char* pos = stream.data() + dataOffset + 8;
       traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
           level + 1,
           0,
           "Sentinels",
+          useVarintRowCount,
           visitor);
       break;
     }
@@ -324,7 +413,7 @@ void traverseEncodings(
         std::unordered_map<
             EncodingPropertyType,
             EncodingProperty> /* properties */)> visitor) {
-  traverseEncodings(stream, 0, 0, "", visitor);
+  traverseEncodings(stream, 0, 0, "", /*useVarintRowCount=*/false, visitor);
 }
 
 std::string getStreamInputLabel(nimble::ChunkedStream& stream) {

--- a/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
+++ b/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
@@ -21,6 +21,8 @@
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "dwio/nimble/tools/EncodingUtilities.h"
@@ -43,16 +45,22 @@ class EncodingUtilitiesTest : public ::testing::Test {
   //   bytes 2-5: rowCount (uint32_t)
   //   byte 6: CompressionType::Uncompressed (0)
   //   bytes 7+: raw data (rowCount * sizeof(uint32_t))
-  std::string buildTrivialUint32Stream(const std::vector<uint32_t>& values) {
+  std::string buildTrivialUint32Stream(
+      const std::vector<uint32_t>& values,
+      bool useVarintRowCount = false) {
     uint32_t rowCount = static_cast<uint32_t>(values.size());
     uint32_t dataSize = rowCount * sizeof(uint32_t);
-    uint32_t totalSize = 6 + 1 + dataSize; // prefix + compressionType + data
+    uint32_t totalSize =
+        EncodingPrefix::serializedSize(rowCount, useVarintRowCount) + 1 +
+        dataSize;
     std::string buf(totalSize, '\0');
     char* pos = buf.data();
-    encoding::writeChar(
-        static_cast<char>(EncodingType::Trivial), pos); // byte 0
-    encoding::writeChar(static_cast<char>(DataType::Uint32), pos); // byte 1
-    encoding::writeUint32(rowCount, pos); // bytes 2-5
+    EncodingPrefix::serialize(
+        EncodingType::Trivial,
+        DataType::Uint32,
+        rowCount,
+        useVarintRowCount,
+        pos);
     encoding::writeChar(
         static_cast<char>(CompressionType::Uncompressed), pos); // byte 6
     for (auto v : values) {
@@ -117,31 +125,46 @@ class EncodingUtilitiesTest : public ::testing::Test {
   //   bytes 0-5: prefix (EncodingType::BlockBitPacking, DataType::Uint32,
   //              rowCount)
   //   byte 6: compressionType (Uncompressed)
-  //   bytes 7-8: blockSize (uint16)
-  //   bytes 9-10: numBlocks (uint16)
+  //   varint: blockSize
+  //   varint: numBlocks
   //   then the baselines / bitWidths / offsets sub-streams, each preceded by a
-  //   4-byte size.
+  //   varint size, followed by firstBlockRows.
   std::string buildBlockBitPackingUint32Stream(
       const std::string& baselines,
       const std::string& bitWidths,
       const std::string& offsets) {
-    const size_t totalSize = 6 + 1 /* compressionType */ + 2 /* blockSize */ +
-        2 /* numBlocks */ + sizeof(uint32_t) + baselines.size() +
-        sizeof(uint32_t) + bitWidths.size() + sizeof(uint32_t) + offsets.size();
+    constexpr uint32_t kRowCount{100};
+    constexpr uint32_t kBlockSize{64};
+    constexpr uint32_t kNumBlocks{2};
+    constexpr uint32_t kFirstBlockRows{kBlockSize};
+    const size_t totalSize =
+        EncodingPrefix::serializedSize(kRowCount, /*useVarint=*/false) +
+        1 /* compressionType */ + varint::varintSize(kBlockSize) +
+        varint::varintSize(kNumBlocks) +
+        varint::varintSize(static_cast<uint32_t>(baselines.size())) +
+        baselines.size() +
+        varint::varintSize(static_cast<uint32_t>(bitWidths.size())) +
+        bitWidths.size() +
+        varint::varintSize(static_cast<uint32_t>(offsets.size())) +
+        offsets.size() + varint::varintSize(kFirstBlockRows);
     std::string buf(totalSize, '\0');
     char* pos = buf.data();
-    encoding::writeChar(static_cast<char>(EncodingType::BlockBitPacking), pos);
-    encoding::writeChar(static_cast<char>(DataType::Uint32), pos);
-    encoding::writeUint32(/* rowCount */ 100, pos);
+    EncodingPrefix::serialize(
+        EncodingType::BlockBitPacking,
+        DataType::Uint32,
+        kRowCount,
+        /*useVarint=*/false,
+        pos);
     encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
-    encoding::write<uint16_t>(/* blockSize */ 64, pos);
-    encoding::write<uint16_t>(/* numBlocks */ 2, pos);
-    encoding::writeUint32(static_cast<uint32_t>(baselines.size()), pos);
+    varint::writeVarint(kBlockSize, &pos);
+    varint::writeVarint(kNumBlocks, &pos);
+    varint::writeVarint(static_cast<uint32_t>(baselines.size()), &pos);
     encoding::writeBytes(baselines, pos);
-    encoding::writeUint32(static_cast<uint32_t>(bitWidths.size()), pos);
+    varint::writeVarint(static_cast<uint32_t>(bitWidths.size()), &pos);
     encoding::writeBytes(bitWidths, pos);
-    encoding::writeUint32(static_cast<uint32_t>(offsets.size()), pos);
+    varint::writeVarint(static_cast<uint32_t>(offsets.size()), &pos);
     encoding::writeBytes(offsets, pos);
+    varint::writeVarint(kFirstBlockRows, &pos);
     return buf;
   }
 
@@ -398,9 +421,11 @@ TEST_F(EncodingUtilitiesTest, GetEncodingLabelPfor) {
 // --- BlockBitPacking nested metadata sub-streams ---
 
 TEST_F(EncodingUtilitiesTest, TraverseEncodingsBlockBitPackingChildren) {
-  auto baselines = buildTrivialUint32Stream({0, 64});
-  auto bitWidths = buildTrivialUint32Stream({4, 5});
-  auto offsets = buildTrivialUint32Stream({0, 32});
+  auto baselines =
+      buildTrivialUint32Stream({0, 64}, /*useVarintRowCount=*/false);
+  auto bitWidths =
+      buildTrivialUint32Stream({4, 5}, /*useVarintRowCount=*/false);
+  auto offsets = buildTrivialUint32Stream({0, 32}, /*useVarintRowCount=*/false);
   auto stream = buildBlockBitPackingUint32Stream(baselines, bitWidths, offsets);
 
   EncodingType rootType = EncodingType::Constant; // init to something else
@@ -432,9 +457,11 @@ TEST_F(EncodingUtilitiesTest, GetEncodingLabelBlockBitPacking) {
   // The rendered label surfaces the picked sub-encodings for the per-block
   // metadata, e.g. BlockBitPacking<Uint32>[Baselines:Trivial<...>,
   // BitWidths:Trivial<...>,DataOffsets:Trivial<...>].
-  auto baselines = buildTrivialUint32Stream({0, 64});
-  auto bitWidths = buildTrivialUint32Stream({4, 5});
-  auto offsets = buildTrivialUint32Stream({0, 32});
+  auto baselines =
+      buildTrivialUint32Stream({0, 64}, /*useVarintRowCount=*/false);
+  auto bitWidths =
+      buildTrivialUint32Stream({4, 5}, /*useVarintRowCount=*/false);
+  auto offsets = buildTrivialUint32Stream({0, 32}, /*useVarintRowCount=*/false);
   auto stream = buildBlockBitPackingUint32Stream(baselines, bitWidths, offsets);
 
   auto label = getEncodingLabel(stream);

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -483,7 +483,9 @@ std::string_view encodeStreamTyped(
   // time, so it stays valid regardless of a later chunk's nulls.
   if (context.options().enableEncodingSelectionCache) {
     streamContext(streamData.descriptor())
-        .setEncoding(EncodingLayoutCapture::capture(encoded));
+        .setEncoding(
+            EncodingLayoutCapture::capture(
+                encoded, context.options().buildEncodingOptions()));
   }
   return encoded;
 }
@@ -1751,10 +1753,10 @@ bool VeloxWriter::evaluateFlushPolicy() {
     }
   }
 
-  if (shouldFlush(flushPolicy.get())) {
-    return writeStripe();
+  if (!shouldFlush(flushPolicy.get())) {
+    return false;
   }
-  return false;
+  return writeStripe();
 }
 
 VeloxWriter::Stats VeloxWriter::stats() const {

--- a/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EFilterTest.cpp
@@ -764,8 +764,8 @@ class E2EFilterTest
         if (!chunkedStream.hasNext()) {
           continue;
         }
-        auto capture =
-            EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+        auto capture = EncodingLayoutCapture::capture(
+            chunkedStream.nextChunk(), Encoding::Options{});
         // The top-level encoding may be Nullable (wrapping the data encoding)
         // or the data encoding directly.
         if (capture.encodingType() == EncodingType::Nullable) {
@@ -813,7 +813,8 @@ class E2EFilterTest
       if (!chunkedStream.hasNext()) {
         continue;
       }
-      auto capture = EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+      auto capture = EncodingLayoutCapture::capture(
+          chunkedStream.nextChunk(), Encoding::Options{});
       if (capture.encodingType() == EncodingType::Nullable) {
         ASSERT_TRUE(capture.child(1).has_value())
             << "Column " << columnName << " stripe " << i;

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -389,7 +389,8 @@ class SelectiveNimbleReaderTest
 
       InMemoryChunkedStream chunkedStream{*pool(), std::move(streams[0])};
       ASSERT_TRUE(chunkedStream.hasNext());
-      auto capture = EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+      auto capture = EncodingLayoutCapture::capture(
+          chunkedStream.nextChunk(), Encoding::Options{});
       if (isNullable) {
         // Nullable encoding wraps the data encoding. The data child is at
         // index 1 (index 0 is the nulls bool stream).

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -220,7 +220,8 @@ std::vector<ChunkEncoding> getStreamChunkEncodings(
     }
     InMemoryChunkedStream chunkedStream{*pool, std::move(streams[0])};
     while (chunkedStream.hasNext()) {
-      auto capture = EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+      auto capture = EncodingLayoutCapture::capture(
+          chunkedStream.nextChunk(), Encoding::Options{});
       ChunkEncoding chunk{capture.encodingType(), std::nullopt};
       if (capture.encodingType() == EncodingType::RLE) {
         const auto& runValues =

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -134,7 +134,8 @@ class VeloxWriterTest : public ::testing::Test {
           *leafPool_, std::move(streams[0])};
       while (chunkedStream.hasNext()) {
         chunkLayouts.push_back(
-            nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk()));
+            nimble::EncodingLayoutCapture::capture(
+                chunkedStream.nextChunk(), nimble::Encoding::Options{}));
       }
     }
     return chunkLayouts;
@@ -411,7 +412,8 @@ nimble::EncodingLayout captureFirstColumnEncoding(
   auto streams = tablet->load(tablet->stripeIdentifier(0), streamIdentifiers);
   nimble::InMemoryChunkedStream chunkedStream{*pool, std::move(streams[0])};
   NIMBLE_CHECK(chunkedStream.hasNext(), "Expected at least one chunk.");
-  return nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+  return nimble::EncodingLayoutCapture::capture(
+      chunkedStream.nextChunk(), nimble::Encoding::Options{});
 }
 
 template <typename T>
@@ -751,8 +753,8 @@ TEST_F(VeloxWriterTest, fsstEncodingTargetControlsWriterEncoding) {
     nimble::InMemoryChunkedStream chunkedStream{
         *leafPool_, std::move(streams[0])};
     ASSERT_TRUE(chunkedStream.hasNext());
-    const auto capture =
-        nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+    const auto capture = nimble::EncodingLayoutCapture::capture(
+        chunkedStream.nextChunk(), nimble::Encoding::Options{});
 
     EXPECT_EQ(capture.encodingType(), testCase.expectedEncodingType);
     EXPECT_EQ(capture.compressionType(), testCase.expectedCompressionType);
@@ -1657,8 +1659,8 @@ TEST_F(VeloxWriterTest, encodingLayout) {
             *leafPool_, std::move(streams[0])};
         ASSERT_TRUE(chunkedStream.hasNext());
         // Verify Map stream
-        auto capture =
-            nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+        auto capture = nimble::EncodingLayoutCapture::capture(
+            chunkedStream.nextChunk(), nimble::Encoding::Options{});
         EXPECT_EQ(nimble::EncodingType::Dictionary, capture.encodingType());
         EXPECT_EQ(
             nimble::EncodingType::FixedBitWidth,
@@ -1675,8 +1677,8 @@ TEST_F(VeloxWriterTest, encodingLayout) {
             *leafPool_, std::move(streams[1])};
         ASSERT_TRUE(chunkedStream.hasNext());
         // Verify Map Values stream
-        auto capture =
-            nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+        auto capture = nimble::EncodingLayoutCapture::capture(
+            chunkedStream.nextChunk(), nimble::Encoding::Options{});
         EXPECT_EQ(nimble::EncodingType::MainlyConstant, capture.encodingType());
         EXPECT_EQ(
             nimble::EncodingType::Trivial,
@@ -1695,8 +1697,8 @@ TEST_F(VeloxWriterTest, encodingLayout) {
             *leafPool_, std::move(streams[2])};
         ASSERT_TRUE(chunkedStream.hasNext());
         // Verify FlatMap Kay "1" stream
-        auto capture =
-            nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+        auto capture = nimble::EncodingLayoutCapture::capture(
+            chunkedStream.nextChunk(), nimble::Encoding::Options{});
         EXPECT_EQ(nimble::EncodingType::MainlyConstant, capture.encodingType());
         EXPECT_EQ(
             nimble::EncodingType::Trivial,
@@ -1725,8 +1727,8 @@ TEST_F(VeloxWriterTest, encodingLayout) {
             *leafPool_, std::move(streams[3])};
         ASSERT_TRUE(chunkedStream.hasNext());
         // Verify FlatMap Kay "2" stream
-        auto capture =
-            nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+        auto capture = nimble::EncodingLayoutCapture::capture(
+            chunkedStream.nextChunk(), nimble::Encoding::Options{});
         EXPECT_EQ(nimble::EncodingType::Constant, capture.encodingType());
       }
     }
@@ -1825,8 +1827,8 @@ TEST_F(VeloxWriterTest, openZLCompressionNumericRoundTrip) {
       nimble::InMemoryChunkedStream chunkedStream{
           *leafPool_, std::move(streams[0])};
       while (chunkedStream.hasNext()) {
-        auto capture =
-            nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+        auto capture = nimble::EncodingLayoutCapture::capture(
+            chunkedStream.nextChunk(), nimble::Encoding::Options{});
         if (usesCompression(capture, nimble::CompressionType::OpenZL)) {
           anyOpenZL = true;
         }
@@ -4380,7 +4382,8 @@ TEST_F(VeloxWriterTest, cachedEncodingLayoutNullableEncoding) {
         *leafPool_, std::move(streams[0])};
     while (chunkedStream.hasNext()) {
       const auto rawChunk = chunkedStream.nextChunk();
-      auto dataLayout = nimble::EncodingLayoutCapture::capture(rawChunk);
+      auto dataLayout = nimble::EncodingLayoutCapture::capture(
+          rawChunk, nimble::Encoding::Options{});
       const auto wrapper =
           static_cast<nimble::EncodingType>(static_cast<uint8_t>(rawChunk[0]));
       chunkEncodings.push_back(ChunkEncoding{wrapper, std::move(dataLayout)});
@@ -6734,8 +6737,8 @@ void verifyDeltaEncoding(
 
     nimble::InMemoryChunkedStream chunkedStream{pool, std::move(streams[0])};
     ASSERT_TRUE(chunkedStream.hasNext());
-    auto capture =
-        nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+    auto capture = nimble::EncodingLayoutCapture::capture(
+        chunkedStream.nextChunk(), nimble::Encoding::Options{});
     EXPECT_EQ(nimble::EncodingType::Delta, capture.encodingType())
         << "Stripe " << i;
     if (checkChildren) {
@@ -6799,8 +6802,8 @@ TEST_F(VeloxWriterTest, encodingLayoutDelta) {
       nimble::InMemoryChunkedStream chunkedStream{
           *leafPool_, std::move(streams[0])};
       ASSERT_TRUE(chunkedStream.hasNext());
-      auto capture =
-          nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+      auto capture = nimble::EncodingLayoutCapture::capture(
+          chunkedStream.nextChunk(), nimble::Encoding::Options{});
       EXPECT_EQ(nimble::EncodingType::Delta, capture.encodingType());
       EXPECT_EQ(
           nimble::EncodingType::Trivial,
@@ -7112,16 +7115,16 @@ TEST_F(VeloxWriterTest, encodingLayoutDeltaMultiColumn) {
       nimble::InMemoryChunkedStream chunkedStream{
           *leafPool_, std::move(streams[0])};
       ASSERT_TRUE(chunkedStream.hasNext());
-      auto capture =
-          nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+      auto capture = nimble::EncodingLayoutCapture::capture(
+          chunkedStream.nextChunk(), nimble::Encoding::Options{});
       EXPECT_EQ(nimble::EncodingType::Delta, capture.encodingType());
     }
     {
       nimble::InMemoryChunkedStream chunkedStream{
           *leafPool_, std::move(streams[1])};
       ASSERT_TRUE(chunkedStream.hasNext());
-      auto capture =
-          nimble::EncodingLayoutCapture::capture(chunkedStream.nextChunk());
+      auto capture = nimble::EncodingLayoutCapture::capture(
+          chunkedStream.nextChunk(), nimble::Encoding::Options{});
       EXPECT_EQ(nimble::EncodingType::MainlyConstant, capture.encodingType());
     }
   }


### PR DESCRIPTION
Summary:

Adds native slicing for BlockBitPacking streams.

The slice path parses the source header directly, preserves source block layout using optional first/last partial block row counts, and updates BlockBitPackingEncodingView to read those partial-edge slices. Full source blocks copy packed bytes directly; partial raw blocks copy raw subranges; partial bit-packed blocks use bit-level copying instead of materialize/re-encode.

For metadata, slice reuses nested baseline and bit-width substream slices, reads needed metadata ranges through EncodingView, reuses a bit-width EncodingView for partial-edge access, and regenerates the packed-data offset stream by replaying the captured source offset layout because offsets are relative to the sliced payload.

Reviewed By: HuamengJiang

Differential Revision: D113727235
