### PR TITLE
feat: Add Dictionary native slice support

### DIFF
--- a/dwio/nimble/common/DataTypeDispatch.h
+++ b/dwio/nimble/common/DataTypeDispatch.h
@@ -248,6 +248,35 @@ namespace facebook::nimble {
 #define NIMBLE_TRY_RETURN_BY_NUMERIC_DATA_TYPE(dataType, Type, expression) \
   NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE_OR(dataType, Type, expression, return {})
 
+#define NIMBLE_RETURN_BY_FLOATING_POINT_DATA_TYPE_OR( \
+    dataType, Type, expression, ...)                  \
+  switch (dataType) {                                 \
+    case ::facebook::nimble::DataType::Float: {       \
+      using Type = float;                             \
+      return (expression);                            \
+    }                                                 \
+    case ::facebook::nimble::DataType::Double: {      \
+      using Type = double;                            \
+      return (expression);                            \
+    }                                                 \
+    default: {                                        \
+      __VA_ARGS__;                                    \
+    }                                                 \
+  }
+
+#define NIMBLE_RETURN_BY_FLOATING_POINT_DATA_TYPE(dataType, Type, expression) \
+  NIMBLE_RETURN_BY_FLOATING_POINT_DATA_TYPE_OR(                               \
+      dataType,                                                               \
+      Type,                                                                   \
+      expression,                                                             \
+      NIMBLE_UNREACHABLE(                                                     \
+          "Unsupported floating point data type {}.", dataType))
+
+#define NIMBLE_TRY_RETURN_BY_FLOATING_POINT_DATA_TYPE( \
+    dataType, Type, expression)                        \
+  NIMBLE_RETURN_BY_FLOATING_POINT_DATA_TYPE_OR(        \
+      dataType, Type, expression, return {})
+
 #define NIMBLE_RETURN_BY_INTEGER_DATA_TYPE_OR(dataType, Type, expression, ...) \
   switch (dataType) {                                                          \
     case ::facebook::nimble::DataType::Int8: {                                 \

--- a/dwio/nimble/common/tests/DataTypeDispatchTest.cpp
+++ b/dwio/nimble/common/tests/DataTypeDispatchTest.cpp
@@ -78,6 +78,11 @@ std::string dispatchNumericDataType(nimble::DataType dataType) {
   NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE(dataType, T, TypeName{}.operator()<T>());
 }
 
+std::string dispatchFloatingPointDataType(nimble::DataType dataType) {
+  NIMBLE_RETURN_BY_FLOATING_POINT_DATA_TYPE(
+      dataType, T, TypeName{}.operator()<T>());
+}
+
 std::string dispatchIntegerDataType(nimble::DataType dataType) {
   NIMBLE_RETURN_BY_INTEGER_DATA_TYPE(dataType, T, TypeName{}.operator()<T>());
 }
@@ -146,6 +151,18 @@ TEST(DataTypeDispatchTest, dispatchesNumericDataTypes) {
   NIMBLE_ASSERT_THROW(
       dispatchNumericDataType(nimble::DataType::String),
       "Unsupported numeric data type");
+}
+
+TEST(DataTypeDispatchTest, dispatchesFloatingPointDataTypes) {
+  EXPECT_EQ(dispatchFloatingPointDataType(nimble::DataType::Float), "float");
+  EXPECT_EQ(dispatchFloatingPointDataType(nimble::DataType::Double), "double");
+
+  NIMBLE_ASSERT_THROW(
+      dispatchFloatingPointDataType(nimble::DataType::Int32),
+      "Unsupported floating point data type");
+  NIMBLE_ASSERT_THROW(
+      dispatchFloatingPointDataType(nimble::DataType::String),
+      "Unsupported floating point data type");
 }
 
 TEST(DataTypeDispatchTest, dispatchesIntegerDataTypes) {

--- a/dwio/nimble/encodings/ALPEncoding.h
+++ b/dwio/nimble/encodings/ALPEncoding.h
@@ -291,6 +291,105 @@ class ALPEncoding final
     return {reserved, encodingSize};
   }
 
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {}) {
+    const auto sourceRowCount =
+        EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+    NIMBLE_CHECK_LE(offset, sourceRowCount);
+    NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+    NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+
+    const char* pos = encoded.data() +
+        EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+    const auto header = detail::alp::readHeader(pos);
+    const uint32_t exceptionCount =
+        header.hasExceptions ? varint::readVarint32(&pos) : 0;
+    const uint32_t encodedValuesSize = varint::readVarint32(&pos);
+    const std::string_view encodedValues{pos, encodedValuesSize};
+    pos += encodedValuesSize;
+
+    const auto* exceptionPositions = reinterpret_cast<const uint32_t*>(pos);
+    pos += exceptionCount * sizeof(uint32_t);
+    const auto* exceptionValues = reinterpret_cast<const physicalType*>(pos);
+
+    auto* pool = &buffer.getMemoryPool();
+    ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+    const auto slicedEncodedValues = EncodingFactory::slice(
+        encodedValues, offset, length, scopedBuffer.get(), options);
+    NIMBLE_CHECK_LE(
+        slicedEncodedValues.size(),
+        std::numeric_limits<uint32_t>::max(),
+        "ALP sliced encoded values are too large.");
+    const auto slicedEncodedValuesSize =
+        static_cast<uint32_t>(slicedEncodedValues.size());
+
+    const auto* exceptionEnd = exceptionPositions + exceptionCount;
+    const auto* first =
+        std::lower_bound(exceptionPositions, exceptionEnd, offset);
+    const auto* last = std::lower_bound(first, exceptionEnd, offset + length);
+    const auto slicedExceptionCount = static_cast<uint32_t>(last - first);
+    ScopedVector<uint32_t> slicedExceptionPositions{
+        slicedExceptionCount, pool, options.bufferPool};
+    ScopedVector<physicalType> slicedExceptionValues{
+        slicedExceptionCount, pool, options.bufferPool};
+    uint32_t exceptionIndex{0};
+    for (const auto* it = first; it != last; ++it) {
+      slicedExceptionPositions[exceptionIndex] = *it - offset;
+      slicedExceptionValues[exceptionIndex] =
+          exceptionValues[it - exceptionPositions];
+      ++exceptionIndex;
+    }
+    NIMBLE_CHECK_EQ(exceptionIndex, slicedExceptionCount);
+
+    const uint32_t exceptionPositionsSize =
+        slicedExceptionCount * sizeof(uint32_t);
+    const uint32_t exceptionValuesSize =
+        slicedExceptionCount * sizeof(physicalType);
+    const uint32_t metadataSize = kHeaderSize +
+        (slicedExceptionCount > 0 ? varint::varintSize(slicedExceptionCount)
+                                  : 0) +
+        varint::varintSize(slicedEncodedValuesSize);
+    const uint32_t encodingSize =
+        Encoding::serializePrefixSize(length, options.useVarintRowCount) +
+        metadataSize + slicedEncodedValuesSize + exceptionPositionsSize +
+        exceptionValuesSize;
+
+    char* reserved = buffer.reserve(encodingSize);
+    char* writePos = reserved;
+    Encoding::serializePrefix(
+        EncodingType::ALP,
+        TypeTraits<T>::dataType,
+        length,
+        options.useVarintRowCount,
+        writePos);
+    detail::alp::writeHeader(
+        detail::alp::Header{
+            .exponent = header.exponent,
+            .factor = header.factor,
+            .hasExceptions = slicedExceptionCount > 0},
+        writePos);
+    if (slicedExceptionCount > 0) {
+      varint::writeVarint(slicedExceptionCount, &writePos);
+    }
+    varint::writeVarint(slicedEncodedValuesSize, &writePos);
+    encoding::writeBytes(slicedEncodedValues, writePos);
+    if (slicedExceptionCount > 0) {
+      std::memcpy(
+          writePos, slicedExceptionPositions.data(), exceptionPositionsSize);
+      writePos += exceptionPositionsSize;
+      std::memcpy(writePos, slicedExceptionValues.data(), exceptionValuesSize);
+      writePos += exceptionValuesSize;
+    }
+
+    NIMBLE_CHECK_EQ(
+        encodingSize, writePos - reserved, "Encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+
   static std::optional<uint64_t> estimateSize(
       std::span<const physicalType> values,
       const Encoding::Options& options = {}) {

--- a/dwio/nimble/encodings/DictionaryEncoding.h
+++ b/dwio/nimble/encodings/DictionaryEncoding.h
@@ -23,6 +23,7 @@
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
@@ -84,6 +85,13 @@ class DictionaryEncoding
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
       Buffer& buffer,
       const Encoding::Options& options = {});
 
@@ -476,6 +484,49 @@ std::string_view DictionaryEncoding<T>::encode(
   encoding::writeBytes(serializedAlphabet, pos);
   encoding::writeBytes(serializedIndices, pos);
   NIMBLE_DCHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string_view DictionaryEncoding<T>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+
+  const char* pos = encoded.data() +
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  const uint32_t alphabetSize = encoding::readUint32(pos);
+  const std::string_view alphabet{pos, alphabetSize};
+  pos += alphabetSize;
+  const std::string_view indices{pos, static_cast<size_t>(encoded.end() - pos)};
+
+  auto* pool = &buffer.getMemoryPool();
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  const auto slicedIndices = EncodingFactory::slice(
+      indices, offset, length, scopedBuffer.get(), options);
+
+  const uint32_t encodingSize =
+      EncodingPrefix::serializedSize(length, options.useVarintRowCount) +
+      sizeof(uint32_t) + alphabet.size() + slicedIndices.size();
+  char* reserved = buffer.reserve(encodingSize);
+  char* writePos = reserved;
+  EncodingPrefix::serialize(
+      EncodingType::Dictionary,
+      TypeTraits<T>::dataType,
+      length,
+      options.useVarintRowCount,
+      writePos);
+  encoding::writeUint32(alphabet.size(), writePos);
+  encoding::writeBytes(alphabet, writePos);
+  encoding::writeBytes(slicedIndices, writePos);
+  NIMBLE_CHECK_EQ(writePos - reserved, encodingSize, "Encoding size mismatch.");
   return {reserved, encodingSize};
 }
 

--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -19,8 +19,10 @@
 #include <span>
 #include <vector>
 
+#include "dwio/nimble/common/DataTypeDispatch.h"
 #include "dwio/nimble/common/NimbleException.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
@@ -196,6 +198,22 @@ std::string_view sliceBlockBitPacking(
           encoded, offset, length, buffer, options));
 }
 
+std::string_view sliceALP(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_FLOATING_POINT_DATA_TYPE_OR(
+      dataType,
+      T,
+      ALPEncoding<T>::slice(encoded, offset, length, buffer, options),
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "ALP encoding only supports float and double data types, got {}.",
+          dataType));
+}
+
 } // namespace
 
 std::string_view EncodingSliceFactory::slice(
@@ -228,6 +246,8 @@ std::string_view EncodingSliceFactory::slice(
     case EncodingType::BlockBitPacking:
       return sliceBlockBitPacking(
           encoded, dataType, offset, length, buffer, options);
+    case EncodingType::ALP:
+      return sliceALP(encoded, dataType, offset, length, buffer, options);
     case EncodingType::Nullable:
       return sliceNullable(encoded, dataType, offset, length, buffer, options);
     case EncodingType::SparseBool:

--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -25,6 +25,7 @@
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -170,6 +171,19 @@ std::string_view sliceConstant(
       ConstantEncoding<T>::slice(encoded, offset, length, buffer, options));
 }
 
+std::string_view sliceDictionary(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_NON_BOOL_DATA_TYPE(
+      dataType,
+      T,
+      DictionaryEncoding<T>::slice(encoded, offset, length, buffer, options));
+}
+
 std::string_view sliceFixedBitWidth(
     std::string_view encoded,
     DataType dataType,
@@ -240,6 +254,9 @@ std::string_view EncodingSliceFactory::slice(
       return sliceTrivial(encoded, dataType, offset, length, buffer, options);
     case EncodingType::RLE:
       return sliceRLE(encoded, dataType, offset, length, buffer, options);
+    case EncodingType::Dictionary:
+      return sliceDictionary(
+          encoded, dataType, offset, length, buffer, options);
     case EncodingType::FixedBitWidth:
       return sliceFixedBitWidth(
           encoded, dataType, offset, length, buffer, options);

--- a/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
@@ -94,26 +95,36 @@ void materializeBenchmark(const std::string& encoded, uint32_t iters) {
   }
 }
 
+Vector<double> makeAlpDouble(uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<double> data{pool.get()};
+  data.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    data[i] = static_cast<double>(static_cast<int32_t>(i % 2048) - 1024) / 100;
+  }
+  return data;
+}
+
 } // namespace
 
