### PR TITLE
refactor(writer): FeatureGate for write-path rollout knobs (#1036)

### DIFF
--- a/dwio/nimble/common/CMakeLists.txt
+++ b/dwio/nimble/common/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(
   Checksum.cpp
   DataTypeDispatch.h
   Exceptions.cpp
+  FeatureGate.cpp
   FixedBitArray.cpp
   MetricsLogger.cpp
   NimbleException.cpp

--- a/dwio/nimble/common/FeatureGate.cpp
+++ b/dwio/nimble/common/FeatureGate.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/common/FeatureGate.h"
+
+#include <folly/Synchronized.h>
+
+namespace facebook::nimble {
+
+namespace {
+// Process-wide gate, defaulting to the base no-op. Held by shared_ptr so that
+// featureGate() can hand out an owning pointer that outlives a concurrent
+// re-registration.
+folly::Synchronized<std::shared_ptr<FeatureGate>>& gateStorage() {
+  static auto* storage = new folly::Synchronized<std::shared_ptr<FeatureGate>>(
+      std::make_shared<FeatureGate>());
+  return *storage;
+}
+} // namespace
+
+void registerFeatureGate(std::shared_ptr<FeatureGate> gate) {
+  if (gate == nullptr) {
+    gate = std::make_shared<FeatureGate>();
+  }
+  *gateStorage().wlock() = std::move(gate);
+}
+
+std::shared_ptr<const FeatureGate> featureGate() {
+  return *gateStorage().rlock();
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/common/FeatureGate.h
+++ b/dwio/nimble/common/FeatureGate.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <string_view>
+
+namespace facebook::nimble {
+
+/// Runtime enablement gate for optional writer features (e.g. rollout
+/// killswitches). The base implementation applies no runtime override:
+/// enabled() returns the caller-provided default, so OSS builds honor the
+/// static writer config alone. Internal builds install a dynamic-config-backed
+/// implementation via registerFeatureGate() to gate gradual rollouts.
+class FeatureGate {
+ public:
+  /// Stable identifiers for the runtime-gated writer features. OSS-neutral: no
+  /// dynamic-config (e.g. JustKnobs) names leak into open source. The internal
+  /// FeatureGate implementation maps each identifier to its backing knob.
+  class FeatureSet {
+   public:
+    static constexpr std::string_view kChunkedEncoding = "chunked_encoding";
+    static constexpr std::string_view kStreamDeduplication =
+        "stream_deduplication";
+    static constexpr std::string_view kDisableSharedStringBuffers =
+        "disable_shared_string_buffers";
+  };
+
+  virtual ~FeatureGate() = default;
+
+  /// Resolves whether `feature` is enabled at runtime, given the caller's
+  /// requested `defaultValue`. With no gate installed (the OSS default),
+  /// returns `defaultValue` unchanged. A registered gate may consult dynamic
+  /// config to hold a feature back during rollout (return false) or force it on
+  /// (return true), independent of `defaultValue`.
+  virtual bool enabled(std::string_view feature, bool defaultValue) const {
+    return defaultValue;
+  }
+};
+
+/// Installs the process-wide FeatureGate, replacing any previously registered
+/// one. Intended to be called once at startup by internal (non-OSS) code with a
+/// dynamic-config-backed gate. Passing nullptr restores the default no-op gate.
+/// Thread-safe.
+void registerFeatureGate(std::shared_ptr<FeatureGate> gate);
+
+/// Returns the process-wide FeatureGate: the one installed via
+/// registerFeatureGate(), or a default no-op gate when none has been registered
+/// (the OSS case). The returned pointer is never null and owns the gate, so it
+/// stays valid even if a different gate is registered concurrently.
+/// Thread-safe.
+std::shared_ptr<const FeatureGate> featureGate();
+
+} // namespace facebook::nimble

--- a/dwio/nimble/common/tests/CMakeLists.txt
+++ b/dwio/nimble/common/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
   DataTypeDispatchTest.cpp
   ExceptionHelperTest.cpp
   ExceptionTests.cpp
+  FeatureGateTest.cpp
   FixedBitArrayTests.cpp
   VarintTests.cpp
   VectorTest.cpp

--- a/dwio/nimble/common/tests/FeatureGateTest.cpp
+++ b/dwio/nimble/common/tests/FeatureGateTest.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/common/FeatureGate.h"
+
+#include <memory>
+#include <string_view>
+
+#include <gtest/gtest.h>
+
+namespace facebook::nimble {
+namespace {
+
+// A gate that returns a fixed answer regardless of the requested default,
+// modeling an internal gate that force-enables or gates-off a feature.
+class FixedFeatureGate : public FeatureGate {
+ public:
+  explicit FixedFeatureGate(bool value) : value_{value} {}
+
+  bool enabled(std::string_view /*feature*/, bool /*defaultValue*/)
+      const override {
+    return value_;
+  }
+
+ private:
+  const bool value_;
+};
+
+class FeatureGateTest : public ::testing::Test {
+ protected:
+  // Restore the default no-op gate so tests don't leak process-wide state.
+  void TearDown() override {
+    registerFeatureGate(nullptr);
+  }
+};
+
+TEST_F(FeatureGateTest, defaultGatePassesRequestedValueThrough) {
+  const auto gate = featureGate();
+  EXPECT_TRUE(gate->enabled("any_feature", true));
+  EXPECT_FALSE(gate->enabled("any_feature", false));
+}
+
+TEST_F(FeatureGateTest, registeredGateOverridesDefault) {
+  registerFeatureGate(std::make_shared<FixedFeatureGate>(false));
+  EXPECT_FALSE(featureGate()->enabled("feature", true));
+
+  registerFeatureGate(std::make_shared<FixedFeatureGate>(true));
+  EXPECT_TRUE(featureGate()->enabled("feature", false));
+}
+
+TEST_F(FeatureGateTest, registerNullptrRestoresDefault) {
+  registerFeatureGate(std::make_shared<FixedFeatureGate>(false));
+  ASSERT_FALSE(featureGate()->enabled("feature", true));
+
+  registerFeatureGate(nullptr);
+  EXPECT_TRUE(featureGate()->enabled("feature", true));
+  EXPECT_FALSE(featureGate()->enabled("feature", false));
+}
+
+TEST_F(FeatureGateTest, returnedGateOutlivesReRegistration) {
+  // featureGate() hands out an owning pointer, so an already-fetched gate stays
+  // valid (and unchanged) even after a different gate is registered.
+  const auto original = featureGate();
+  registerFeatureGate(std::make_shared<FixedFeatureGate>(false));
+  EXPECT_TRUE(original->enabled("feature", true));
+  EXPECT_FALSE(featureGate()->enabled("feature", true));
+}
+
+} // namespace
+} // namespace facebook::nimble


### PR DESCRIPTION
Summary:

The Nimble write adapter (`NimbleWriterOptionBuilder`, under `velox/writer/fb/`)
could not move into Nimble OSS because it evaluated `facebook::jk::eval<...>()`
JustKnobs and read force-override gflags directly. This abstracts runtime
enablement behind an OSS-neutral interface so the adapter carries zero
JustKnobs/gflags dependencies, and installs the internal resolution on every
write path.

OSS interface `dwio/nimble/common/FeatureGate.h`:
- Concrete base class `FeatureGate`; the default `enabled(feature, defaultValue)`
  returns `defaultValue` (no-op base), so OSS honors the static writer config
  alone.
- A nested `FeatureGate::FeatureSet` hosts the OSS-neutral feature-name
  constants (`kChunkedEncoding`, `kStreamDeduplication`,
  `kDisableSharedStringBuffers`), decoupled from the internal knob names.
- Global `registerFeatureGate()` / `featureGate()` injection point
  (`folly::Synchronized<shared_ptr>`), mirroring Velox's `BaseStatsReporter`
  register/get pattern.

Internal gate `dwio/nimble/velox/writer/fb/KnobsFeatureGate.cpp` (not exported to
OSS):
- `KnobsFeatureGate` maps each `FeatureSet` id to its JustKnob and force-gflag,
  preserving the exact historical resolution: chunking = `jk ? config : false`;
  dedup / disable-shared-buffers = `force_gflag ? true : (jk ? arg : false)`. A
  JK-eval failure logs and disables the feature (unchanged behavior).
- The two `--nimble_force_*` gflag definitions move here from the adapter.
- Self-registers at process startup via a static initializer, kept alive by
  `link_whole` on the new `knobs-feature-gate` target, which
  `nimble-write-option-builder` depends on.

Why self-registration instead of an explicit call from `dwio/api/FileWriter`:
the builder is constructed on ~9 internal write paths -- most importantly the
Velox `NimbleWriterFactory` (`NimbleWriter.cpp`, the Prestissimo/Gluten
TableWrite path), plus `AlphaWriterJNI`, `DwrfToNimble`, `NimblePerfTuningUtils`,
`EncodingLayoutTrainer`, `NimbleSerializer`, `NimbleIndexer`, and
`dwio/api/FileWriter`. Registering only from `FileWriter` (and `dwio/api` cannot
be depended on from `velox/writer/fb` without a layering cycle) would silently
drop the JustKnobs kill switch and the `--nimble_force_*` gflags on those paths.
Linking the builder auto-installs the gate, so behavior matches the pre-refactor
code -- which always evaluated the knobs inside the builder -- on every path.

The adapter now calls
`featureGate()->enabled(FeatureGate::FeatureSet::k<Feature>, requested)` and
depends on neither `//justknobs` nor gflags; its source is OSS-clean. OSS/CMake
omits the internal gate library and keeps the pass-through default.

Follow-up (separate diff): physically relocate the adapter out of
`velox/writer/fb/` into `velox/writer/` and add it to the OSS CMakeLists.

Reviewed By: xiaoxmeng

Differential Revision: D113756418
