### PR TITLE
fix(nimlble)(OSS): Link random encoding selection policy in CMake tests (#1038)

### DIFF
--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -14,6 +14,7 @@
 add_subdirectory(benchmarks)
 add_subdirectory(tests)
 add_subdirectory(legacy)
+add_subdirectory(selection/tests)
 
 add_library(
   nimble_encodings

--- a/dwio/nimble/encodings/selection/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/selection/tests/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(
+  nimble_random_encoding_selection_policy
+  RandomEncodingSelectionPolicy.cpp
+)
+target_link_libraries(
+  nimble_random_encoding_selection_policy
+  nimble_encodings
+  Folly::folly
+)

--- a/dwio/nimble/serializer/tests/ProjectorTest.cpp
+++ b/dwio/nimble/serializer/tests/ProjectorTest.cpp
@@ -3620,11 +3620,11 @@ TEST_F(ProjectorTest, projectedComplexNullFuzzerPreservesNulls) {
           {
               .vectorSize = kRowsPerBatch,
               .nullRatio = 0,
+              .useRandomNullPattern = true,
               .stringLength = 12,
               .stringVariableLength = true,
               .containerLength = 3,
               .containerVariableLength = true,
-              .useRandomNullPattern = true,
               .normalizeMapKeys = true,
           },
           pool_.get(),

--- a/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/tests/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(
   nimble_common
   nimble_encodings
   nimble_encodings_tests_utils
+  nimble_random_encoding_selection_policy
   nimble_index_test_utils
   velox_key_encoder
   velox_vector


### PR DESCRIPTION
Summary:

per title

Differential Revision: D114072505