-#define SLICE_BENCHMARKS(Name, EncodingT, EncodingTypeValue, DataExpr) \
-  BENCHMARK(Slice_##Name, iters) {                                     \
-    std::string encoded;                                               \
-    BENCHMARK_SUSPEND {                                                \
-      const auto data = DataExpr;                                      \
-      encoded = encodeData<EncodingT>(EncodingTypeValue, data);        \
-    }                                                                  \
-    sliceBenchmark(encoded, iters);                                    \
-  }                                                                    \
-  BENCHMARK_RELATIVE(MaterializeEncode_##Name, iters) {                \
-    std::string encoded;                                               \
-    BENCHMARK_SUSPEND {                                                \
-      const auto data = DataExpr;                                      \
-      encoded = encodeData<EncodingT>(EncodingTypeValue, data);        \
-    }                                                                  \
-    materializeEncodeBenchmark<EncodingT, uint32_t>(                   \
-        encoded, EncodingTypeValue, iters);                            \
-  }                                                                    \
+#define SLICE_BENCHMARKS(Name, EncodingT, ValueT, EncodingTypeValue, DataExpr) \
+  BENCHMARK(Slice_##Name, iters) {                                             \
+    std::string encoded;                                                       \
+    BENCHMARK_SUSPEND {                                                        \
+      const auto data = DataExpr;                                              \
+      encoded = encodeData<EncodingT>(EncodingTypeValue, data);                \
+    }                                                                          \
+    sliceBenchmark(encoded, iters);                                            \
+  }                                                                            \
+  BENCHMARK_RELATIVE(MaterializeEncode_##Name, iters) {                        \
+    std::string encoded;                                                       \
+    BENCHMARK_SUSPEND {                                                        \
+      const auto data = DataExpr;                                              \
+      encoded = encodeData<EncodingT>(EncodingTypeValue, data);                \
+    }                                                                          \
+    materializeEncodeBenchmark<EncodingT, ValueT>(                             \
+        encoded, EncodingTypeValue, iters);                                    \
+  }                                                                            \
   BENCHMARK_DRAW_LINE()
 
 #define SLICE_MATERIALIZE_BENCHMARKS(                           \
@@ -139,28 +150,39 @@ void materializeBenchmark(const std::string& encoded, uint32_t iters) {
 SLICE_BENCHMARKS(
     ConstantUint32,
     ConstantEncoding<uint32_t>,
+    uint32_t,
     EncodingType::Constant,
     makeConstant<uint32_t>(42));
 SLICE_BENCHMARKS(
     TrivialUint32,
     TrivialEncoding<uint32_t>,
+    uint32_t,
     EncodingType::Trivial,
     makeRandom<uint32_t>());
 SLICE_BENCHMARKS(
     RLEUint32,
     RLEEncoding<uint32_t>,
+    uint32_t,
     EncodingType::RLE,
     makeRunLength<uint32_t>());
 SLICE_BENCHMARKS(
     FixedBitWidthUint32,
     FixedBitWidthEncoding<uint32_t>,
+    uint32_t,
     EncodingType::FixedBitWidth,
     makeNarrow<uint32_t>(12));
 SLICE_BENCHMARKS(
     BlockBitPackingUint32,
     BlockBitPackingEncoding<uint32_t>,
+    uint32_t,
     EncodingType::BlockBitPacking,
     makeIncreasing<uint32_t>());
+SLICE_BENCHMARKS(
+    ALPDouble,
+    ALPEncoding<double>,
+    double,
+    EncodingType::ALP,
+    makeAlpDouble());
 
 BENCHMARK(Slice_BlockBitPackingUint32PartialBlock, iters) {
   std::string encoded;

--- a/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -165,6 +166,12 @@ SLICE_BENCHMARKS(
     uint32_t,
     EncodingType::RLE,
     makeRunLength<uint32_t>());
+SLICE_BENCHMARKS(
+    DictionaryUint32,
+    DictionaryEncoding<uint32_t>,
+    uint32_t,
+    EncodingType::Dictionary,
+    makeLowCardinality<uint32_t>(1024));
 SLICE_BENCHMARKS(
     FixedBitWidthUint32,
     FixedBitWidthEncoding<uint32_t>,

--- a/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
@@ -343,6 +343,126 @@ TYPED_TEST(ALPEncodingTest, headerMetadataUsesVarints) {
   }
 }
 
+TYPED_TEST(ALPEncodingTest, slice) {
+  using DataType = typename TypeParam::data_type;
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint,
+      .fixedBitWidthUseExactBits = true};
+
+  nimble::Vector<DataType> values{this->pool_.get()};
+  for (uint32_t i = 0; i < 128; ++i) {
+    values.push_back(
+        static_cast<DataType>((i % 37) - 18) / static_cast<DataType>(10));
+  }
+
+  const auto serialized = encodeWithLayout<DataType>(
+      *this->buffer_, values, alpWithFixedBitWidthPayloadLayout(), options);
+
+  for (const auto range :
+       {Range{/*offset=*/0, /*length=*/11},
+        Range{/*offset=*/7, /*length=*/19},
+        Range{/*offset=*/64, /*length=*/32},
+        Range{/*offset=*/120, /*length=*/8}}) {
+    SCOPED_TRACE(
+        testing::Message() << "offset=" << range.offset
+                           << " length=" << range.length);
+    nimble::Buffer sliceBuffer{*this->pool_};
+    const auto sliced = nimble::EncodingFactory::slice(
+        serialized, range.offset, range.length, sliceBuffer, options);
+
+    EXPECT_EQ(
+        nimble::EncodingPrefix::encodingType(sliced),
+        nimble::EncodingType::ALP);
+    EXPECT_EQ(
+        nimble::EncodingPrefix::readRowCount(sliced, options.useVarintRowCount),
+        range.length);
+
+    std::vector<velox::BufferPtr> stringBuffers;
+    auto encoding =
+        createEncoding(this->pool_.get(), sliced, options, stringBuffers);
+    nimble::Vector<DataType> result{this->pool_.get(), range.length};
+    encoding->materialize(range.length, result.data());
+    for (uint32_t i = 0; i < range.length; ++i) {
+      SCOPED_TRACE(fmt::format("i={}", i));
+      EXPECT_TRUE(
+          nimble::NimbleCompare<DataType>::equals(
+              result[i], values[range.offset + i]));
+    }
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, rejectsZeroLengthSlice) {
+  using DataType = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint,
+      .fixedBitWidthUseExactBits = true};
+
+  const auto values = this->template toVector<DataType>({1, 2, 3});
+  const auto serialized = encodeWithLayout<DataType>(
+      *this->buffer_, values, alpWithFixedBitWidthPayloadLayout(), options);
+
+  nimble::Buffer sliceBuffer{*this->pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::EncodingFactory::slice(
+          serialized,
+          /*offset=*/1,
+          /*length=*/0,
+          sliceBuffer,
+          options),
+      "Cannot slice zero rows.");
+}
+
+TYPED_TEST(ALPEncodingTest, sliceRebasesExceptions) {
+  using DataType = typename TypeParam::data_type;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = TypeParam::useVarint,
+      .fixedBitWidthUseExactBits = true};
+
+  nimble::Vector<DataType> values{this->pool_.get(), 128};
+  values.fill(DataType{1.25});
+  values[3] = std::numeric_limits<DataType>::infinity();
+  values[17] = -std::numeric_limits<DataType>::infinity();
+  values[31] = std::numeric_limits<DataType>::quiet_NaN();
+  values[97] = std::numeric_limits<DataType>::infinity();
+
+  const auto serialized = encodeWithLayout<DataType>(
+      *this->buffer_, values, alpWithFixedBitWidthPayloadLayout(), options);
+
+  constexpr uint32_t kOffset{16};
+  constexpr uint32_t kLength{32};
+  nimble::Buffer sliceBuffer{*this->pool_};
+  const auto sliced = nimble::EncodingFactory::slice(
+      serialized, kOffset, kLength, sliceBuffer, options);
+
+  const char* pos = sliced.data() +
+      nimble::EncodingPrefix::prefixSize(sliced, options.useVarintRowCount);
+  const auto header = nimble::detail::alp::readHeader(pos);
+  EXPECT_TRUE(header.hasExceptions);
+  EXPECT_EQ(nimble::varint::readVarint32(&pos), 2);
+  const auto encodedValuesSize = nimble::varint::readVarint32(&pos);
+  pos += encodedValuesSize;
+  // Source exceptions at rows 17 and 31 become slice-local rows 1 and 15.
+  EXPECT_EQ(nimble::encoding::readUint32(pos), 1);
+  EXPECT_EQ(nimble::encoding::readUint32(pos), 15);
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  auto encoding =
+      createEncoding(this->pool_.get(), sliced, options, stringBuffers);
+  nimble::Vector<DataType> result{this->pool_.get(), kLength};
+  encoding->materialize(kLength, result.data());
+  for (uint32_t i = 0; i < kLength; ++i) {
+    SCOPED_TRACE(fmt::format("i={}", i));
+    EXPECT_TRUE(
+        nimble::NimbleCompare<DataType>::equals(
+            result[i], values[kOffset + i]));
+  }
+}
+
 TYPED_TEST(ALPEncodingTest, roundTripSignedDecimals) {
   using D = typename TypeParam::data_type;
   const nimble::Encoding::Options options{

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(nimble_encodings_tests_utils TestUtils.cpp)
+add_library(
+  nimble_encodings_tests_utils
+  TestUtils.cpp
+  ../selection/tests/RandomEncodingSelectionPolicy.cpp
+)
 target_link_libraries(nimble_encodings_tests_utils nimble_encodings)
 
 add_library(nimble_encoding_layout_test_helper EncodingLayoutTestHelper.cpp)
@@ -24,6 +28,7 @@ add_executable(
   BlockBitPackingEncodingViewTest.cpp
   ConstantEncodingViewTest.cpp
   ConstantEncodingTest.cpp
+  DictionaryEncodingTest.cpp
   DictionaryEncodingViewTest.cpp
   EncodingLayoutTest.cpp
   EncodingSelectionTest.cpp

--- a/dwio/nimble/encodings/tests/DictionaryEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/DictionaryEncodingTest.cpp
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/common/tests/NimbleCompare.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "velox/common/memory/Memory.h"
+
+#include <vector>
+
+using namespace facebook;
+
+template <typename T>
+struct DictionaryTestValues;
+
+template <>
+struct DictionaryTestValues<uint32_t> {
+  static std::vector<uint32_t> values() {
+    return {10, 20, 10, 30, 40, 20, 30};
+  }
+};
+
+template <>
+struct DictionaryTestValues<double> {
+  static std::vector<double> values() {
+    return {1.25, 2.5, 1.25, -3.75, 8.0, 2.5, -3.75};
+  }
+};
+
+template <>
+struct DictionaryTestValues<std::string_view> {
+  static std::vector<std::string_view> values() {
+    return {"alpha", "beta", "alpha", "gamma", "delta", "beta", "gamma"};
+  }
+};
+
+template <typename T>
+class DictionaryEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() override {
+    rootPool_ =
+        velox::memory::memoryManager()->addRootPool("DictionaryEncodingTest");
+    pool_ = rootPool_->addLeafChild("DictionaryEncodingTestLeaf");
+    buffer_ = std::make_unique<nimble::Buffer>(*pool_);
+  }
+
+  nimble::Vector<T> makeValues() {
+    nimble::Vector<T> values{pool_.get()};
+    const auto source = DictionaryTestValues<T>::values();
+    for (const auto value : source) {
+      values.push_back(value);
+    }
+    return values;
+  }
+
+  void* stringBufferFactory(uint32_t totalLength) {
+    auto& stringBuffer = stringBuffers_.emplace_back(
+        velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+    return stringBuffer->asMutable<void>();
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<nimble::Buffer> buffer_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+};
+
+using DictionaryEncodingTypes =
+    ::testing::Types<uint32_t, double, std::string_view>;
+
+TYPED_TEST_CASE(DictionaryEncodingTest, DictionaryEncodingTypes);
+
+TYPED_TEST(DictionaryEncodingTest, slicePreservesAlphabetAndMaterializesRange) {
+  using DataType = TypeParam;
+
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    const auto values = this->makeValues();
+    const auto encoded =
+        nimble::test::Encoder<nimble::DictionaryEncoding<DataType>>::encode(
+            *this->buffer_,
+            values,
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    nimble::DictionaryEncoding<DataType> source{
+        *this->pool_,
+        encoded,
+        [this](uint32_t totalLength) {
+          return this->stringBufferFactory(totalLength);
+        },
+        options};
+    const auto sourceDictionarySize = source.dictionarySize();
+
+    for (const auto range :
+         {Range{/*offset=*/0, /*length=*/1},
+          Range{/*offset=*/1, /*length=*/3},
+          Range{/*offset=*/2, /*length=*/4},
+          Range{/*offset=*/6, /*length=*/1}}) {
+      SCOPED_TRACE(
+          testing::Message()
+          << "offset=" << range.offset << ", length=" << range.length);
+      nimble::Buffer sliceBuffer{*this->pool_};
+      const auto sliced = nimble::DictionaryEncoding<DataType>::slice(
+          encoded, range.offset, range.length, sliceBuffer, options);
+      nimble::DictionaryEncoding<DataType> encoding{
+          *this->pool_,
+          sliced,
+          [this](uint32_t totalLength) {
+            return this->stringBufferFactory(totalLength);
+          },
+          options};
+
+      EXPECT_EQ(encoding.encodingType(), nimble::EncodingType::Dictionary);
+      EXPECT_EQ(encoding.dataType(), nimble::TypeTraits<DataType>::dataType);
+      EXPECT_EQ(encoding.rowCount(), range.length);
+      EXPECT_EQ(encoding.dictionarySize(), sourceDictionarySize);
+
+      nimble::Vector<DataType> result{this->pool_.get(), range.length};
+      encoding.materialize(range.length, result.data());
+      for (uint32_t i = 0; i < range.length; ++i) {
+        EXPECT_TRUE(
+            nimble::NimbleCompare<DataType>::equals(
+                result[i], values[range.offset + i]));
+      }
+    }
+  }
+}
+
+TYPED_TEST(DictionaryEncodingTest, invalidSliceRange) {
+  using DataType = TypeParam;
+
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(testing::Message() << "useVarint=" << useVarint);
+    const nimble::Encoding::Options options{.useVarintRowCount = useVarint};
+    const auto values = this->makeValues();
+    const auto encoded =
+        nimble::test::Encoder<nimble::DictionaryEncoding<DataType>>::encode(
+            *this->buffer_,
+            values,
+            nimble::CompressionType::Uncompressed,
+            options);
+
+    nimble::Buffer sliceBuffer{*this->pool_};
+    NIMBLE_ASSERT_THROW(
+        nimble::DictionaryEncoding<DataType>::slice(
+            encoded,
+            /*offset=*/0,
+            /*length=*/0,
+            sliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::DictionaryEncoding<DataType>::slice(
+            encoded,
+            /*offset=*/values.size() + 1,
+            /*length=*/1,
+            sliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        nimble::DictionaryEncoding<DataType>::slice(
+            encoded,
+            /*offset=*/values.size() - 1,
+            /*length=*/2,
+            sliceBuffer,
+            options),
+        "");
+  }
+}

--- a/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -362,6 +362,16 @@ TYPED_TEST(SliceEncodingTypedTest, rejectsZeroLengthRange) {
   NIMBLE_ASSERT_THROW(this->slice(encoded, /*offset=*/0, /*length=*/0), "");
 }
 
+TEST_F(SliceEncodingTest, dictionaryRejectsZeroLengthRange) {
+  const auto values = makeVector<uint32_t>({10, 11, 10, 12});
+  const auto encoded =
+      nimble::test::Encoder<nimble::DictionaryEncoding<uint32_t>>::encode(
+          *buffer_, values);
+
+  NIMBLE_ASSERT_THROW(
+      slice(encoded, /*offset=*/1, /*length=*/0), "Cannot slice zero rows.");
+}
+
 TYPED_TEST(SliceEncodingTypedTest, materializesRandomRanges) {
   using EncodingType = typename TypeParam::EncodingType;
   constexpr uint32_t kIterations{64};


### PR DESCRIPTION
Summary:
Adds native slice support for Dictionary-encoded streams.

The slice path trims the dictionary index stream to the requested row range and preserves the original dictionary value stream, avoiding the materialize + re-encode fallback for this encoding. The change also extends the slice benchmark with a DictionaryUint32 case so the native path is tracked alongside the generic materialization baseline.

The native benchmark result for DictionaryUint32 is 1.13us vs 247.71us for materialize + encode, about 219x faster.

Reviewed By: HuamengJiang

Differential Revision: D113728376


