### PR TITLE
feat(nimble): Gate per-chunk null count on chunk.stats.enabled (#1039)

### DIFF
--- a/dwio/nimble/docs/develop/nimble_metadata_cache.rst
+++ b/dwio/nimble/docs/develop/nimble_metadata_cache.rst
@@ -80,7 +80,7 @@ What Goes Where
      - FlatBuffers
      - Random
      - TabletReader → CachedMetadataInput (lazy)
-   * - Cluster / chunk index
+   * - Cluster / chunk stats
      - FlatBuffers
      - Random
      - TabletReader → CachedMetadataInput
@@ -151,7 +151,7 @@ Stripe N
 
 3
 
-Pointers to StripeChunkIndex 0, 1…
+Pointers to StripeChunkStats 0, 1…
 
 
 stripe_indexes: [MetadataSection]
@@ -312,11 +312,11 @@ Metadata Cache Contents
         partitions: [MetadataSection{off, sz, comp, uncomp}, ...]
 
     Cache key {fileId, ci.offset}
-      ChunkIndex root:
+      ChunkStats root:
         stripe_indexes: [MetadataSection{off, sz, comp, uncomp}, ...]
 
     Cache key {fileId, cig[0].offset}
-      ChunkIndex group[0]:
+      ChunkStats group[0]:
         Per-chunk stream boundaries within stripe group 0
 
     Cached values are decompressed contiguous bytes.
@@ -366,7 +366,7 @@ footerSize, compressionType, checksum, version, magic
     │ └──────────────────────────────────────────────────────────────────────┘ │
     ├──────────────────────────────────────────────────────────────────────────┤
     │ StripeGroup 0 Metadata (FlatBuffers: stream_offsets[], stream_sizes[])  │
-    │ Chunk Index Group 0    (FlatBuffers: chunk_rows[], chunk_offsets[])     │
+    │ Chunk Stats Group 0    (FlatBuffers: chunk_rows[], chunk_offsets[])     │
     │ Cluster Index Group 0  (FlatBuffers, optional: key boundaries)          │
     │ StripeStrideIndex 0    (FlatBuffers, *** NEW ***: min/max per stride)   │
     ├──────────────────────────────────────────────────────────────────────────┤
@@ -377,7 +377,7 @@ footerSize, compressionType, checksum, version, magic
     │   Schema         "columnar.schema"          — type tree                 │
     │   Metadata       "columnar.metadata"        — key-value pairs           │
     │   Stats          "columnar.vectorized_stats"— per-column stats          │
-    │   ChunkIndex     "columnar.chunk.index"     — root → per-group blobs   │
+    │   ChunkStats     "columnar.chunk.stats"     — root → per-group blobs   │
     │   FileIndexes    "columnar.indexes"         — named index manifest     │
     │   StrideIndex    "columnar.stride.index"    — root → per-group blobs   │
     ├──────────────────────────────────────────────────────────────────────────┤
@@ -400,7 +400,7 @@ Per-Group FlatBuffer Details
       stream_sizes:    [uint32]   flattened [stripe x stream]
           ↑ locates individual stream bytes within stripe data
 
-    StripeChunkIndex (one per group)
+    StripeChunkStats (one per group)
       stream_count:          uint32
       stream_chunk_counts:   [uint32]   prefix-sum [stripe x stream]
       stream_chunk_rows:     [uint32]   prefix-sum row counts per chunk
@@ -435,14 +435,14 @@ Footer = Directory of Pointers
                        │                                                {0x9000, 248, Zstd}]
                        │                              optional_sections:
                        │                                "columnar.schema"        → {0xB000, ...}
-                       │                                "columnar.chunk.index"   → {0xC000, ...}
+                       │                                "columnar.chunk.stats"   → {0xC000, ...}
                        │                                "columnar.indexes"       → {0xD000, ...}
                        │
                        ├─ 0x8000: StripeGroup 0 blob
                        ├─ 0x9000: StripeGroup 1 blob
                        ├─ 0xA000: Stripes blob
                        ├─ 0xB000: Schema blob
-                       ├─ 0xC000: ChunkIndex root blob
+                       ├─ 0xC000: ChunkStats root blob
                        └─ 0xD000: File index manifest blob
 
     One field (row_count) gives the answer directly.
@@ -533,7 +533,7 @@ Section Status
      - Legacy (replaced by vectorized_stats)
    * - columnar.vectorized_stats
      - Active
-   * - columnar.chunk.index
+   * - columnar.chunk.stats
      - Active
    * - columnar.indexes
      - Active file index manifest
@@ -549,13 +549,13 @@ Write Order Example
 
     [stripe 0..66 data]
                               ← metadata threshold hit, flush group 0
-    [StripeGroup 0] [ChunkIndex 0] [ClusterIndex 0] [StrideIndex 0]
+    [StripeGroup 0] [ChunkStats 0] [ClusterIndex 0] [StrideIndex 0]
 
     [stripe 67..120 data]
                               ← close(), force flush group 1
-    [StripeGroup 1] [ChunkIndex 1] [ClusterIndex 1] [StrideIndex 1]
+    [StripeGroup 1] [ChunkStats 1] [ClusterIndex 1] [StrideIndex 1]
 
-    [ChunkIndex root]         ← pointers to ChunkIndex 0, 1
+    [ChunkStats root]         ← pointers to ChunkStats 0, 1
     [ClusterIndex root]       ← pointers to ClusterIndex 0, 1
     [StrideIndex root]        ← pointers to StrideIndex 0, 1
     [Stripes blob]            ← row counts, offsets for all 121 stripes
@@ -610,7 +610,7 @@ Each metadata section is compressed independently when it is larger than the def
      - 2KB
      - No
      - 2KB < 64KB
-   * - ChunkIndex Root
+   * - ChunkStats Root
      - 90KB
      - Zstd
      - 90KB > 64KB
@@ -673,9 +673,9 @@ Cold Path
       if one stripe group and the group is in buf:
         eagerly pin StripeGroup[0] into stripeGroupCache_
 
-    initClusterIndex() / initChunkIndex(buf)    // no IO
+    initClusterIndex() / initChunkStats(buf)    // no IO
       parse index roots from cache
-      if chunk index group 0 is in buf:
+      if chunk stats group 0 is in buf:
         pin it
 
     cacheMetadata(buf)                          // no IO

--- a/dwio/nimble/index/ChunkStats.cpp
+++ b/dwio/nimble/index/ChunkStats.cpp
@@ -56,7 +56,7 @@ ChunkStats::ChunkStats(
 
 const MetadataSection& ChunkStats::groupMetadata(uint32_t groupIndex) const {
   NIMBLE_CHECK_LT(
-      groupIndex, groupSections_.size(), "Chunk index group out of range");
+      groupIndex, groupSections_.size(), "Chunk stats group out of range");
   return groupSections_[groupIndex];
 }
 

--- a/dwio/nimble/index/ChunkStats.h
+++ b/dwio/nimble/index/ChunkStats.h
@@ -25,8 +25,8 @@ namespace facebook::nimble::index {
 /// ChunkStats provides access to chunk-level position index metadata for Nimble
 /// tablets.
 ///
-/// This is the root-level chunk index that contains per-stripe-group
-/// MetadataSection references. Each stripe group's chunk index data
+/// This is the root-level chunk stats that contains per-stripe-group
+/// MetadataSection references. Each stripe group's chunk stats data
 /// (ChunkStatsGroup) can be loaded on demand using the metadata sections
 /// provided by this class.
 ///
@@ -34,9 +34,9 @@ namespace facebook::nimble::index {
 /// exposes per-group metadata for on-demand loading.
 class ChunkStats {
  public:
-  /// Creates a ChunkStats from the root chunk index optional section.
+  /// Creates a ChunkStats from the root chunk stats optional section.
   ///
-  /// @param indexSection The section containing the serialized root chunk index
+  /// @param indexSection The section containing the serialized root chunk stats
   /// @return A unique pointer to a newly created ChunkStats, or nullptr if the
   ///         section contains no stripe indexes
   static std::unique_ptr<ChunkStats> create(Section indexSection);
@@ -46,7 +46,7 @@ class ChunkStats {
     return groupSections_.size();
   }
 
-  /// Returns the metadata section for a specific stripe group's chunk index.
+  /// Returns the metadata section for a specific stripe group's chunk stats.
   ///
   /// @param groupIndex The zero-based stripe group index
   /// @return MetadataSection containing offset, size, and compression info

--- a/dwio/nimble/index/ChunkStatsGroup.cpp
+++ b/dwio/nimble/index/ChunkStatsGroup.cpp
@@ -87,13 +87,13 @@ std::shared_ptr<StreamIndex> ChunkStatsGroup::createStreamIndex(
 }
 
 std::shared_ptr<StreamIndex> StreamIndex::create(
-    std::shared_ptr<const ChunkStatsGroup> chunkIndex,
+    std::shared_ptr<const ChunkStatsGroup> chunkStats,
     uint32_t streamId,
     uint32_t startChunkOffset,
     uint32_t endChunkOffset,
     uint32_t streamSize) {
   return std::shared_ptr<StreamIndex>(new StreamIndex(
-      std::move(chunkIndex),
+      std::move(chunkStats),
       streamId,
       startChunkOffset,
       endChunkOffset,
@@ -101,12 +101,12 @@ std::shared_ptr<StreamIndex> StreamIndex::create(
 }
 
 StreamIndex::StreamIndex(
-    std::shared_ptr<const ChunkStatsGroup> chunkIndex,
+    std::shared_ptr<const ChunkStatsGroup> chunkStats,
     uint32_t streamId,
     uint32_t startChunkOffset,
     uint32_t endChunkOffset,
     uint32_t streamSize)
-    : chunkStats_(std::move(chunkIndex)),
+    : chunkStats_(std::move(chunkStats)),
       streamId_(streamId),
       startChunkOffset_(startChunkOffset),
       endChunkOffset_(endChunkOffset),

--- a/dwio/nimble/index/ChunkStatsGroup.h
+++ b/dwio/nimble/index/ChunkStatsGroup.h
@@ -73,7 +73,7 @@ class ChunkStatsGroup : public std::enable_shared_from_this<ChunkStatsGroup> {
     NIMBLE_CHECK_LT(
         offset,
         stripeCount_,
-        "Stripe offset is out of range for this chunk index group");
+        "Stripe offset is out of range for this chunk stats group");
     return offset;
   }
 
@@ -93,7 +93,7 @@ class ChunkStatsGroup : public std::enable_shared_from_this<ChunkStatsGroup> {
 class StreamIndex {
  public:
   static std::shared_ptr<StreamIndex> create(
-      std::shared_ptr<const ChunkStatsGroup> chunkIndex,
+      std::shared_ptr<const ChunkStatsGroup> chunkStats,
       uint32_t streamId,
       uint32_t startChunkOffset,
       uint32_t endChunkOffset,
@@ -117,7 +117,7 @@ class StreamIndex {
 
  private:
   StreamIndex(
-      std::shared_ptr<const ChunkStatsGroup> chunkIndex,
+      std::shared_ptr<const ChunkStatsGroup> chunkStats,
       uint32_t streamId,
       uint32_t startChunkOffset,
       uint32_t endChunkOffset,

--- a/dwio/nimble/index/tests/ChunkStatsTest.cpp
+++ b/dwio/nimble/index/tests/ChunkStatsTest.cpp
@@ -58,8 +58,8 @@ TEST_F(ChunkStatsTest, lookupChunkWithRowId) {
 
   auto indexBuffers =
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-  auto chunkIndex = createChunkIndex(indexBuffers, 0);
-  ASSERT_NE(chunkIndex, nullptr);
+  auto chunkStats = createChunkStats(indexBuffers, 0);
+  ASSERT_NE(chunkStats, nullptr);
 
   struct {
     uint32_t stripeIndex;
@@ -144,7 +144,7 @@ TEST_F(ChunkStatsTest, lookupChunkWithRowId) {
             testCase.stripeIndex,
             testCase.streamId,
             testCase.rowId));
-    auto streamIndex = chunkIndex->createStreamIndex(
+    auto streamIndex = chunkStats->createStreamIndex(
         testCase.stripeIndex, testCase.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
     auto result = streamIndex->lookupChunk(testCase.rowId);
@@ -153,17 +153,17 @@ TEST_F(ChunkStatsTest, lookupChunkWithRowId) {
   }
 
   // Row at/after last chunk boundary — throws
-  auto s00 = chunkIndex->createStreamIndex(0, 0, /*streamSize=*/1000);
+  auto s00 = chunkStats->createStreamIndex(0, 0, /*streamSize=*/1000);
   NIMBLE_ASSERT_THROW(s00->lookupChunk(750), "beyond the last chunk");
   NIMBLE_ASSERT_THROW(s00->lookupChunk(850), "beyond the last chunk");
 
-  auto s01 = chunkIndex->createStreamIndex(0, 1, /*streamSize=*/1000);
+  auto s01 = chunkStats->createStreamIndex(0, 1, /*streamSize=*/1000);
   NIMBLE_ASSERT_THROW(s01->lookupChunk(450), "beyond the last chunk");
 
-  auto s10 = chunkIndex->createStreamIndex(1, 0, /*streamSize=*/1000);
+  auto s10 = chunkStats->createStreamIndex(1, 0, /*streamSize=*/1000);
   NIMBLE_ASSERT_THROW(s10->lookupChunk(550), "beyond the last chunk");
 
-  auto s11 = chunkIndex->createStreamIndex(1, 1, /*streamSize=*/1000);
+  auto s11 = chunkStats->createStreamIndex(1, 1, /*streamSize=*/1000);
   NIMBLE_ASSERT_THROW(s11->lookupChunk(650), "beyond the last chunk");
 }
 
@@ -190,8 +190,8 @@ TEST_F(ChunkStatsTest, lookupChunkPopulatesChunkIndex) {
 
   auto indexBuffers =
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-  auto chunkIndex = createChunkIndex(indexBuffers, 0);
-  ASSERT_NE(chunkIndex, nullptr);
+  auto chunkStats = createChunkStats(indexBuffers, 0);
+  ASSERT_NE(chunkStats, nullptr);
 
   struct {
     uint32_t streamId;
@@ -218,7 +218,7 @@ TEST_F(ChunkStatsTest, lookupChunkPopulatesChunkIndex) {
 
   for (const auto& tc : testCases) {
     SCOPED_TRACE(fmt::format("streamId {} rowId {}", tc.streamId, tc.rowId));
-    auto streamIndex = chunkIndex->createStreamIndex(
+    auto streamIndex = chunkStats->createStreamIndex(
         /*stripe=*/0, tc.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
     const auto result = streamIndex->lookupChunk(tc.rowId);
@@ -247,12 +247,12 @@ TEST_F(ChunkStatsTest, createStreamIndex) {
 
   auto indexBuffers =
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-  auto chunkIndex = createChunkIndex(indexBuffers, 0);
-  ASSERT_NE(chunkIndex, nullptr);
+  auto chunkStats = createChunkStats(indexBuffers, 0);
+  ASSERT_NE(chunkStats, nullptr);
 
   // Multi-chunk streams return non-null StreamIndex.
-  EXPECT_NE(chunkIndex->createStreamIndex(0, 0, /*streamSize=*/1000), nullptr);
-  EXPECT_NE(chunkIndex->createStreamIndex(0, 1, /*streamSize=*/1000), nullptr);
+  EXPECT_NE(chunkStats->createStreamIndex(0, 0, /*streamSize=*/1000), nullptr);
+  EXPECT_NE(chunkStats->createStreamIndex(0, 1, /*streamSize=*/1000), nullptr);
 }
 
 TEST_F(ChunkStatsTest, singleChunkStreamReturnsNullptr) {
@@ -275,15 +275,15 @@ TEST_F(ChunkStatsTest, singleChunkStreamReturnsNullptr) {
 
   auto indexBuffers =
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-  auto chunkIndex = createChunkIndex(indexBuffers, 0);
-  ASSERT_NE(chunkIndex, nullptr);
+  auto chunkStats = createChunkStats(indexBuffers, 0);
+  ASSERT_NE(chunkStats, nullptr);
 
   // Single-chunk streams return nullptr.
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 0, /*streamSize=*/1000), nullptr);
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 2, /*streamSize=*/1000), nullptr);
+  EXPECT_EQ(chunkStats->createStreamIndex(0, 0, /*streamSize=*/1000), nullptr);
+  EXPECT_EQ(chunkStats->createStreamIndex(0, 2, /*streamSize=*/1000), nullptr);
 
   // Multi-chunk stream returns non-null.
-  auto streamIndex = chunkIndex->createStreamIndex(0, 1, /*streamSize=*/1000);
+  auto streamIndex = chunkStats->createStreamIndex(0, 1, /*streamSize=*/1000);
   ASSERT_NE(streamIndex, nullptr);
   EXPECT_EQ(streamIndex->streamId(), 1);
 }
@@ -315,8 +315,8 @@ TEST_F(ChunkStatsTest, streamIndexStreamId) {
 
   auto indexBuffers =
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-  auto chunkIndex = createChunkIndex(indexBuffers, 0);
-  ASSERT_NE(chunkIndex, nullptr);
+  auto chunkStats = createChunkStats(indexBuffers, 0);
+  ASSERT_NE(chunkStats, nullptr);
 
   struct {
     uint32_t stripeIndex;
@@ -336,7 +336,7 @@ TEST_F(ChunkStatsTest, streamIndexStreamId) {
             "stripeIndex {} streamId {}",
             testCase.stripeIndex,
             testCase.streamId));
-    auto streamIndex = chunkIndex->createStreamIndex(
+    auto streamIndex = chunkStats->createStreamIndex(
         testCase.stripeIndex, testCase.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
     EXPECT_EQ(streamIndex->streamId(), testCase.streamId);
@@ -487,10 +487,10 @@ TEST_F(ChunkStatsTest, streamIndexLookupChunk) {
             testCase.streamId,
             testCase.rowId));
 
-    auto chunkIndex = createChunkIndex(indexBuffers, testCase.groupIndex);
-    ASSERT_NE(chunkIndex, nullptr);
+    auto chunkStats = createChunkStats(indexBuffers, testCase.groupIndex);
+    ASSERT_NE(chunkStats, nullptr);
 
-    auto streamIndex = chunkIndex->createStreamIndex(
+    auto streamIndex = chunkStats->createStreamIndex(
         testCase.stripeIndex, testCase.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
 
@@ -500,7 +500,7 @@ TEST_F(ChunkStatsTest, streamIndexLookupChunk) {
   }
 
   // Row at/after last chunk boundary — throws
-  auto ci0 = createChunkIndex(indexBuffers, 0);
+  auto ci0 = createChunkStats(indexBuffers, 0);
   NIMBLE_ASSERT_THROW(
       ci0->createStreamIndex(0, 0, /*streamSize=*/1000)->lookupChunk(750),
       "beyond the last chunk");
@@ -514,7 +514,7 @@ TEST_F(ChunkStatsTest, streamIndexLookupChunk) {
       ci0->createStreamIndex(1, 1, /*streamSize=*/1000)->lookupChunk(650),
       "beyond the last chunk");
 
-  auto ci1 = createChunkIndex(indexBuffers, 1);
+  auto ci1 = createChunkStats(indexBuffers, 1);
   NIMBLE_ASSERT_THROW(
       ci1->createStreamIndex(2, 0, /*streamSize=*/1000)->lookupChunk(450),
       "beyond the last chunk");
@@ -576,45 +576,45 @@ TEST_F(ChunkStatsTest, stripeIndexAndStreamIdOutOfBound) {
       createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
 
   // Test Group 0 (stripes 0, 1)
-  auto chunkIndex0 = createChunkIndex(indexBuffers, 0);
-  ASSERT_NE(chunkIndex0, nullptr);
+  auto chunkStats0 = createChunkStats(indexBuffers, 0);
+  ASSERT_NE(chunkStats0, nullptr);
 
   // Test stripe index after group's range
   NIMBLE_ASSERT_THROW(
-      chunkIndex0->createStreamIndex(2, 0, /*streamSize=*/1000),
-      "Stripe offset is out of range for this chunk index group");
+      chunkStats0->createStreamIndex(2, 0, /*streamSize=*/1000),
+      "Stripe offset is out of range for this chunk stats group");
   NIMBLE_ASSERT_THROW(
-      chunkIndex0->createStreamIndex(3, 0, /*streamSize=*/1000),
-      "Stripe offset is out of range for this chunk index group");
+      chunkStats0->createStreamIndex(3, 0, /*streamSize=*/1000),
+      "Stripe offset is out of range for this chunk stats group");
 
   // streamId >= streamCount returns nullptr.
-  EXPECT_EQ(chunkIndex0->createStreamIndex(0, 2, /*streamSize=*/1000), nullptr);
+  EXPECT_EQ(chunkStats0->createStreamIndex(0, 2, /*streamSize=*/1000), nullptr);
   EXPECT_EQ(
-      chunkIndex0->createStreamIndex(1, 10, /*streamSize=*/1000), nullptr);
+      chunkStats0->createStreamIndex(1, 10, /*streamSize=*/1000), nullptr);
 
   // Test Group 1 (stripes 2, 3)
-  auto chunkIndex1 = createChunkIndex(indexBuffers, 1);
-  ASSERT_NE(chunkIndex1, nullptr);
+  auto chunkStats1 = createChunkStats(indexBuffers, 1);
+  ASSERT_NE(chunkStats1, nullptr);
 
   // Stripe index before group's range (group 1 starts at stripe 2)
   NIMBLE_ASSERT_THROW(
-      chunkIndex1->createStreamIndex(0, 0, /*streamSize=*/1000),
+      chunkStats1->createStreamIndex(0, 0, /*streamSize=*/1000),
       "Stripe index is before this group's range");
   NIMBLE_ASSERT_THROW(
-      chunkIndex1->createStreamIndex(1, 0, /*streamSize=*/1000),
+      chunkStats1->createStreamIndex(1, 0, /*streamSize=*/1000),
       "Stripe index is before this group's range");
 
   // Stripe index after group's range (group 1 has stripes 2, 3)
   NIMBLE_ASSERT_THROW(
-      chunkIndex1->createStreamIndex(4, 0, /*streamSize=*/1000),
-      "Stripe offset is out of range for this chunk index group");
+      chunkStats1->createStreamIndex(4, 0, /*streamSize=*/1000),
+      "Stripe offset is out of range for this chunk stats group");
   NIMBLE_ASSERT_THROW(
-      chunkIndex1->createStreamIndex(5, 0, /*streamSize=*/1000),
-      "Stripe offset is out of range for this chunk index group");
+      chunkStats1->createStreamIndex(5, 0, /*streamSize=*/1000),
+      "Stripe offset is out of range for this chunk stats group");
 
   // streamId >= streamCount returns nullptr.
-  EXPECT_EQ(chunkIndex1->createStreamIndex(2, 2, /*streamSize=*/1000), nullptr);
-  EXPECT_EQ(chunkIndex1->createStreamIndex(3, 5, /*streamSize=*/1000), nullptr);
+  EXPECT_EQ(chunkStats1->createStreamIndex(2, 2, /*streamSize=*/1000), nullptr);
+  EXPECT_EQ(chunkStats1->createStreamIndex(3, 5, /*streamSize=*/1000), nullptr);
 }
 
 TEST_F(ChunkStatsTest, streamIndexRowCount) {
@@ -716,10 +716,10 @@ TEST_F(ChunkStatsTest, streamIndexRowCount) {
             testCase.stripeIndex,
             testCase.streamId));
 
-    auto chunkIndex = createChunkIndex(indexBuffers, testCase.groupIndex);
-    ASSERT_NE(chunkIndex, nullptr);
+    auto chunkStats = createChunkStats(indexBuffers, testCase.groupIndex);
+    ASSERT_NE(chunkStats, nullptr);
 
-    auto streamIndex = chunkIndex->createStreamIndex(
+    auto streamIndex = chunkStats->createStreamIndex(
         testCase.stripeIndex, testCase.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
     EXPECT_EQ(streamIndex->rowCount(), testCase.expectedRowCount);
@@ -744,8 +744,8 @@ TEST_F(ChunkStatsTest, chunkOnlyLookupByRowId) {
   std::vector<int> stripeGroups = {2};
 
   auto indexBuffers = createChunkOnlyTestClusterIndex(stripes, stripeGroups);
-  auto chunkIndex = createChunkIndex(indexBuffers, 0);
-  ASSERT_NE(chunkIndex, nullptr);
+  auto chunkStats = createChunkStats(indexBuffers, 0);
+  ASSERT_NE(chunkStats, nullptr);
 
   struct {
     uint32_t stripeIndex;
@@ -777,7 +777,7 @@ TEST_F(ChunkStatsTest, chunkOnlyLookupByRowId) {
             testCase.stripeIndex,
             testCase.streamId,
             testCase.rowId));
-    auto streamIndex = chunkIndex->createStreamIndex(
+    auto streamIndex = chunkStats->createStreamIndex(
         testCase.stripeIndex, testCase.streamId, /*streamSize=*/1000);
     ASSERT_NE(streamIndex, nullptr);
     auto result = streamIndex->lookupChunk(testCase.rowId);
@@ -787,15 +787,15 @@ TEST_F(ChunkStatsTest, chunkOnlyLookupByRowId) {
 
   // Row at/after last chunk boundary — throws
   NIMBLE_ASSERT_THROW(
-      chunkIndex->createStreamIndex(0, 0, /*streamSize=*/1000)
+      chunkStats->createStreamIndex(0, 0, /*streamSize=*/1000)
           ->lookupChunk(750),
       "beyond the last chunk");
   NIMBLE_ASSERT_THROW(
-      chunkIndex->createStreamIndex(0, 1, /*streamSize=*/1000)
+      chunkStats->createStreamIndex(0, 1, /*streamSize=*/1000)
           ->lookupChunk(450),
       "beyond the last chunk");
   NIMBLE_ASSERT_THROW(
-      chunkIndex->createStreamIndex(1, 0, /*streamSize=*/1000)
+      chunkStats->createStreamIndex(1, 0, /*streamSize=*/1000)
           ->lookupChunk(550),
       "beyond the last chunk");
 }
@@ -813,10 +813,10 @@ TEST_F(ChunkStatsTest, chunkNullCountAbsentReturnsNullopt) {
   std::vector<int> stripeGroups = {1};
 
   auto indexBuffers = createChunkOnlyTestClusterIndex(stripes, stripeGroups);
-  auto chunkIndex = createChunkIndex(indexBuffers, 0);
-  ASSERT_NE(chunkIndex, nullptr);
+  auto chunkStats = createChunkStats(indexBuffers, 0);
+  ASSERT_NE(chunkStats, nullptr);
 
-  auto streamIndex = chunkIndex->createStreamIndex(0, 0, /*streamSize=*/1000);
+  auto streamIndex = chunkStats->createStreamIndex(0, 0, /*streamSize=*/1000);
   ASSERT_NE(streamIndex, nullptr);
   const auto location = streamIndex->lookupChunk(0);
   EXPECT_FALSE(streamIndex->chunkNullCount(location.chunkIndex).has_value());

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.cpp
@@ -158,16 +158,16 @@ ClusterIndexTestBase::IndexBuffers ClusterIndexTestBase::createTestClusterIndex(
     const uint32_t numStreams = streamChunkCounts.size() / groupStripeCount;
 
     // Build standalone StripeChunkStats flatbuffer
-    auto stripeChunkIndex = serialization::CreateStripeChunkStats(
+    auto stripeChunkStats = serialization::CreateStripeChunkStats(
         chunkBuilder,
         numStreams,
         chunkBuilder.CreateVector(streamChunkCounts),
         chunkBuilder.CreateVector(streamChunkRows),
         chunkBuilder.CreateVector(streamChunkOffsets));
-    chunkBuilder.Finish(stripeChunkIndex);
+    chunkBuilder.Finish(stripeChunkStats);
 
-    result.chunkIndexGroupSizes.push_back(chunkBuilder.GetSize());
-    result.chunkIndexGroups.append(
+    result.chunkStatsGroupSizes.push_back(chunkBuilder.GetSize());
+    result.chunkStatsGroups.append(
         reinterpret_cast<const char*>(chunkBuilder.GetBufferPointer()),
         chunkBuilder.GetSize());
   }
@@ -299,16 +299,16 @@ ClusterIndexTestBase::createChunkOnlyTestClusterIndex(
 
     const uint32_t numStreams = streamChunkCounts.size() / groupStripeCount;
 
-    auto stripeChunkIndex = serialization::CreateStripeChunkStats(
+    auto stripeChunkStats = serialization::CreateStripeChunkStats(
         chunkBuilder,
         numStreams,
         chunkBuilder.CreateVector(streamChunkCounts),
         chunkBuilder.CreateVector(streamChunkRows),
         chunkBuilder.CreateVector(streamChunkOffsets));
-    chunkBuilder.Finish(stripeChunkIndex);
+    chunkBuilder.Finish(stripeChunkStats);
 
-    result.chunkIndexGroupSizes.push_back(chunkBuilder.GetSize());
-    result.chunkIndexGroups.append(
+    result.chunkStatsGroupSizes.push_back(chunkBuilder.GetSize());
+    result.chunkStatsGroups.append(
         reinterpret_cast<const char*>(chunkBuilder.GetBufferPointer()),
         chunkBuilder.GetSize());
 
@@ -378,7 +378,7 @@ std::unique_ptr<ClusterIndex> ClusterIndexTestBase::createClusterIndex(
       std::move(dataInput));
 }
 
-std::shared_ptr<ChunkStatsGroup> ClusterIndexTestBase::createChunkIndex(
+std::shared_ptr<ChunkStatsGroup> ClusterIndexTestBase::createChunkStats(
     const IndexBuffers& indexBuffers,
     uint32_t stripeGroupIndex) {
   // Compute firstStripe and stripeCount from stripeGroupIndices.
@@ -394,24 +394,24 @@ std::shared_ptr<ChunkStatsGroup> ClusterIndexTestBase::createChunkIndex(
   }
 
   // Find the ChunkStatsGroup data for this group using recorded sizes.
-  NIMBLE_CHECK_LT(stripeGroupIndex, indexBuffers.chunkIndexGroupSizes.size());
+  NIMBLE_CHECK_LT(stripeGroupIndex, indexBuffers.chunkStatsGroupSizes.size());
   size_t offset = 0;
   for (uint32_t g = 0; g < stripeGroupIndex; ++g) {
-    offset += indexBuffers.chunkIndexGroupSizes[g];
+    offset += indexBuffers.chunkStatsGroupSizes[g];
   }
 
-  auto chunkIndexBuffer =
+  auto chunkStatsBuffer =
       std::make_unique<MetadataBuffer>(MetadataBuffer::decompress(
           toBufferPtr(
               std::string_view(
-                  indexBuffers.chunkIndexGroups.data() + offset,
-                  indexBuffers.chunkIndexGroupSizes[stripeGroupIndex]),
+                  indexBuffers.chunkStatsGroups.data() + offset,
+                  indexBuffers.chunkStatsGroupSizes[stripeGroupIndex]),
               pool_.get()),
           CompressionType::Uncompressed,
           pool_.get()));
 
   return ChunkStatsGroup::create(
-      firstStripe, stripeCount, std::move(chunkIndexBuffer));
+      firstStripe, stripeCount, std::move(chunkStatsBuffer));
 }
 
 } // namespace facebook::nimble::index::test

--- a/dwio/nimble/index/tests/ClusterIndexTestBase.h
+++ b/dwio/nimble/index/tests/ClusterIndexTestBase.h
@@ -60,9 +60,9 @@ class ClusterIndexTestBase : public ::testing::Test {
     /// sequentially.
     std::string indexPartitions;
     /// Serialized ChunkStats flatbuffers appended sequentially.
-    std::string chunkIndexGroups;
-    /// Size of each ChunkStats flatbuffer in chunkIndexGroups.
-    std::vector<size_t> chunkIndexGroupSizes;
+    std::string chunkStatsGroups;
+    /// Size of each ChunkStats flatbuffer in chunkStatsGroups.
+    std::vector<size_t> chunkStatsGroupSizes;
     /// Serialized root Index flatbuffer.
     std::string rootIndex;
     /// Per-stripe row counts (from test data).
@@ -104,7 +104,7 @@ class ClusterIndexTestBase : public ::testing::Test {
       velox::ReadFile* keyStreamFile = nullptr);
 
   /// Creates a ChunkStatsGroup from the serialized IndexBuffers.
-  std::shared_ptr<ChunkStatsGroup> createChunkIndex(
+  std::shared_ptr<ChunkStatsGroup> createChunkStats(
       const IndexBuffers& indexBuffers,
       uint32_t stripeGroupIndex);
 

--- a/dwio/nimble/tablet/Chunk.h
+++ b/dwio/nimble/tablet/Chunk.h
@@ -28,7 +28,7 @@ struct Chunk {
   uint32_t rowCount{0};
 
   /// Number of null values in this chunk. Only populated when chunk statistics
-  /// are enabled (VeloxWriterOptions::enableChunkIndex); left at 0 otherwise.
+  /// are enabled (VeloxWriterOptions::enableChunkStats); left at 0 otherwise.
   uint32_t nullCount{0};
 
   /// The encoded and compressed data content of this chunk, stored as a vector

--- a/dwio/nimble/tablet/ChunkStatsWriter.cpp
+++ b/dwio/nimble/tablet/ChunkStatsWriter.cpp
@@ -39,8 +39,11 @@ std::string_view asView(const flatbuffers::FlatBufferBuilder& builder) {
 
 ChunkStatsWriter::ChunkStatsWriter(
     velox::memory::MemoryPool& pool,
-    float minAvgChunksPerStream)
-    : pool_{&pool}, minAvgChunksPerStream_{minAvgChunksPerStream} {}
+    float minAvgChunksPerStream,
+    bool enableStats)
+    : pool_{&pool},
+      minAvgChunksPerStream_{minAvgChunksPerStream},
+      enableStats_{enableStats} {}
 
 void ChunkStatsWriter::newStripe(size_t streamCount) {
   NIMBLE_CHECK(!finalized_, "ChunkStatsWriter has been finalized");
@@ -150,13 +153,17 @@ void ChunkStatsWriter::writeGroup(
   }
 
   flatbuffers::FlatBufferBuilder builder(kInitialFooterSize);
+  // Omit null counts when stats are disabled; readers treat them as absent.
+  const auto nullCountsVector = enableStats_
+      ? builder.CreateVector(flattenedChunkNullCounts)
+      : flatbuffers::Offset<flatbuffers::Vector<uint32_t>>{0};
   auto chunkStats = serialization::CreateStripeChunkStats(
       builder,
       static_cast<uint32_t>(streamCount),
       builder.CreateVector(flattenedStreamChunkCounts),
       builder.CreateVector(flattenedChunkRows),
       builder.CreateVector(flattenedChunkOffsets),
-      builder.CreateVector(flattenedChunkNullCounts));
+      nullCountsVector);
   builder.Finish(chunkStats);
 
   chunkStatsSections_.push_back(createMetadataSection(asView(builder)));

--- a/dwio/nimble/tablet/ChunkStatsWriter.cpp
+++ b/dwio/nimble/tablet/ChunkStatsWriter.cpp
@@ -96,13 +96,13 @@ void ChunkStatsWriter::writeGroup(
     }
   }
 
-  // Check threshold: skip chunk index for this group if average chunks
+  // Check threshold: skip chunk stats for this group if average chunks
   // per stream is below threshold.
   if (minAvgChunksPerStream_ > 0) {
     const float avgChunks =
         static_cast<float>(totalNumChunks) / static_cast<float>(streamCount);
     if (avgChunks < minAvgChunksPerStream_) {
-      chunkIndexSections_.emplace_back(0, 0, CompressionType::Uncompressed);
+      chunkStatsSections_.emplace_back(0, 0, CompressionType::Uncompressed);
       return;
     }
   }
@@ -150,16 +150,16 @@ void ChunkStatsWriter::writeGroup(
   }
 
   flatbuffers::FlatBufferBuilder builder(kInitialFooterSize);
-  auto chunkIndex = serialization::CreateStripeChunkStats(
+  auto chunkStats = serialization::CreateStripeChunkStats(
       builder,
       static_cast<uint32_t>(streamCount),
       builder.CreateVector(flattenedStreamChunkCounts),
       builder.CreateVector(flattenedChunkRows),
       builder.CreateVector(flattenedChunkOffsets),
       builder.CreateVector(flattenedChunkNullCounts));
-  builder.Finish(chunkIndex);
+  builder.Finish(chunkStats);
 
-  chunkIndexSections_.push_back(createMetadataSection(asView(builder)));
+  chunkStatsSections_.push_back(createMetadataSection(asView(builder)));
 }
 
 void ChunkStatsWriter::writeRoot(
@@ -169,11 +169,11 @@ void ChunkStatsWriter::writeRoot(
     finalized_ = true;
   };
 
-  // Skip writing the chunk_index section if all groups were skipped or no
+  // Skip writing the chunk stats section if all groups were skipped or no
   // groups were written.
   const bool hasNonEmptyGroup = std::any_of(
-      chunkIndexSections_.begin(),
-      chunkIndexSections_.end(),
+      chunkStatsSections_.begin(),
+      chunkStatsSections_.end(),
       [](const auto& section) { return section.size() > 0; });
   if (!hasNonEmptyGroup) {
     return;
@@ -183,15 +183,15 @@ void ChunkStatsWriter::writeRoot(
 
   auto stripeIndexesVector =
       builder.CreateVector<flatbuffers::Offset<serialization::MetadataSection>>(
-          chunkIndexSections_.size(), [&builder, this](size_t i) {
+          chunkStatsSections_.size(), [&builder, this](size_t i) {
             return serialization::CreateMetadataSection(
                 builder,
-                chunkIndexSections_[i].offset(),
-                chunkIndexSections_[i].size(),
+                chunkStatsSections_[i].offset(),
+                chunkStatsSections_[i].size(),
                 static_cast<serialization::CompressionType>(
-                    chunkIndexSections_[i].compressionType()),
-                chunkIndexSections_[i].uncompressedSize().value_or(
-                    chunkIndexSections_[i].size()));
+                    chunkStatsSections_[i].compressionType()),
+                chunkStatsSections_[i].uncompressedSize().value_or(
+                    chunkStatsSections_[i].size()));
           });
 
   builder.Finish(serialization::CreateChunkStats(builder, stripeIndexesVector));

--- a/dwio/nimble/tablet/ChunkStatsWriter.h
+++ b/dwio/nimble/tablet/ChunkStatsWriter.h
@@ -40,9 +40,9 @@ struct Chunk;
 class ChunkStatsWriter {
  public:
   /// @param pool Memory pool for allocations.
-  /// @param minAvgChunksPerStream Skip writing chunk index for a stripe group
+  /// @param minAvgChunksPerStream Skip writing chunk stats for a stripe group
   ///        if the average number of chunks per stream is below this threshold.
-  ///        0 disables chunk index skipping.
+  ///        0 disables chunk stats skipping.
   explicit ChunkStatsWriter(
       velox::memory::MemoryPool& pool,
       float minAvgChunksPerStream = 2);
@@ -71,7 +71,7 @@ class ChunkStatsWriter {
   /// Writes the root ChunkStats table to the "columnar.chunk.stats" optional
   /// section.
   ///
-  /// @param writeOptionalSection Callback to persist the root chunk index as a
+  /// @param writeOptionalSection Callback to persist the root chunk stats as a
   ///        named optional section in the file footer.
   void writeRoot(const WriteOptionalSectionFn& writeOptionalSection);
 
@@ -105,8 +105,8 @@ class ChunkStatsWriter {
   velox::memory::MemoryPool* const pool_;
   const float minAvgChunksPerStream_;
   std::unique_ptr<GroupIndex> groupIndex_;
-  // Metadata sections for chunk index flatbuffers (used by writeRoot).
-  std::vector<MetadataSection> chunkIndexSections_;
+  // Metadata sections for chunk stats flatbuffers (used by writeRoot).
+  std::vector<MetadataSection> chunkStatsSections_;
   bool finalized_{false};
 };
 

--- a/dwio/nimble/tablet/ChunkStatsWriter.h
+++ b/dwio/nimble/tablet/ChunkStatsWriter.h
@@ -45,7 +45,8 @@ class ChunkStatsWriter {
   ///        0 disables chunk stats skipping.
   explicit ChunkStatsWriter(
       velox::memory::MemoryPool& pool,
-      float minAvgChunksPerStream = 2);
+      float minAvgChunksPerStream = 2,
+      bool enableStats = true);
 
   ChunkStatsWriter(const ChunkStatsWriter&) = delete;
   ChunkStatsWriter& operator=(const ChunkStatsWriter&) = delete;
@@ -104,6 +105,8 @@ class ChunkStatsWriter {
 
   velox::memory::MemoryPool* const pool_;
   const float minAvgChunksPerStream_;
+  // When false, omit per-chunk null counts (positional index only).
+  const bool enableStats_;
   std::unique_ptr<GroupIndex> groupIndex_;
   // Metadata sections for chunk stats flatbuffers (used by writeRoot).
   std::vector<MetadataSection> chunkStatsSections_;

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -35,7 +35,6 @@ constexpr std::string_view kStatsSection = "columnar.stats";
 constexpr std::string_view kVectorizedStatsSection =
     "columnar.vectorized_stats";
 constexpr std::string_view kIndexSection = "columnar.indexes";
-// TODO: Rename this section to "columnar.chunk.stats".
 constexpr std::string_view kChunkStatsSection = "columnar.chunk.stats";
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -83,8 +83,8 @@ TabletReader::Options TabletReader::configureOptions(
       std::string(kSchemaSection), std::string(kVectorizedStatsSection)};
   tabletOptions.loadClusterIndex = options.loadClusterIndex();
   tabletOptions.preloadIndex = options.preloadIndex();
-  tabletOptions.loadChunkIndex = options.loadChunkIndex();
-  if (tabletOptions.loadChunkIndex) {
+  tabletOptions.loadChunkStats = options.loadChunkStats();
+  if (tabletOptions.loadChunkStats) {
     tabletOptions.preloadOptionalSections.emplace_back(kChunkStatsSection);
   }
   tabletOptions.pinMetadata = options.pinMetadata();
@@ -186,7 +186,7 @@ TabletReader::TabletReader(
       file_{std::move(readFile)},
       loadClusterIndex_{options.loadClusterIndex},
       clusterIndexName_{options.clusterIndexName},
-      loadChunkIndex_{options.loadChunkIndex},
+      loadChunkStats_{options.loadChunkStats},
       loadDenseIndexes_{options.loadDenseIndexes},
       ioOptions_{[&]() {
         NIMBLE_CHECK(options.ioOptions.has_value(), "ioOptions is not set.");
@@ -232,7 +232,7 @@ TabletReader::TabletReader(
             return loadStripeGroup(stripeGroupIndex);
           },
           options.pinMetadata},
-      chunkIndexCache_{
+      chunkStatsCache_{
           [this](uint32_t stripeGroupIndex) {
             return loadChunkStatsGroup(stripeGroupIndex);
           },
@@ -282,7 +282,7 @@ void TabletReader::init(const Options& options) {
   initStripes(footerView, footerOffset);
   initIndexDescriptors();
   initClusterIndex();
-  initChunkIndex(footerView, footerOffset);
+  initChunkStats(footerView, footerOffset);
   initDenseIndexes();
 
   cacheMetadata(footerView, footerOffset);
@@ -407,7 +407,7 @@ bool TabletReader::initFromCache(const Options& options) {
   initStripes();
   initIndexDescriptors();
   initClusterIndex();
-  initChunkIndex();
+  initChunkStats();
   initDenseIndexes();
   return true;
 }
@@ -468,9 +468,9 @@ void TabletReader::cacheMetadata(
   }
 
   if (chunkStats_ != nullptr) {
-    auto chunkIndexIt = optionalSections_.find(std::string{kChunkStatsSection});
-    NIMBLE_CHECK(chunkIndexIt != optionalSections_.end());
-    cacheSection(chunkIndexIt->second);
+    auto chunkStatsIt = optionalSections_.find(std::string{kChunkStatsSection});
+    NIMBLE_CHECK(chunkStatsIt != optionalSections_.end());
+    cacheSection(chunkStatsIt->second);
 
     const auto& firstSection = chunkStats_->groupMetadata(0);
     if (firstSection.size() > 0) {
@@ -505,7 +505,7 @@ void TabletReader::loadStripes(
   if (options.loadClusterIndex || options.loadDenseIndexes) {
     updateOffset(kIndexSection);
   }
-  if (options.loadChunkIndex) {
+  if (options.loadChunkStats) {
     updateOffset(kChunkStatsSection);
   }
   const uint64_t requiredSize = fileSize_ - requiredOffset;
@@ -815,11 +815,11 @@ TabletReader::StripeGroupMetadata TabletReader::loadStripeGroupMetadata(
   const auto groupSection =
       toMetadataSection(footer->stripe_groups()->Get(stripeGroupIndex));
 
-  const bool hasChunkIndex = this->hasChunkIndex(stripeGroupIndex);
+  const bool hasChunkStats = this->hasChunkStats(stripeGroupIndex);
 
   std::vector<MetadataSection> sections;
   sections.emplace_back(groupSection);
-  if (hasChunkIndex) {
+  if (hasChunkStats) {
     sections.emplace_back(chunkStats_->groupMetadata(stripeGroupIndex));
   }
 
@@ -830,13 +830,13 @@ TabletReader::StripeGroupMetadata TabletReader::loadStripeGroupMetadata(
   StripeGroupMetadata result;
   result.stripeGroup = std::make_shared<StripeGroup>(
       stripeGroupIndex, *stripes_, std::move(groupMetadata), pool_);
-  if (hasChunkIndex) {
-    auto chunkIndexMetadata =
+  if (hasChunkStats) {
+    auto chunkStatsMetadata =
         std::make_unique<MetadataBuffer>(std::move(*results[1]));
-    result.chunkIndex = ChunkStatsGroup::create(
+    result.chunkStats = ChunkStatsGroup::create(
         result.stripeGroup->firstStripe(),
         result.stripeGroup->stripeCount(),
-        std::move(chunkIndexMetadata));
+        std::move(chunkStatsMetadata));
   }
   return result;
 }
@@ -880,22 +880,22 @@ StripeIdentifier TabletReader::stripeIdentifier(uint32_t stripeIndex) const {
   NIMBLE_CHECK_LT(stripeIndex, stripeCount_, "Stripe is out of range.");
   const auto stripeGroupIndex = this->stripeGroupIndex(stripeIndex);
 
-  const bool hasChunkIndex = this->hasChunkIndex(stripeGroupIndex);
+  const bool hasChunkStats = this->hasChunkStats(stripeGroupIndex);
 
   // Check which metadata is already cached.
   const bool stripeGroupCached =
       stripeGroupCache_.hasCacheEntry(stripeGroupIndex);
-  const bool chunkIndexCached =
-      hasChunkIndex && chunkIndexCache_.hasCacheEntry(stripeGroupIndex);
+  const bool chunkStatsCached =
+      hasChunkStats && chunkStatsCache_.hasCacheEntry(stripeGroupIndex);
 
   // If all needed metadata is cached, load each individually (cache hits).
   const bool allCached =
-      stripeGroupCached && (!hasChunkIndex || chunkIndexCached);
+      stripeGroupCached && (!hasChunkStats || chunkStatsCached);
   if (allCached) {
     return StripeIdentifier{
         stripeIndex,
         stripeGroup(stripeGroupIndex),
-        hasChunkIndex ? chunkIndex(stripeGroupIndex) : nullptr};
+        hasChunkStats ? chunkStats(stripeGroupIndex) : nullptr};
   }
 
   // At least one is not cached — use coalesced loading.
@@ -907,15 +907,15 @@ StripeIdentifier TabletReader::stripeIdentifier(uint32_t stripeIndex) const {
       stripeGroupIndex,
       [&loaded](uint32_t) { return std::move(loaded.stripeGroup); });
 
-  std::shared_ptr<ChunkStatsGroup> cachedChunkIndex;
-  if (hasChunkIndex) {
-    cachedChunkIndex = chunkIndexCache_.getOrCreate(
+  std::shared_ptr<ChunkStatsGroup> cachedChunkStats;
+  if (hasChunkStats) {
+    cachedChunkStats = chunkStatsCache_.getOrCreate(
         stripeGroupIndex,
-        [&loaded](uint32_t) { return std::move(loaded.chunkIndex); });
+        [&loaded](uint32_t) { return std::move(loaded.chunkStats); });
   }
 
   return StripeIdentifier{
-      stripeIndex, std::move(cachedStripeGroup), std::move(cachedChunkIndex)};
+      stripeIndex, std::move(cachedStripeGroup), std::move(cachedChunkStats)};
 }
 
 std::vector<std::unique_ptr<StreamLoader>> TabletReader::load(
@@ -1062,7 +1062,7 @@ std::optional<Section> TabletReader::loadOptionalSection(
   return Section{std::move(*readMetadata(it->second))};
 }
 
-bool TabletReader::hasChunkIndexSection() const {
+bool TabletReader::hasChunkStatsSection() const {
   return hasOptionalSection(std::string{kChunkStatsSection});
 }
 
@@ -1182,13 +1182,13 @@ void TabletReader::initDenseIndexes() {
       std::move(entries), indexOptions_, pool_);
 }
 
-void TabletReader::initChunkIndex(
+void TabletReader::initChunkStats(
     std::string_view footerBuf,
     uint64_t footerOffset) {
-  if (!loadChunkIndex_) {
+  if (!loadChunkStats_) {
     return;
   }
-  if (!hasChunkIndexSection()) {
+  if (!hasChunkStatsSection()) {
     return;
   }
 
@@ -1196,12 +1196,12 @@ void TabletReader::initChunkIndex(
       loadOptionalSection(std::string{kChunkStatsSection}, /*keepCache=*/false);
   NIMBLE_CHECK(section.has_value(), "Failed to load chunk stats section.");
 
-  auto chunkIndex = ChunkStats::create(std::move(section.value()));
-  if (chunkIndex->numGroups() > 0) {
-    chunkStats_ = std::move(chunkIndex);
+  auto chunkStats = ChunkStats::create(std::move(section.value()));
+  if (chunkStats->numGroups() > 0) {
+    chunkStats_ = std::move(chunkStats);
   }
 
-  // Eagerly pin the first chunk index group if covered by the speculative
+  // Eagerly pin the first chunk stats group if covered by the speculative
   // buffer.
   if (chunkStats_ != nullptr && chunkStats_->numGroups() == 1) {
     const auto& groupMetadata = chunkStats_->groupMetadata(0);
@@ -1209,7 +1209,7 @@ void TabletReader::initChunkIndex(
       auto metadataBuffer =
           tryExtractFromBuffer(footerBuf, footerOffset, groupMetadata, pool_);
       if (metadataBuffer != nullptr) {
-        chunkIndexCache_.pin(
+        chunkStatsCache_.pin(
             0,
             ChunkStatsGroup::create(
                 firstStripe(0), stripeCount(0), std::move(metadataBuffer)));
@@ -1264,18 +1264,18 @@ uint32_t TabletReader::stripeCount(uint32_t stripeGroupIndex) const {
   return count;
 }
 
-std::shared_ptr<ChunkStatsGroup> TabletReader::chunkIndex(
+std::shared_ptr<ChunkStatsGroup> TabletReader::chunkStats(
     uint32_t stripeGroupIndex) const {
-  return chunkIndexCache_.getOrCreate(stripeGroupIndex);
+  return chunkStatsCache_.getOrCreate(stripeGroupIndex);
 }
 
 std::shared_ptr<ChunkStatsGroup> TabletReader::loadChunkStatsGroup(
     uint32_t stripeGroupIndex) const {
-  NIMBLE_CHECK_NOT_NULL(chunkStats_, "Chunk index not initialized.");
+  NIMBLE_CHECK_NOT_NULL(chunkStats_, "Chunk stats not initialized.");
   NIMBLE_CHECK_LT(
       stripeGroupIndex,
       chunkStats_->numGroups(),
-      "Chunk index group out of range");
+      "Chunk stats group out of range");
 
   const auto& section = chunkStats_->groupMetadata(stripeGroupIndex);
   if (section.size() == 0) {

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -83,10 +83,10 @@ class StripeIdentifier {
   StripeIdentifier(
       uint32_t stripeId,
       std::shared_ptr<StripeGroup> stripeGroup,
-      std::shared_ptr<ChunkStatsGroup> chunkIndex = nullptr)
+      std::shared_ptr<ChunkStatsGroup> chunkStats = nullptr)
       : stripeId_{stripeId},
         stripeGroup_{std::move(stripeGroup)},
-        chunkStats_{std::move(chunkIndex)} {}
+        chunkStats_{std::move(chunkStats)} {}
 
   uint32_t stripeId() const {
     return stripeId_;
@@ -96,7 +96,7 @@ class StripeIdentifier {
     return stripeGroup_;
   }
 
-  const std::shared_ptr<ChunkStatsGroup>& chunkIndex() const {
+  const std::shared_ptr<ChunkStatsGroup>& chunkStats() const {
     return chunkStats_;
   }
 
@@ -140,8 +140,8 @@ class TabletReader {
     /// Default false.
     bool preloadIndex{false};
 
-    /// Whether to load the chunk index during initialization. Default true.
-    bool loadChunkIndex{true};
+    /// Whether to load the chunk stats during initialization. Default true.
+    bool loadChunkStats{true};
 
     /// Whether to load the dense indexes during initialization. Default false.
     bool loadDenseIndexes{false};
@@ -235,8 +235,8 @@ class TabletReader {
       const std::string& name,
       bool keepCache = false) const;
 
-  // Returns true if the file has a chunk index optional section.
-  bool hasChunkIndexSection() const;
+  // Returns true if the file has a chunk stats optional section.
+  bool hasChunkStatsSection() const;
 
   // Returns true if the file has an index optional section.
   bool hasIndexSection() const;
@@ -246,9 +246,9 @@ class TabletReader {
     return clusterIndex_ != nullptr;
   }
 
-  // Returns true if the chunk index is loaded and has data for the given
+  // Returns true if the chunk stats is loaded and has data for the given
   // stripe group.
-  inline bool hasChunkIndex(uint32_t stripeGroupIndex) const {
+  inline bool hasChunkStats(uint32_t stripeGroupIndex) const {
     return chunkStats_ != nullptr &&
         chunkStats_->groupMetadata(stripeGroupIndex).size() > 0;
   }
@@ -475,10 +475,10 @@ class TabletReader {
   // Holds the result of a coalesced metadata load for a stripe group.
   struct StripeGroupMetadata {
     std::shared_ptr<StripeGroup> stripeGroup;
-    std::shared_ptr<ChunkStatsGroup> chunkIndex;
+    std::shared_ptr<ChunkStatsGroup> chunkStats;
   };
 
-  // Loads stripe group and chunk index together using coalesced IO via
+  // Loads stripe group and chunk stats together using coalesced IO via
   // MetadataInput.
   StripeGroupMetadata loadStripeGroupMetadata(uint32_t stripeGroupIndex) const;
 
@@ -497,14 +497,14 @@ class TabletReader {
 
   void initDenseIndexes();
 
-  // Loads chunk index and preloads the first group from footerBuf
+  // Loads chunk stats and preloads the first group from footerBuf
   // when available.
-  void initChunkIndex(
+  void initChunkStats(
       std::string_view footerBuf = {},
       uint64_t footerOffset = 0);
 
   // Returns the cached ChunkStatsGroup for the given stripe group index.
-  std::shared_ptr<ChunkStatsGroup> chunkIndex(uint32_t stripeGroupIndex) const;
+  std::shared_ptr<ChunkStatsGroup> chunkStats(uint32_t stripeGroupIndex) const;
 
   // Loads the ChunkStatsGroup for the given stripe group index from file.
   std::shared_ptr<ChunkStatsGroup> loadChunkStatsGroup(
@@ -520,7 +520,7 @@ class TabletReader {
   const std::shared_ptr<velox::ReadFile> file_;
   const bool loadClusterIndex_;
   const std::string clusterIndexName_;
-  const bool loadChunkIndex_;
+  const bool loadChunkStats_;
   const bool loadDenseIndexes_;
   // IO options copied from Options.ioOptions (required, with non-null
   // metadataIoStats).
@@ -558,7 +558,7 @@ class TabletReader {
 
   // Chunk stats root, loaded from the "columnar.chunk.stats" optional section.
   std::unique_ptr<ChunkStats> chunkStats_;
-  mutable MetadataCache<uint32_t, ChunkStatsGroup> chunkIndexCache_;
+  mutable MetadataCache<uint32_t, ChunkStatsGroup> chunkStatsCache_;
 
   std::unordered_map<std::string, MetadataSection> optionalSections_;
   mutable folly::Synchronized<

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -42,10 +42,12 @@ TabletWriter::TabletWriter(
       pool_(&pool),
       options_(std::move(options)),
       checksum_{ChecksumFactory::create(options_.checksumType)},
-      chunkIndexWriter_{
+      // TODO: keeps the chunkIndex name for now; rename to the chunkStats
+      // naming once per-chunk null/min/max stats are fully rolled out.
+      chunkStatsWriter_{
           options_.enableChunkIndex ? std::make_unique<ChunkStatsWriter>(
                                           pool,
-                                          options_.chunkIndexMinAvgChunks)
+                                          options_.chunkStatsMinAvgChunks)
                                     : nullptr} {}
 
 namespace {
@@ -194,8 +196,8 @@ void TabletWriter::close() {
 
   invokeCloseCallback();
 
-  // Write chunk index root.
-  writeChunkIndexRoot();
+  // Write chunk stats root.
+  writeChunkStatsRoot();
 
   // write stripes
   MetadataSection stripes = writeStripes(stripeCount);
@@ -341,7 +343,7 @@ void TabletWriter::writeStripe(uint32_t rowCount, std::vector<Stream> streams) {
             static_cast<uint32_t>(file_->size() - stripeOffsets_.back());
 
         writeStreamWithChecksum(stream);
-        addStreamChunkIndex(stream.offset, stream.chunks);
+        addStreamChunkStats(stream.offset, stream.chunks);
 
         NIMBLE_DCHECK_LT(
             file_->size() -
@@ -366,7 +368,7 @@ void TabletWriter::writeStripe(uint32_t rowCount, std::vector<Stream> streams) {
         stripeStreamOffsets[index] = it.first->second.first;
         // @lint-ignore CLANGTIDY facebook-hte-LocalUncheckedArrayBounds
         stripeStreamSizes[index] = it.first->second.second;
-        addStreamChunkIndex(index, it.first->first->chunks);
+        addStreamChunkStats(index, it.first->first->chunks);
       }
     }
   } else {
@@ -390,7 +392,7 @@ void TabletWriter::writeStripe(uint32_t rowCount, std::vector<Stream> streams) {
           static_cast<uint32_t>(file_->size() - stripeOffsets_.back());
 
       writeStreamWithChecksum(stream);
-      addStreamChunkIndex(stream.offset, stream.chunks);
+      addStreamChunkStats(stream.offset, stream.chunks);
 
       NIMBLE_DCHECK_LT(
           file_->size() - (stripeStreamOffsets[index] + stripeOffsets_.back()),
@@ -733,38 +735,38 @@ void TabletWriter::writeStreamWithChecksum(const Stream& stream) {
 }
 
 void TabletWriter::finishStripeChunkStats(size_t streamCount) {
-  if (hasChunkIndex()) {
-    chunkIndexWriter_->newStripe(streamCount);
+  if (hasChunkStats()) {
+    chunkStatsWriter_->newStripe(streamCount);
   }
 }
 
-void TabletWriter::addStreamChunkIndex(
+void TabletWriter::addStreamChunkStats(
     uint32_t streamIndex,
     const std::vector<Chunk>& chunks) {
-  if (!hasChunkIndex()) {
+  if (!hasChunkStats()) {
     return;
   }
-  chunkIndexWriter_->addStream(streamIndex, chunks);
+  chunkStatsWriter_->addStream(streamIndex, chunks);
 }
 
 void TabletWriter::writeChunkStatsGroup(
     size_t streamCount,
     size_t stripeCount) {
-  if (hasChunkIndex()) {
+  if (hasChunkStats()) {
     auto createMetadataFn = [this](std::string_view metadata) {
       return createMetadataSection(metadata);
     };
-    chunkIndexWriter_->writeGroup(streamCount, stripeCount, createMetadataFn);
+    chunkStatsWriter_->writeGroup(streamCount, stripeCount, createMetadataFn);
   }
 }
 
-void TabletWriter::writeChunkIndexRoot() {
-  if (hasChunkIndex()) {
+void TabletWriter::writeChunkStatsRoot() {
+  if (hasChunkStats()) {
     auto writeOptionalSectionFn =
         [this](std::string name, std::string_view content) {
           writeOptionalSection(std::move(name), content);
         };
-    chunkIndexWriter_->writeRoot(writeOptionalSectionFn);
+    chunkStatsWriter_->writeRoot(writeOptionalSectionFn);
   }
 }
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/TabletWriter.cpp
+++ b/dwio/nimble/tablet/TabletWriter.cpp
@@ -45,10 +45,16 @@ TabletWriter::TabletWriter(
       // TODO: keeps the chunkIndex name for now; rename to the chunkStats
       // naming once per-chunk null/min/max stats are fully rolled out.
       chunkStatsWriter_{
-          options_.enableChunkIndex ? std::make_unique<ChunkStatsWriter>(
-                                          pool,
-                                          options_.chunkStatsMinAvgChunks)
-                                    : nullptr} {}
+          options_.enableChunkIndex
+              ? std::make_unique<ChunkStatsWriter>(
+                    pool,
+                    options_.chunkStatsMinAvgChunks,
+                    /*enableStats=*/options_.enableChunkStats)
+              : nullptr} {
+  NIMBLE_CHECK(
+      !options_.enableChunkStats || options_.enableChunkIndex,
+      "enableChunkStats requires enableChunkIndex to be true.");
+}
 
 namespace {
 template <typename Source, typename Target = Source>

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -73,6 +73,9 @@ class TabletWriter {
     // When true, chunk-level position index is built for all streams,
     // enabling O(1) chunk-level seeking within stripes.
     bool enableChunkIndex{false};
+    // Write per-chunk value statistics (null counts); requires
+    // enableChunkIndex.
+    bool enableChunkStats{false};
     // Skip writing chunk stats for a stripe group if the average number
     // of chunks per stream is below this threshold. 0 disables chunk stats
     // skipping.

--- a/dwio/nimble/tablet/TabletWriter.h
+++ b/dwio/nimble/tablet/TabletWriter.h
@@ -50,14 +50,14 @@ constexpr uint32_t kMetadataCompressionThreshold = 64 * 1024; // 64kB
 /// Writes a new nimble file.
 class TabletWriter {
  public:
-  /// Called AFTER stripe group and chunk index metadata are written.
+  /// Called AFTER stripe group and chunk stats metadata are written.
   /// Writes partition data (key stream + metadata) aligned with stripe groups.
   using StripeGroupFlushCallback = std::function<void(
       const WriteDataFn& writeDataFn,
       const CreateMetadataSectionFn& createMetadataFn)>;
 
   /// Called during close() after all stripe groups have been flushed,
-  /// before the chunk index root and footer are written. Used by index
+  /// before the chunk stats root and footer are written. Used by index
   /// writers to finalize and write the root index as an optional section.
   using CloseCallback = std::function<void(
       const WriteDataFn& writeDataFn,
@@ -73,10 +73,10 @@ class TabletWriter {
     // When true, chunk-level position index is built for all streams,
     // enabling O(1) chunk-level seeking within stripes.
     bool enableChunkIndex{false};
-    // Skip writing chunk index for a stripe group if the average number
-    // of chunks per stream is below this threshold. 0 disables chunk index
+    // Skip writing chunk stats for a stripe group if the average number
+    // of chunks per stream is below this threshold. 0 disables chunk stats
     // skipping.
-    float chunkIndexMinAvgChunks{2};
+    float chunkStatsMinAvgChunks{2};
     // Selects how per-stripe-group stream offsets/sizes are serialized (default
     // kRaw); see StripeGroup::EncodingLayout.
     StripeGroup::EncodingLayout stripeGroupEncodingLayout{
@@ -156,8 +156,8 @@ class TabletWriter {
       velox::memory::MemoryPool& pool,
       Options options);
 
-  bool hasChunkIndex() const {
-    return chunkIndexWriter_ != nullptr;
+  bool hasChunkStats() const {
+    return chunkStatsWriter_ != nullptr;
   }
 
   // Checks that writer is not closed and throws if it is.
@@ -203,26 +203,26 @@ class TabletWriter {
 
   void writeStreamWithChecksum(const Stream& stream);
 
-  // Starts chunk index writing for a new stripe.
+  // Starts chunk stats writing for a new stripe.
   void finishStripeChunkStats(size_t streamCount);
 
   // Adds chunk-level index data for a stream.
-  void addStreamChunkIndex(
+  void addStreamChunkStats(
       uint32_t streamIndex,
       const std::vector<Chunk>& chunks);
 
-  // Writes the chunk index group for a completed stripe group.
+  // Writes the chunk stats group for a completed stripe group.
   void writeChunkStatsGroup(size_t streamCount, size_t stripeCount);
 
-  // Writes the chunk index root.
-  void writeChunkIndexRoot();
+  // Writes the chunk stats root.
+  void writeChunkStatsRoot();
 
   velox::WriteFile* const file_;
   velox::memory::MemoryPool* const pool_;
   const Options options_;
   const std::unique_ptr<Checksum> checksum_;
   // Chunk-level position index.
-  const std::unique_ptr<ChunkStatsWriter> chunkIndexWriter_;
+  const std::unique_ptr<ChunkStatsWriter> chunkStatsWriter_;
 
   // Number of rows in each stripe.
   std::vector<uint32_t> stripeRowCounts_;

--- a/dwio/nimble/tablet/tests/ChunkStatsWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ChunkStatsWriterTest.cpp
@@ -66,7 +66,7 @@ class ChunkStatsWriterTest : public ::testing::Test {
   }
 
   // Creates a ChunkStatsGroup reader from a serialized group metadata section.
-  std::shared_ptr<index::ChunkStatsGroup> loadChunkIndex(
+  std::shared_ptr<index::ChunkStatsGroup> loadChunkStats(
       const std::string& groupData,
       uint32_t firstStripe,
       uint32_t stripeCount) {
@@ -100,20 +100,20 @@ TEST_F(ChunkStatsWriterTest, singleStripe) {
   writer.writeGroup(2, 1, createMetadataSectionCallback(fileIndex));
   writer.writeRoot(writeRootCallback(fileIndex));
 
-  // Verify root index (ChunkIndexes flatbuffer).
+  // Verify root index (ChunkStats flatbuffer).
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 1);
   ASSERT_FALSE(fileIndex.rootIndexData.empty());
 
-  auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkStats>(
+  auto* rootChunkStats = flatbuffers::GetRoot<serialization::ChunkStats>(
       fileIndex.rootIndexData.data());
-  ASSERT_NE(rootChunkIndexes, nullptr);
-  ASSERT_NE(rootChunkIndexes->stripe_indexes(), nullptr);
-  EXPECT_EQ(rootChunkIndexes->stripe_indexes()->size(), 1);
+  ASSERT_NE(rootChunkStats, nullptr);
+  ASSERT_NE(rootChunkStats->stripe_indexes(), nullptr);
+  EXPECT_EQ(rootChunkStats->stripe_indexes()->size(), 1);
 
   // Load as ChunkStatsGroup reader.
-  auto chunkIndex = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 1);
+  auto chunkStats = loadChunkStats(fileIndex.groupMetadataSections[0], 0, 1);
 
-  ChunkStatsTestHelper helper(chunkIndex.get());
+  ChunkStatsTestHelper helper(chunkStats.get());
   EXPECT_EQ(helper.firstStripe(), 0);
   EXPECT_EQ(helper.stripeCount(), 1);
   EXPECT_EQ(helper.streamCount(), 2);
@@ -132,7 +132,7 @@ TEST_F(ChunkStatsWriterTest, singleStripe) {
 
   // Lookup via StreamIndex (public API).
   // Stream 0: 3 chunks, sizes {10, 15, 8}, total = 33.
-  auto stream0 = chunkIndex->createStreamIndex(0, 0, 33);
+  auto stream0 = chunkStats->createStreamIndex(0, 0, 33);
   ASSERT_NE(stream0, nullptr);
 
   auto r00 = stream0->lookupChunk(0);
@@ -151,7 +151,7 @@ TEST_F(ChunkStatsWriterTest, singleStripe) {
   EXPECT_EQ(r02.rowOffset, 75);
 
   // Stream 1: 2 chunks, sizes {20, 12}, total = 32.
-  auto stream1 = chunkIndex->createStreamIndex(0, 1, 32);
+  auto stream1 = chunkStats->createStreamIndex(0, 1, 32);
   ASSERT_NE(stream1, nullptr);
 
   auto r10 = stream1->lookupChunk(0);
@@ -182,10 +182,10 @@ TEST_F(ChunkStatsWriterTest, perChunkNullCounts) {
   writer.writeGroup(2, 1, createMetadataSectionCallback(fileIndex));
   writer.writeRoot(writeRootCallback(fileIndex));
 
-  auto chunkIndex = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 1);
+  auto chunkStats = loadChunkStats(fileIndex.groupMetadataSections[0], 0, 1);
 
   // Null counts round-trip through the flatbuffer in flattened order.
-  ChunkStatsTestHelper helper(chunkIndex.get());
+  ChunkStatsTestHelper helper(chunkStats.get());
   EXPECT_EQ(
       helper.streamStats(0).chunkNullCounts, (std::vector<uint32_t>{3, 0, 5}));
   EXPECT_EQ(
@@ -193,13 +193,13 @@ TEST_F(ChunkStatsWriterTest, perChunkNullCounts) {
 
   // Public reader accessor: lookupChunk() yields the absolute chunk index,
   // which chunkNullCount() maps to the per-chunk null statistic.
-  auto stream0 = chunkIndex->createStreamIndex(0, 0, 33);
+  auto stream0 = chunkStats->createStreamIndex(0, 0, 33);
   ASSERT_NE(stream0, nullptr);
   EXPECT_EQ(stream0->chunkNullCount(stream0->lookupChunk(0).chunkIndex), 3);
   EXPECT_EQ(stream0->chunkNullCount(stream0->lookupChunk(30).chunkIndex), 0);
   EXPECT_EQ(stream0->chunkNullCount(stream0->lookupChunk(75).chunkIndex), 5);
 
-  auto stream1 = chunkIndex->createStreamIndex(0, 1, 32);
+  auto stream1 = chunkStats->createStreamIndex(0, 1, 32);
   ASSERT_NE(stream1, nullptr);
   EXPECT_EQ(stream1->chunkNullCount(stream1->lookupChunk(60).chunkIndex), 40);
 }
@@ -227,9 +227,9 @@ TEST_F(ChunkStatsWriterTest, multipleStripesInSingleGroup) {
   writer.writeRoot(writeRootCallback(fileIndex));
 
   // Load and verify.
-  auto chunkIndex = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 2);
+  auto chunkStats = loadChunkStats(fileIndex.groupMetadataSections[0], 0, 2);
 
-  ChunkStatsTestHelper helper(chunkIndex.get());
+  ChunkStatsTestHelper helper(chunkStats.get());
   EXPECT_EQ(helper.stripeCount(), 2);
   EXPECT_EQ(helper.streamCount(), 2);
 
@@ -281,15 +281,15 @@ TEST_F(ChunkStatsWriterTest, multipleStripeGroups) {
   // All 3 groups are written (threshold=0, no skipping).
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 3);
 
-  auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkStats>(
+  auto* rootChunkStats = flatbuffers::GetRoot<serialization::ChunkStats>(
       fileIndex.rootIndexData.data());
-  ASSERT_NE(rootChunkIndexes, nullptr);
-  ASSERT_NE(rootChunkIndexes->stripe_indexes(), nullptr);
-  EXPECT_EQ(rootChunkIndexes->stripe_indexes()->size(), 3);
+  ASSERT_NE(rootChunkStats, nullptr);
+  ASSERT_NE(rootChunkStats->stripe_indexes(), nullptr);
+  EXPECT_EQ(rootChunkStats->stripe_indexes()->size(), 3);
 
   // Verify group 0 (stripe 0).
   {
-    auto ci = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 1);
+    auto ci = loadChunkStats(fileIndex.groupMetadataSections[0], 0, 1);
     ChunkStatsTestHelper helper(ci.get());
     EXPECT_EQ(helper.stripeCount(), 1);
     EXPECT_EQ(helper.streamCount(), 1);
@@ -301,7 +301,7 @@ TEST_F(ChunkStatsWriterTest, multipleStripeGroups) {
 
   // Verify group 1 (stripe 1).
   {
-    auto ci = loadChunkIndex(fileIndex.groupMetadataSections[1], 1, 1);
+    auto ci = loadChunkStats(fileIndex.groupMetadataSections[1], 1, 1);
     ChunkStatsTestHelper helper(ci.get());
     EXPECT_EQ(helper.stripeCount(), 1);
     EXPECT_EQ(helper.streamCount(), 1);
@@ -313,7 +313,7 @@ TEST_F(ChunkStatsWriterTest, multipleStripeGroups) {
 
   // Verify group 2 (stripe 2): 1 chunk, createStreamIndex returns nullptr.
   {
-    auto ci = loadChunkIndex(fileIndex.groupMetadataSections[2], 2, 1);
+    auto ci = loadChunkStats(fileIndex.groupMetadataSections[2], 2, 1);
     ChunkStatsTestHelper helper(ci.get());
     EXPECT_EQ(helper.stripeCount(), 1);
     EXPECT_EQ(helper.streamCount(), 1);
@@ -340,9 +340,9 @@ TEST_F(ChunkStatsWriterTest, emptyStream) {
   writer.writeGroup(3, 1, createMetadataSectionCallback(fileIndex));
   writer.writeRoot(writeRootCallback(fileIndex));
 
-  auto chunkIndex = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 1);
+  auto chunkStats = loadChunkStats(fileIndex.groupMetadataSections[0], 0, 1);
 
-  ChunkStatsTestHelper helper(chunkIndex.get());
+  ChunkStatsTestHelper helper(chunkStats.get());
   // All 3 streams are indexed (dense layout).
   EXPECT_EQ(helper.streamCount(), 3);
 
@@ -364,10 +364,10 @@ TEST_F(ChunkStatsWriterTest, emptyStream) {
   EXPECT_EQ(stream2.chunkOffsets, (std::vector<uint32_t>{0}));
 
   // createStreamIndex returns nullptr for streams with ≤1 chunk.
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 1, 0), nullptr);
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 2, 25), nullptr);
+  EXPECT_EQ(chunkStats->createStreamIndex(0, 1, 0), nullptr);
+  EXPECT_EQ(chunkStats->createStreamIndex(0, 2, 25), nullptr);
   // streamId out of range returns nullptr.
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 3, 0), nullptr);
+  EXPECT_EQ(chunkStats->createStreamIndex(0, 3, 0), nullptr);
 }
 
 TEST_F(ChunkStatsWriterTest, emptyFileNoStripeGroups) {
@@ -377,7 +377,7 @@ TEST_F(ChunkStatsWriterTest, emptyFileNoStripeGroups) {
   // No stripes written — writeGroup() is never called.
   writer.writeRoot(writeRootCallback(fileIndex));
 
-  // No chunk_index section should be written.
+  // No chunk stats section should be written.
   EXPECT_TRUE(fileIndex.rootIndexData.empty());
 }
 
@@ -450,15 +450,15 @@ TEST_F(ChunkStatsWriterTest, multipleStripesInMultipleGroups) {
 
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 2);
 
-  auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkStats>(
+  auto* rootChunkStats = flatbuffers::GetRoot<serialization::ChunkStats>(
       fileIndex.rootIndexData.data());
-  ASSERT_NE(rootChunkIndexes, nullptr);
-  ASSERT_NE(rootChunkIndexes->stripe_indexes(), nullptr);
-  EXPECT_EQ(rootChunkIndexes->stripe_indexes()->size(), 2);
+  ASSERT_NE(rootChunkStats, nullptr);
+  ASSERT_NE(rootChunkStats->stripe_indexes(), nullptr);
+  EXPECT_EQ(rootChunkStats->stripe_indexes()->size(), 2);
 
   // Verify group 0 (2 stripes, firstStripe=0).
   {
-    auto ci = loadChunkIndex(fileIndex.groupMetadataSections[0], 0, 2);
+    auto ci = loadChunkStats(fileIndex.groupMetadataSections[0], 0, 2);
     ChunkStatsTestHelper helper(ci.get());
     EXPECT_EQ(helper.stripeCount(), 2);
 
@@ -475,7 +475,7 @@ TEST_F(ChunkStatsWriterTest, multipleStripesInMultipleGroups) {
 
   // Verify group 1 (1 stripe, firstStripe=2).
   {
-    auto ci = loadChunkIndex(fileIndex.groupMetadataSections[1], 2, 1);
+    auto ci = loadChunkStats(fileIndex.groupMetadataSections[1], 2, 1);
     ChunkStatsTestHelper helper(ci.get());
     EXPECT_EQ(helper.stripeCount(), 1);
     EXPECT_EQ(helper.streamCount(), 2);
@@ -533,7 +533,7 @@ TEST_F(ChunkStatsWriterTest, minAvgChunksPerStream) {
       {1.5f, 2, 3, {false, false, true}},
       // threshold=2.0: groups 1 (avg=1.5) and 2 (avg=1.0) are skipped.
       {2.0f, 1, 3, {false, true, true}},
-      // threshold=3.0: all groups skipped — no chunk_index section written.
+      // threshold=3.0: all groups skipped — no chunk stats section written.
       {3.0f, 0, 0, {true, true, true}},
   };
 
@@ -568,23 +568,22 @@ TEST_F(ChunkStatsWriterTest, minAvgChunksPerStream) {
         fileIndex.groupMetadataSections.size(), testData.expectedWrittenGroups);
 
     if (testData.expectedRootEntries == 0) {
-      // All groups were skipped — no chunk_index section written.
+      // All groups were skipped — no chunk stats section written.
       EXPECT_TRUE(fileIndex.rootIndexData.empty());
       continue;
     }
 
     ASSERT_FALSE(fileIndex.rootIndexData.empty());
 
-    auto* rootChunkIndexes = flatbuffers::GetRoot<serialization::ChunkStats>(
+    auto* rootChunkStats = flatbuffers::GetRoot<serialization::ChunkStats>(
         fileIndex.rootIndexData.data());
-    ASSERT_NE(rootChunkIndexes, nullptr);
-    ASSERT_NE(rootChunkIndexes->stripe_indexes(), nullptr);
+    ASSERT_NE(rootChunkStats, nullptr);
+    ASSERT_NE(rootChunkStats->stripe_indexes(), nullptr);
     EXPECT_EQ(
-        rootChunkIndexes->stripe_indexes()->size(),
-        testData.expectedRootEntries);
+        rootChunkStats->stripe_indexes()->size(), testData.expectedRootEntries);
 
     for (uint32_t i = 0; i < testData.expectedRootEntries; ++i) {
-      auto* entry = rootChunkIndexes->stripe_indexes()->Get(i);
+      auto* entry = rootChunkStats->stripe_indexes()->Get(i);
       if (testData.expectedSkipped[i]) {
         EXPECT_EQ(entry->size(), 0) << "Group " << i << " should be skipped";
       } else {
@@ -650,12 +649,12 @@ TEST_F(ChunkStatsWriterTest, uncompressedSizeRoundtrip) {
       MetadataBuffer::decompress(
           std::move(rootBuffer), CompressionType::Uncompressed, pool_.get()))};
 
-  auto chunkIndex = index::ChunkStats::create(std::move(rootSection));
-  ASSERT_NE(chunkIndex, nullptr);
-  ASSERT_EQ(chunkIndex->numGroups(), 2);
+  auto chunkStats = index::ChunkStats::create(std::move(rootSection));
+  ASSERT_NE(chunkStats, nullptr);
+  ASSERT_EQ(chunkStats->numGroups(), 2);
 
   for (uint32_t i = 0; i < 2; ++i) {
-    const auto& section = chunkIndex->groupMetadata(i);
+    const auto& section = chunkStats->groupMetadata(i);
     EXPECT_EQ(section.compressionType(), CompressionType::Zstd)
         << "Group " << i;
     EXPECT_TRUE(section.uncompressedSize().has_value()) << "Group " << i;
@@ -698,16 +697,16 @@ TEST_F(ChunkStatsWriterTest, missingUncompressedSizeBackwardCompat) {
       MetadataBuffer::decompress(
           std::move(rootBuffer), CompressionType::Uncompressed, pool_.get()))};
 
-  auto chunkIndex = index::ChunkStats::create(std::move(rootSection));
-  ASSERT_NE(chunkIndex, nullptr);
-  ASSERT_EQ(chunkIndex->numGroups(), 2);
+  auto chunkStats = index::ChunkStats::create(std::move(rootSection));
+  ASSERT_NE(chunkStats, nullptr);
+  ASSERT_EQ(chunkStats->numGroups(), 2);
 
-  const auto& zstdSection = chunkIndex->groupMetadata(0);
+  const auto& zstdSection = chunkStats->groupMetadata(0);
   EXPECT_EQ(zstdSection.compressionType(), CompressionType::Zstd);
   EXPECT_FALSE(zstdSection.uncompressedSize().has_value());
   EXPECT_EQ(zstdSection.size(), 200);
 
-  const auto& uncompressedSection = chunkIndex->groupMetadata(1);
+  const auto& uncompressedSection = chunkStats->groupMetadata(1);
   EXPECT_EQ(
       uncompressedSection.compressionType(), CompressionType::Uncompressed);
   EXPECT_FALSE(uncompressedSection.uncompressedSize().has_value());
@@ -752,11 +751,11 @@ TEST_F(ChunkStatsWriterTest, uncompressedSizeForUncompressedSections) {
       MetadataBuffer::decompress(
           std::move(rootBuffer), CompressionType::Uncompressed, pool_.get()))};
 
-  auto chunkIndex = index::ChunkStats::create(std::move(rootSection));
-  ASSERT_NE(chunkIndex, nullptr);
-  ASSERT_EQ(chunkIndex->numGroups(), 1);
+  auto chunkStats = index::ChunkStats::create(std::move(rootSection));
+  ASSERT_NE(chunkStats, nullptr);
+  ASSERT_EQ(chunkStats->numGroups(), 1);
 
-  const auto& section = chunkIndex->groupMetadata(0);
+  const auto& section = chunkStats->groupMetadata(0);
   EXPECT_EQ(section.compressionType(), CompressionType::Uncompressed);
   EXPECT_TRUE(section.uncompressedSize().has_value());
   EXPECT_EQ(section.uncompressedSize().value(), section.size());

--- a/dwio/nimble/tablet/tests/ClusterIndexWriterTest.cpp
+++ b/dwio/nimble/tablet/tests/ClusterIndexWriterTest.cpp
@@ -55,9 +55,9 @@ struct TestFileIndex {
   std::vector<std::string> groupMetadataSections;
   // Root index data written via writeRootIndexCallback().
   std::string rootIndexData;
-  // Chunk index metadata sections for each stripe group.
-  std::vector<std::string> chunkIndexGroupSections;
-  // Root chunk index data written via writeChunkRootIndexCallback().
+  // Chunk stats metadata sections for each stripe group.
+  std::vector<std::string> chunkStatsGroupSections;
+  // Root chunk stats data written via writeChunkRootIndexCallback().
   std::string chunkRootIndexData;
 };
 
@@ -69,7 +69,7 @@ class ClusterIndexWriterTest : public ::testing::Test {
 
   void SetUp() override {
     pool_ = velox::memory::memoryManager()->addLeafPool();
-    chunkIndexWriter_ = std::make_unique<ChunkStatsWriter>(*pool_, 0);
+    chunkStatsWriter_ = std::make_unique<ChunkStatsWriter>(*pool_, 0);
   }
 
   // Returns a callback that appends key stream data to TestFileIndex.
@@ -95,10 +95,10 @@ class ClusterIndexWriterTest : public ::testing::Test {
     };
   }
 
-  // Returns a callback that stores chunk index metadata sections.
+  // Returns a callback that stores chunk stats metadata sections.
   static auto createChunkMetadataSectionCallback(TestFileIndex& fileIndex) {
     return [&fileIndex](std::string_view metadata) -> MetadataSection {
-      fileIndex.chunkIndexGroupSections.emplace_back(metadata);
+      fileIndex.chunkStatsGroupSections.emplace_back(metadata);
       return MetadataSection(0, metadata.size(), CompressionType::Uncompressed);
     };
   }
@@ -112,7 +112,7 @@ class ClusterIndexWriterTest : public ::testing::Test {
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
-  std::unique_ptr<ChunkStatsWriter> chunkIndexWriter_;
+  std::unique_ptr<ChunkStatsWriter> chunkStatsWriter_;
 };
 
 TEST_F(ClusterIndexWriterTest, basic) {
@@ -189,19 +189,19 @@ TEST_F(ClusterIndexWriterTest, stripeKeyEnforcementValidation) {
     auto writer = ClusterIndexWriter::create(config, *pool_);
 
     // Multi-row first stripe with equal keys - pass (no checks)
-    chunkIndexWriter_->newStripe(1);
+    chunkStatsWriter_->newStripe(1);
     writer->newStripe();
     EXPECT_NO_THROW(
         writer->addStripeKey(createKeyStream(buffer, {{5, "aaa", "aaa"}})));
 
     // Duplicate key - pass (no checks)
-    chunkIndexWriter_->newStripe(1);
+    chunkStatsWriter_->newStripe(1);
     writer->newStripe();
     EXPECT_NO_THROW(
         writer->addStripeKey(createKeyStream(buffer, {{1, "aaa", "aaa"}})));
 
     // Out of order key - pass (no checks)
-    chunkIndexWriter_->newStripe(1);
+    chunkStatsWriter_->newStripe(1);
     writer->newStripe();
     EXPECT_NO_THROW(
         writer->addStripeKey(createKeyStream(buffer, {{1, "000", "000"}})));
@@ -219,19 +219,19 @@ TEST_F(ClusterIndexWriterTest, stripeKeyEnforcementValidation) {
     auto writer = ClusterIndexWriter::create(config, *pool_);
 
     // Multi-row first stripe with equal keys - pass (duplicates allowed)
-    chunkIndexWriter_->newStripe(1);
+    chunkStatsWriter_->newStripe(1);
     writer->newStripe();
     EXPECT_NO_THROW(
         writer->addStripeKey(createKeyStream(buffer, {{5, "aaa", "aaa"}})));
 
     // Duplicate key - pass (duplicates allowed)
-    chunkIndexWriter_->newStripe(1);
+    chunkStatsWriter_->newStripe(1);
     writer->newStripe();
     EXPECT_NO_THROW(
         writer->addStripeKey(createKeyStream(buffer, {{1, "aaa", "aaa"}})));
 
     // Out of order key - fail
-    chunkIndexWriter_->newStripe(1);
+    chunkStatsWriter_->newStripe(1);
     writer->newStripe();
     NIMBLE_ASSERT_USER_THROW(
         writer->addStripeKey(createKeyStream(buffer, {{1, "000", "000"}})),
@@ -250,19 +250,19 @@ TEST_F(ClusterIndexWriterTest, stripeKeyEnforcementValidation) {
     auto writer = ClusterIndexWriter::create(config, *pool_);
 
     // Single-row first stripe with equal keys - pass
-    chunkIndexWriter_->newStripe(1);
+    chunkStatsWriter_->newStripe(1);
     writer->newStripe();
     EXPECT_NO_THROW(
         writer->addStripeKey(createKeyStream(buffer, {{1, "aaa", "aaa"}})));
 
     // Duplicate key - pass (duplicates allowed)
-    chunkIndexWriter_->newStripe(1);
+    chunkStatsWriter_->newStripe(1);
     writer->newStripe();
     EXPECT_NO_THROW(
         writer->addStripeKey(createKeyStream(buffer, {{1, "aaa", "aaa"}})));
 
     // Out of order key - fail
-    chunkIndexWriter_->newStripe(1);
+    chunkStatsWriter_->newStripe(1);
     writer->newStripe();
     NIMBLE_ASSERT_USER_THROW(
         writer->addStripeKey(createKeyStream(buffer, {{1, "000", "000"}})),
@@ -282,7 +282,7 @@ TEST_F(ClusterIndexWriterTest, stripeKeyEnforcementValidation) {
     // Multi-row first stripe with equal keys - fail (implies duplicates)
     {
       auto writer = ClusterIndexWriter::create(config, *pool_);
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       NIMBLE_ASSERT_USER_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{5, "aaa", "aaa"}})),
@@ -292,20 +292,20 @@ TEST_F(ClusterIndexWriterTest, stripeKeyEnforcementValidation) {
     // Multi-row first stripe with strictly ascending keys - pass
     {
       auto writer = ClusterIndexWriter::create(config, *pool_);
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       EXPECT_NO_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{5, "aaa", "bbb"}})));
 
       // Strictly greater key across stripes - pass
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       EXPECT_NO_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{5, "ccc", "ddd"}})));
 
       // Duplicate key across stripes (lastKey of prev stripe == lastKey of new
       // stripe) - fail
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       NIMBLE_ASSERT_USER_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{5, "ddd", "ddd"}})),
@@ -315,12 +315,12 @@ TEST_F(ClusterIndexWriterTest, stripeKeyEnforcementValidation) {
     // Out of order key across stripes - fail
     {
       auto writer = ClusterIndexWriter::create(config, *pool_);
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       EXPECT_NO_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{5, "bbb", "ccc"}})));
 
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       NIMBLE_ASSERT_USER_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{5, "aaa", "aab"}})),
@@ -343,17 +343,17 @@ TEST_F(ClusterIndexWriterTest, stripeKeyEnforcementValidation) {
     // Then duplicate key - fail
     {
       auto writer = ClusterIndexWriter::create(config, *pool_);
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       EXPECT_NO_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{1, "aaa", "aaa"}})));
 
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       EXPECT_NO_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{1, "bbb", "bbb"}})));
 
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       NIMBLE_ASSERT_USER_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{1, "bbb", "bbb"}})),
@@ -363,12 +363,12 @@ TEST_F(ClusterIndexWriterTest, stripeKeyEnforcementValidation) {
     // Single-row first stripe, then out of order key - fail
     {
       auto writer = ClusterIndexWriter::create(config, *pool_);
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       EXPECT_NO_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{1, "ccc", "ccc"}})));
 
-      chunkIndexWriter_->newStripe(1);
+      chunkStatsWriter_->newStripe(1);
       writer->newStripe();
       NIMBLE_ASSERT_USER_THROW(
           writer->addStripeKey(createKeyStream(buffer, {{1, "aaa", "aaa"}})),
@@ -386,7 +386,7 @@ TEST_F(ClusterIndexWriterTest, checkNotFinalizedAfterWriteRootIndex) {
 
   Buffer buffer{*pool_};
   TestFileIndex fileIndex;
-  chunkIndexWriter_->newStripe(2);
+  chunkStatsWriter_->newStripe(2);
   writer->newStripe();
 
   auto keyStream = createKeyStream(buffer, {{100, "aaa", "bbb"}});
@@ -395,7 +395,7 @@ TEST_F(ClusterIndexWriterTest, checkNotFinalizedAfterWriteRootIndex) {
   writer->writeKeyStream(0, keyStream.chunks, writeStreamCallback(fileIndex));
 
   auto chunks = createChunks(buffer, {{100, 20}});
-  chunkIndexWriter_->addStream(0, chunks);
+  chunkStatsWriter_->addStream(0, chunks);
 
   // Write root index - this finalizes the writer
   writer->writeRoot({0}, writeRootIndexCallback(fileIndex));
@@ -439,7 +439,7 @@ TEST_F(ClusterIndexWriterTest, emptyStreamInStripe) {
 
   Buffer buffer{*pool_};
   TestFileIndex fileIndex;
-  chunkIndexWriter_->newStripe(3);
+  chunkStatsWriter_->newStripe(3);
   writer->newStripe();
 
   auto keyStream = createKeyStream(buffer, {{100, "aaa", "bbb"}});
@@ -449,17 +449,17 @@ TEST_F(ClusterIndexWriterTest, emptyStreamInStripe) {
 
   // Stream 0 has data
   auto chunks0 = createChunks(buffer, {{50, 10}, {50, 12}});
-  chunkIndexWriter_->addStream(0, chunks0);
+  chunkStatsWriter_->addStream(0, chunks0);
 
   // Stream 1 is empty (no addStreamIndex call)
 
   // Stream 2 has data
   auto chunks2 = createChunks(buffer, {{100, 25}});
-  chunkIndexWriter_->addStream(2, chunks2);
+  chunkStatsWriter_->addStream(2, chunks2);
 
   EXPECT_NO_THROW(
       writer->writeGroup(1, createMetadataSectionCallback(fileIndex)));
-  chunkIndexWriter_->writeGroup(
+  chunkStatsWriter_->writeGroup(
       3, 1, createChunkMetadataSectionCallback(fileIndex));
   EXPECT_EQ(fileIndex.groupMetadataSections.size(), 1);
 }
@@ -489,7 +489,7 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithSingleGroup) {
   // Stream 1: 2 chunks (rows: 60, 40)
   // Key stream: 2 chunks (rows: 50, 50), keys: "aaa"->"bbb", "bbb"->"ccc"
   {
-    chunkIndexWriter_->newStripe(2);
+    chunkStatsWriter_->newStripe(2);
     writer->newStripe();
     auto keyStream = createKeyStream(
         buffer,
@@ -505,8 +505,8 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithSingleGroup) {
 
     auto chunks0 = createChunks(buffer, {{30, 10}, {45, 15}, {25, 8}});
     auto chunks1 = createChunks(buffer, {{60, 20}, {40, 12}});
-    chunkIndexWriter_->addStream(0, chunks0);
-    chunkIndexWriter_->addStream(1, chunks1);
+    chunkStatsWriter_->addStream(0, chunks0);
+    chunkStatsWriter_->addStream(1, chunks1);
   }
 
   // ========== Stripe 1 ==========
@@ -516,7 +516,7 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithSingleGroup) {
   // Key stream: 4 chunks (rows: 50, 50, 50, 50), keys: "ccc"->"ddd",
   // "ddd"->"eee", "eee"->"fff", "fff"->"ggg"
   {
-    chunkIndexWriter_->newStripe(2);
+    chunkStatsWriter_->newStripe(2);
     writer->newStripe();
     auto keyStream = createKeyStream(
         buffer,
@@ -534,8 +534,8 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithSingleGroup) {
 
     auto chunks0 = createChunks(buffer, {{40, 5}, {55, 18}, {65, 22}, {40, 7}});
     auto chunks1 = createChunks(buffer, {{200, 50}});
-    chunkIndexWriter_->addStream(0, chunks0);
-    chunkIndexWriter_->addStream(1, chunks1);
+    chunkStatsWriter_->addStream(0, chunks0);
+    chunkStatsWriter_->addStream(1, chunks1);
   }
 
   // ========== Stripe 2 ==========
@@ -544,7 +544,7 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithSingleGroup) {
   // Stream 1: 5 chunks (rows: 20, 35, 40, 25, 30)
   // Key stream: 1 chunk (rows: 150), keys: "ggg"->"hhh"
   {
-    chunkIndexWriter_->newStripe(2);
+    chunkStatsWriter_->newStripe(2);
     writer->newStripe();
     auto keyStream = createKeyStream(
         buffer,
@@ -560,18 +560,18 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithSingleGroup) {
     auto chunks0 = createChunks(buffer, {{100, 30}, {50, 14}});
     auto chunks1 =
         createChunks(buffer, {{20, 6}, {35, 9}, {40, 11}, {25, 4}, {30, 16}});
-    chunkIndexWriter_->addStream(0, chunks0);
-    chunkIndexWriter_->addStream(1, chunks1);
+    chunkStatsWriter_->addStream(0, chunks0);
+    chunkStatsWriter_->addStream(1, chunks1);
   }
 
   // Write single index group containing all 3 stripes
   writer->writeGroup(3, createMetadataSectionCallback(fileIndex));
-  chunkIndexWriter_->writeGroup(
+  chunkStatsWriter_->writeGroup(
       2, 3, createChunkMetadataSectionCallback(fileIndex));
 
   // Write root index with all stripes in group 0
   writer->writeRoot({0, 0, 0}, writeRootIndexCallback(fileIndex));
-  chunkIndexWriter_->writeRoot(writeChunkRootIndexCallback(fileIndex));
+  chunkStatsWriter_->writeRoot(writeChunkRootIndexCallback(fileIndex));
 
   // ========== Verify written data ==========
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 1);
@@ -669,14 +669,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithSingleGroup) {
 
   // Verify chunk index for stream position data
   {
-    auto chunkIndex = index::ChunkStatsGroup::create(
+    auto chunkStats = index::ChunkStatsGroup::create(
         0,
         3,
         std::make_unique<MetadataBuffer>(
             *pool_,
-            fileIndex.chunkIndexGroupSections[0],
+            fileIndex.chunkStatsGroupSections[0],
             CompressionType::Uncompressed));
-    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkStats.get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify stream 0 position index stats
@@ -748,7 +748,7 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
   // Stream 1: 3 chunks (rows: 30, 40, 30)
   // Key stream: 2 chunks (rows: 50, 50), keys: "aaa"->"bbb", "bbb"->"ccc"
   {
-    chunkIndexWriter_->newStripe(2);
+    chunkStatsWriter_->newStripe(2);
     writer->newStripe();
     auto keyStream = createKeyStream(
         buffer,
@@ -764,10 +764,10 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
 
     auto chunks0 = createChunks(buffer, {{50, 10}, {50, 12}});
     auto chunks1 = createChunks(buffer, {{30, 8}, {40, 10}, {30, 6}});
-    chunkIndexWriter_->addStream(0, chunks0);
-    chunkIndexWriter_->addStream(1, chunks1);
+    chunkStatsWriter_->addStream(0, chunks0);
+    chunkStatsWriter_->addStream(1, chunks1);
     writer->writeGroup(1, createMetadataSectionCallback(fileIndex));
-    chunkIndexWriter_->writeGroup(
+    chunkStatsWriter_->writeGroup(
         2, 1, createChunkMetadataSectionCallback(fileIndex));
   }
 
@@ -778,7 +778,7 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
   // Key stream: 3 chunks (rows: 50, 50, 50), keys: "ccc"->"ddd", "ddd"->"eee",
   // "eee"->"fff"
   {
-    chunkIndexWriter_->newStripe(2);
+    chunkStatsWriter_->newStripe(2);
     writer->newStripe();
     auto keyStream = createKeyStream(
         buffer,
@@ -795,10 +795,10 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
 
     auto chunks0 = createChunks(buffer, {{40, 8}, {60, 14}, {50, 11}});
     auto chunks1 = createChunks(buffer, {{80, 18}, {70, 15}});
-    chunkIndexWriter_->addStream(0, chunks0);
-    chunkIndexWriter_->addStream(1, chunks1);
+    chunkStatsWriter_->addStream(0, chunks0);
+    chunkStatsWriter_->addStream(1, chunks1);
     writer->writeGroup(1, createMetadataSectionCallback(fileIndex));
-    chunkIndexWriter_->writeGroup(
+    chunkStatsWriter_->writeGroup(
         2, 1, createChunkMetadataSectionCallback(fileIndex));
   }
 
@@ -808,7 +808,7 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
   // Stream 1: 4 chunks (rows: 25, 35, 30, 30)
   // Key stream: 2 chunks (rows: 60, 60), keys: "fff"->"ggg", "ggg"->"hhh"
   {
-    chunkIndexWriter_->newStripe(2);
+    chunkStatsWriter_->newStripe(2);
     writer->newStripe();
     auto keyStream = createKeyStream(
         buffer,
@@ -824,16 +824,16 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
 
     auto chunks0 = createChunks(buffer, {{70, 16}, {50, 13}});
     auto chunks1 = createChunks(buffer, {{25, 5}, {35, 7}, {30, 6}, {30, 8}});
-    chunkIndexWriter_->addStream(0, chunks0);
-    chunkIndexWriter_->addStream(1, chunks1);
+    chunkStatsWriter_->addStream(0, chunks0);
+    chunkStatsWriter_->addStream(1, chunks1);
     writer->writeGroup(1, createMetadataSectionCallback(fileIndex));
-    chunkIndexWriter_->writeGroup(
+    chunkStatsWriter_->writeGroup(
         2, 1, createChunkMetadataSectionCallback(fileIndex));
   }
 
   // Write root index with stripe group indices {0, 1, 2}
   writer->writeRoot({0, 1, 2}, writeRootIndexCallback(fileIndex));
-  chunkIndexWriter_->writeRoot(writeChunkRootIndexCallback(fileIndex));
+  chunkStatsWriter_->writeRoot(writeChunkRootIndexCallback(fileIndex));
 
   // ========== Verify written data ==========
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 3);
@@ -907,14 +907,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
     EXPECT_EQ(keyStats.chunkKeys, (std::vector<std::string>{"bbb", "ccc"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkStatsGroup::create(
+    auto chunkStats = index::ChunkStatsGroup::create(
         0,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
-            fileIndex.chunkIndexGroupSections[0],
+            fileIndex.chunkStatsGroupSections[0],
             CompressionType::Uncompressed));
-    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkStats.get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify stream 0 stats: 2 chunks (rows: 50, 50)
@@ -950,14 +950,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
         keyStats.chunkKeys, (std::vector<std::string>{"ddd", "eee", "fff"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkStatsGroup::create(
+    auto chunkStats = index::ChunkStatsGroup::create(
         1,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
-            fileIndex.chunkIndexGroupSections[1],
+            fileIndex.chunkStatsGroupSections[1],
             CompressionType::Uncompressed));
-    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkStats.get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify stream 0 stats: 3 chunks (rows: 40, 60, 50)
@@ -992,14 +992,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroups) {
     EXPECT_EQ(keyStats.chunkKeys, (std::vector<std::string>{"ggg", "hhh"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkStatsGroup::create(
+    auto chunkStats = index::ChunkStatsGroup::create(
         2,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
-            fileIndex.chunkIndexGroupSections[2],
+            fileIndex.chunkStatsGroupSections[2],
             CompressionType::Uncompressed));
-    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkStats.get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify stream 0 stats: 2 chunks (rows: 70, 50)
@@ -1043,7 +1043,7 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
   // Stream 3: 2 chunks (rows: 60, 40)
   // Key stream: 2 chunks (rows: 50, 50), keys: "aaa"->"bbb", "bbb"->"ccc"
   {
-    chunkIndexWriter_->newStripe(4);
+    chunkStatsWriter_->newStripe(4);
     writer->newStripe();
     auto keyStream = createKeyStream(
         buffer,
@@ -1061,11 +1061,11 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
     auto chunks1 = createChunks(buffer, {{50, 10}, {50, 12}});
     auto chunks2 = createChunks(buffer, {{30, 8}, {40, 10}, {30, 6}});
     auto chunks3 = createChunks(buffer, {{60, 15}, {40, 10}});
-    chunkIndexWriter_->addStream(1, chunks1);
-    chunkIndexWriter_->addStream(2, chunks2);
-    chunkIndexWriter_->addStream(3, chunks3);
+    chunkStatsWriter_->addStream(1, chunks1);
+    chunkStatsWriter_->addStream(2, chunks2);
+    chunkStatsWriter_->addStream(3, chunks3);
     writer->writeGroup(1, createMetadataSectionCallback(fileIndex));
-    chunkIndexWriter_->writeGroup(
+    chunkStatsWriter_->writeGroup(
         4, 1, createChunkMetadataSectionCallback(fileIndex));
   }
 
@@ -1078,7 +1078,7 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
   // Key stream: 3 chunks (rows: 50, 50, 50), keys: "ccc"->"ddd", "ddd"->"eee",
   // "eee"->"fff"
   {
-    chunkIndexWriter_->newStripe(4);
+    chunkStatsWriter_->newStripe(4);
     writer->newStripe();
     auto keyStream = createKeyStream(
         buffer,
@@ -1097,11 +1097,11 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
     // Stream 1 is empty - no addStreamIndex call
     auto chunks2 = createChunks(buffer, {{80, 18}, {70, 15}});
     auto chunks3 = createChunks(buffer, {{150, 30}});
-    chunkIndexWriter_->addStream(0, chunks0);
-    chunkIndexWriter_->addStream(2, chunks2);
-    chunkIndexWriter_->addStream(3, chunks3);
+    chunkStatsWriter_->addStream(0, chunks0);
+    chunkStatsWriter_->addStream(2, chunks2);
+    chunkStatsWriter_->addStream(3, chunks3);
     writer->writeGroup(1, createMetadataSectionCallback(fileIndex));
-    chunkIndexWriter_->writeGroup(
+    chunkStatsWriter_->writeGroup(
         4, 1, createChunkMetadataSectionCallback(fileIndex));
   }
 
@@ -1113,7 +1113,7 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
   // Stream 3: 3 chunks (rows: 40, 40, 40)
   // Key stream: 2 chunks (rows: 60, 60), keys: "fff"->"ggg", "ggg"->"hhh"
   {
-    chunkIndexWriter_->newStripe(4);
+    chunkStatsWriter_->newStripe(4);
     writer->newStripe();
     auto keyStream = createKeyStream(
         buffer,
@@ -1131,11 +1131,11 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
     auto chunks1 = createChunks(buffer, {{25, 5}, {35, 7}, {30, 6}, {30, 8}});
     // Stream 2 is empty - no addStreamIndex call
     auto chunks3 = createChunks(buffer, {{40, 10}, {40, 10}, {40, 10}});
-    chunkIndexWriter_->addStream(0, chunks0);
-    chunkIndexWriter_->addStream(1, chunks1);
-    chunkIndexWriter_->addStream(3, chunks3);
+    chunkStatsWriter_->addStream(0, chunks0);
+    chunkStatsWriter_->addStream(1, chunks1);
+    chunkStatsWriter_->addStream(3, chunks3);
     writer->writeGroup(1, createMetadataSectionCallback(fileIndex));
-    chunkIndexWriter_->writeGroup(
+    chunkStatsWriter_->writeGroup(
         4, 1, createChunkMetadataSectionCallback(fileIndex));
   }
 
@@ -1147,7 +1147,7 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
   // Stream 3: 2 chunks (rows: 30, 70)
   // Key stream: 2 chunks (rows: 50, 50), keys: "hhh"->"iii", "iii"->"jjj"
   {
-    chunkIndexWriter_->newStripe(4);
+    chunkStatsWriter_->newStripe(4);
     writer->newStripe();
     auto keyStream = createKeyStream(
         buffer,
@@ -1165,18 +1165,18 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
     auto chunks1 = createChunks(buffer, {{40, 10}, {60, 14}});
     auto chunks2 = createChunks(buffer, {{100, 25}});
     auto chunks3 = createChunks(buffer, {{30, 8}, {70, 18}});
-    chunkIndexWriter_->addStream(0, chunks0);
-    chunkIndexWriter_->addStream(1, chunks1);
-    chunkIndexWriter_->addStream(2, chunks2);
-    chunkIndexWriter_->addStream(3, chunks3);
+    chunkStatsWriter_->addStream(0, chunks0);
+    chunkStatsWriter_->addStream(1, chunks1);
+    chunkStatsWriter_->addStream(2, chunks2);
+    chunkStatsWriter_->addStream(3, chunks3);
     writer->writeGroup(1, createMetadataSectionCallback(fileIndex));
-    chunkIndexWriter_->writeGroup(
+    chunkStatsWriter_->writeGroup(
         4, 1, createChunkMetadataSectionCallback(fileIndex));
   }
 
   // Write root index with stripe group indices {0, 1, 2, 3}
   writer->writeRoot({0, 1, 2, 3}, writeRootIndexCallback(fileIndex));
-  chunkIndexWriter_->writeRoot(writeChunkRootIndexCallback(fileIndex));
+  chunkStatsWriter_->writeRoot(writeChunkRootIndexCallback(fileIndex));
 
   // ========== Verify written data ==========
   ASSERT_EQ(fileIndex.groupMetadataSections.size(), 4);
@@ -1230,14 +1230,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
     EXPECT_EQ(keyStats.chunkKeys, (std::vector<std::string>{"bbb", "ccc"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkStatsGroup::create(
+    auto chunkStats = index::ChunkStatsGroup::create(
         0,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
-            fileIndex.chunkIndexGroupSections[0],
+            fileIndex.chunkStatsGroupSections[0],
             CompressionType::Uncompressed));
-    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkStats.get());
     // All 4 streams indexed (minAvgChunksPerStream = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
@@ -1288,14 +1288,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
         keyStats.chunkKeys, (std::vector<std::string>{"ddd", "eee", "fff"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkStatsGroup::create(
+    auto chunkStats = index::ChunkStatsGroup::create(
         1,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
-            fileIndex.chunkIndexGroupSections[1],
+            fileIndex.chunkStatsGroupSections[1],
             CompressionType::Uncompressed));
-    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkStats.get());
     // All 4 streams indexed (minAvgChunksPerStream = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
@@ -1345,14 +1345,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
     EXPECT_EQ(keyStats.chunkKeys, (std::vector<std::string>{"ggg", "hhh"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkStatsGroup::create(
+    auto chunkStats = index::ChunkStatsGroup::create(
         2,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
-            fileIndex.chunkIndexGroupSections[2],
+            fileIndex.chunkStatsGroupSections[2],
             CompressionType::Uncompressed));
-    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkStats.get());
     // All 4 streams indexed (minAvgChunksPerStream = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
@@ -1402,14 +1402,14 @@ TEST_F(ClusterIndexWriterTest, writeAndReadWithMultipleGroupsAndEmptyStream) {
     EXPECT_EQ(keyStats.chunkKeys, (std::vector<std::string>{"iii", "jjj"}));
 
     // Verify chunk index for stream position data
-    auto chunkIndex = index::ChunkStatsGroup::create(
+    auto chunkStats = index::ChunkStatsGroup::create(
         3,
         1,
         std::make_unique<MetadataBuffer>(
             *pool_,
-            fileIndex.chunkIndexGroupSections[3],
+            fileIndex.chunkStatsGroupSections[3],
             CompressionType::Uncompressed));
-    ChunkStatsTestHelper chunkHelper(chunkIndex.get());
+    ChunkStatsTestHelper chunkHelper(chunkStats.get());
     // All 4 streams indexed (minAvgChunksPerStream = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
@@ -1497,37 +1497,37 @@ TEST_F(ClusterIndexWriterTest, chunkIndexOnlyWriteAndRead) {
   Buffer buffer{*pool_};
 
   // Stripe 0: 2 streams
-  chunkIndexWriter_->newStripe(2);
+  chunkStatsWriter_->newStripe(2);
   auto chunks0 = createChunks(buffer, {{50, 10}, {50, 12}});
-  chunkIndexWriter_->addStream(0, chunks0);
+  chunkStatsWriter_->addStream(0, chunks0);
   auto chunks1 = createChunks(buffer, {{100, 25}});
-  chunkIndexWriter_->addStream(1, chunks1);
+  chunkStatsWriter_->addStream(1, chunks1);
 
   // Write standalone index group (chunk index only, no value index).
-  chunkIndexWriter_->writeGroup(
+  chunkStatsWriter_->writeGroup(
       2, 1, createChunkMetadataSectionCallback(fileIndex));
 
   // Write standalone root index (no stripe keys, no index columns).
-  chunkIndexWriter_->writeRoot(writeChunkRootIndexCallback(fileIndex));
+  chunkStatsWriter_->writeRoot(writeChunkRootIndexCallback(fileIndex));
 
   // Verify data was written.
-  ASSERT_EQ(fileIndex.chunkIndexGroupSections.size(), 1);
+  ASSERT_EQ(fileIndex.chunkStatsGroupSections.size(), 1);
   ASSERT_FALSE(fileIndex.chunkRootIndexData.empty());
 
   // Verify ChunkStatsGroup can be loaded and used for chunk seeking.
-  auto chunkIndex = index::ChunkStatsGroup::create(
+  auto chunkStats = index::ChunkStatsGroup::create(
       0,
       1,
       std::make_unique<MetadataBuffer>(
           *pool_,
-          fileIndex.chunkIndexGroupSections[0],
+          fileIndex.chunkStatsGroupSections[0],
           CompressionType::Uncompressed));
 
   // Lookup via StreamIndex (public API).
   // Stream 0: chunks at rows {50, 50} -> accumulated {50, 100}
   // Stream 0: 2 chunks of {50 rows, 10 bytes} and {50 rows, 12 bytes}.
   // Total stream size = 10 + 12 = 22.
-  auto stream0 = chunkIndex->createStreamIndex(0, 0, 22);
+  auto stream0 = chunkStats->createStreamIndex(0, 0, 22);
   ASSERT_NE(stream0, nullptr);
 
   auto result00 = stream0->lookupChunk(0);
@@ -1541,7 +1541,7 @@ TEST_F(ClusterIndexWriterTest, chunkIndexOnlyWriteAndRead) {
   EXPECT_EQ(result01.rowOffset, 50);
 
   // Stream 1: 1 chunk → createStreamIndex returns nullptr.
-  EXPECT_EQ(chunkIndex->createStreamIndex(0, 1, 25), nullptr);
+  EXPECT_EQ(chunkStats->createStreamIndex(0, 1, 25), nullptr);
 }
 
 } // namespace facebook::nimble::test

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -1817,10 +1817,10 @@ class TabletWithIndexTest : public TabletTest {
 
     const uint32_t streamSize = tablet.streamSize(stripeIdentifier, streamId);
 
-    // Calculate stripe offset within the chunk index group.
+    // Calculate stripe offset within the chunk stats group.
     // Use the ChunkStatsTestHelper to get the first stripe of the group.
     nimble::index::test::ChunkStatsTestHelper chunkHelper(
-        stripeIdentifier.chunkIndex().get());
+        stripeIdentifier.chunkStats().get());
     const uint32_t stripeOffsetInGroup = stripeIdx - chunkHelper.firstStripe();
 
     // streamStats.chunkCounts now contains accumulated chunk counts for this
@@ -2120,7 +2120,7 @@ TEST_P(TabletWithIndexTest, singleGroup) {
 
   // Verify only one index group is created
   EXPECT_EQ(index->layout().numPartitions, 1);
-  // Verify the first group, index group, and chunk index group is pinned
+  // Verify the first group, index group, and chunk stats group is pinned
   // and is the only one (covered by footer IO).
   EXPECT_TRUE(tabletHelper.hasOnlyFirstStripeGroupCached());
   EXPECT_TRUE(tabletHelper.hasOnlyFirstChunkStatsGroupCached());
@@ -2219,7 +2219,7 @@ TEST_P(TabletWithIndexTest, singleGroup) {
         tablet->clusterIndex());
 
     nimble::index::test::ChunkStatsTestHelper chunkHelper(
-        stripeIdWithIndex.chunkIndex().get());
+        stripeIdWithIndex.chunkStats().get());
     // We have 2 streams per stripe
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
@@ -2297,7 +2297,7 @@ TEST_P(TabletWithIndexTest, singleGroup) {
     for (uint32_t stripeIdx = 0; stripeIdx < 3; ++stripeIdx) {
       auto stripeId = tablet->stripeIdentifier(stripeIdx);
       nimble::index::test::ChunkStatsTestHelper chunkHelper(
-          stripeId.chunkIndex().get());
+          stripeId.chunkStats().get());
       for (uint32_t streamId = 0; streamId < 2; ++streamId) {
         auto streamStats = chunkHelper.streamStats(streamId);
         verifyStreamChunkStats(*tablet, stripeIdx, streamId, streamStats);
@@ -2571,7 +2571,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
           {"i", std::nullopt},
       });
 
-  // Verify partition stats and chunk index structure for each group
+  // Verify partition stats and chunk stats structure for each group
   nimble::index::test::ClusterIndexTestHelper clusterIndexTestHelper(
       tablet->clusterIndex());
 
@@ -2580,7 +2580,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
     auto stripeId = tablet->stripeIdentifier(0);
 
     nimble::index::test::ChunkStatsTestHelper chunkHelper(
-        stripeId.chunkIndex().get());
+        stripeId.chunkStats().get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify partition stats for group 0
@@ -2604,7 +2604,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
     auto stripeId = tablet->stripeIdentifier(1);
 
     nimble::index::test::ChunkStatsTestHelper chunkHelper(
-        stripeId.chunkIndex().get());
+        stripeId.chunkStats().get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify partition stats for group 1
@@ -2631,7 +2631,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
     auto stripeId = tablet->stripeIdentifier(2);
 
     nimble::index::test::ChunkStatsTestHelper chunkHelper(
-        stripeId.chunkIndex().get());
+        stripeId.chunkStats().get());
     EXPECT_EQ(chunkHelper.streamCount(), 2);
 
     // Verify partition stats for group 2
@@ -2659,7 +2659,7 @@ TEST_P(TabletWithIndexTest, multipleGroups) {
     for (uint32_t stripeIdx = 0; stripeIdx < 3; ++stripeIdx) {
       auto stripeId = tablet->stripeIdentifier(stripeIdx);
       nimble::index::test::ChunkStatsTestHelper chunkHelper(
-          stripeId.chunkIndex().get());
+          stripeId.chunkStats().get());
       for (uint32_t streamId = 0; streamId < 2; ++streamId) {
         auto streamStats = chunkHelper.streamStats(streamId);
         verifyStreamChunkStats(*tablet, stripeIdx, streamId, streamStats);
@@ -2956,7 +2956,7 @@ TEST_P(TabletWithIndexTest, singleGroupWithEmptyStream) {
   auto stripeId = tablet->stripeIdentifier(0);
 
   nimble::index::test::ChunkStatsTestHelper chunkHelper(
-      stripeId.chunkIndex().get());
+      stripeId.chunkStats().get());
   EXPECT_EQ(chunkHelper.streamCount(), 4);
 
   // Verify stream 0 position index stats (empty in stripe 0)
@@ -3172,9 +3172,9 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
           .metadataFlushThreshold = 0,
           .streamDeduplicationEnabled = false,
           .enableChunkIndex = true,
-          // Disable chunk index skipping so all groups get a chunk index,
+          // Disable chunk stats skipping so all groups get chunk stats,
           // even when empty streams reduce the average chunks per stream.
-          .chunkIndexMinAvgChunks = 0,
+          .chunkStatsMinAvgChunks = 0,
           .stripeGroupFlushCallback =
               indexHelper.createStripeGroupFlushCallback(),
           .closeCallback = indexHelper.createCloseCallback(),
@@ -3411,8 +3411,8 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
     auto stripeId = tablet->stripeIdentifier(0);
 
     nimble::index::test::ChunkStatsTestHelper chunkHelper(
-        stripeId.chunkIndex().get());
-    // All 4 streams indexed (chunkIndexMinAvgChunks = 0).
+        stripeId.chunkStats().get());
+    // All 4 streams indexed (chunkStatsMinAvgChunks = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
     // Verify partition stats for group 0
@@ -3450,8 +3450,8 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
     auto stripeId = tablet->stripeIdentifier(1);
 
     nimble::index::test::ChunkStatsTestHelper chunkHelper(
-        stripeId.chunkIndex().get());
-    // All 4 streams indexed (chunkIndexMinAvgChunks = 0).
+        stripeId.chunkStats().get());
+    // All 4 streams indexed (chunkStatsMinAvgChunks = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
     // Verify partition stats for group 1
@@ -3489,8 +3489,8 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
     auto stripeId = tablet->stripeIdentifier(2);
 
     nimble::index::test::ChunkStatsTestHelper chunkHelper(
-        stripeId.chunkIndex().get());
-    // All 4 streams indexed (chunkIndexMinAvgChunks = 0).
+        stripeId.chunkStats().get());
+    // All 4 streams indexed (chunkStatsMinAvgChunks = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
     // Verify partition stats for group 2
@@ -3528,8 +3528,8 @@ TEST_P(TabletWithIndexTest, multipleGroupsWithEmptyStream) {
     auto stripeId = tablet->stripeIdentifier(3);
 
     nimble::index::test::ChunkStatsTestHelper chunkHelper(
-        stripeId.chunkIndex().get());
-    // All 4 streams indexed (chunkIndexMinAvgChunks = 0).
+        stripeId.chunkStats().get());
+    // All 4 streams indexed (chunkStatsMinAvgChunks = 0).
     EXPECT_EQ(chunkHelper.streamCount(), 4);
 
     // Verify partition stats for group 3
@@ -3799,7 +3799,7 @@ TEST_P(TabletWithIndexTest, streamDeduplication) {
   auto stripeId = tablet->stripeIdentifier(0);
 
   nimble::index::test::ChunkStatsTestHelper chunkHelper(
-      stripeId.chunkIndex().get());
+      stripeId.chunkStats().get());
   EXPECT_EQ(chunkHelper.streamCount(), 4);
 
   // Verify partition stats
@@ -3969,7 +3969,7 @@ TEST_P(TabletWithIndexTest, noIndex) {
   tabletWriter->close();
   writeFile.close();
 
-  // Verify no index section and no chunk index section
+  // Verify no index section and no chunk stats section
   auto readFile =
       std::make_shared<nimble::testing::InMemoryTrackableReadFile>(file, false);
   auto tablet = createTabletReader(readFile);
@@ -4360,10 +4360,10 @@ TEST_F(TabletWithIndexTest, configCombinations) {
     // Verify chunk index functionality
     if (config.expectChunkIndex) {
       auto stripeId = tablet->stripeIdentifier(0);
-      ASSERT_NE(stripeId.chunkIndex(), nullptr);
+      ASSERT_NE(stripeId.chunkStats(), nullptr);
 
       nimble::index::test::ChunkStatsTestHelper chunkHelper(
-          stripeId.chunkIndex().get());
+          stripeId.chunkStats().get());
       EXPECT_EQ(chunkHelper.streamCount(), 2);
 
       auto stream0Stats = chunkHelper.streamStats(0);
@@ -4398,10 +4398,10 @@ TEST_F(TabletWithIndexTest, configCombinations) {
       EXPECT_TRUE(lookupKey("eee")[0].empty());
     }
 
-    // When chunk index is not enabled, chunkIndex should be null
+    // When chunk index is not enabled, chunkStats should be null
     if (!config.expectChunkIndex) {
       auto stripeId = tablet->stripeIdentifier(0);
-      EXPECT_EQ(stripeId.chunkIndex(), nullptr);
+      EXPECT_EQ(stripeId.chunkStats(), nullptr);
     }
   }
 }
@@ -4563,24 +4563,24 @@ TEST_P(TabletWithIndexTest, fileLayoutOrdering) {
   EXPECT_GT(layout.indexPartitions[0].offset(), layout.stripeGroups[0].offset())
       << "Index partition metadata should come after stripe group metadata";
 
-  // Optional sections (cluster index, chunk index) come after index partitions.
+  // Optional sections (cluster index, chunk stats) come after index partitions.
   const auto clusterIndexIt =
       layout.optionalSections.find(std::string(nimble::kIndexSection));
   ASSERT_NE(clusterIndexIt, layout.optionalSections.end());
   EXPECT_GT(clusterIndexIt->second.offset(), layout.indexPartitions[0].offset())
       << "Cluster index should come after index partition metadata";
 
-  const auto chunkIndexIt =
+  const auto chunkStatsIt =
       layout.optionalSections.find(std::string(nimble::kChunkStatsSection));
-  ASSERT_NE(chunkIndexIt, layout.optionalSections.end());
-  EXPECT_GT(chunkIndexIt->second.offset(), layout.indexPartitions[0].offset())
-      << "Chunk index should come after index partition metadata";
+  ASSERT_NE(chunkStatsIt, layout.optionalSections.end());
+  EXPECT_GT(chunkStatsIt->second.offset(), layout.indexPartitions[0].offset())
+      << "Chunk stats should come after index partition metadata";
 
   // Stripes metadata comes after optional sections.
   EXPECT_GT(layout.stripes.offset(), clusterIndexIt->second.offset())
       << "Stripes metadata should come after cluster index";
-  EXPECT_GT(layout.stripes.offset(), chunkIndexIt->second.offset())
-      << "Stripes metadata should come after chunk index";
+  EXPECT_GT(layout.stripes.offset(), chunkStatsIt->second.offset())
+      << "Stripes metadata should come after chunk stats";
 
   // Footer comes after stripes metadata.
   EXPECT_GT(layout.footer.offset(), layout.stripes.offset())
@@ -4962,7 +4962,7 @@ TEST_P(TabletTest, readerOptionsSpeculativeMode) {
 }
 
 TEST_P(TabletTest, configureOptionsIndexFlags) {
-  // Verify configureOptions wires loadClusterIndex/loadChunkIndex from
+  // Verify configureOptions wires loadClusterIndex/loadChunkStats from
   // ReaderOptions into TabletReader::Options, both as bools and as entries
   // in preloadOptionalSections.
   auto containsSection = [](const std::vector<std::string>& sections,
@@ -4978,7 +4978,7 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
     SCOPED_TRACE("defaults");
     auto opts = nimble::TabletReader::configureOptions(readerOptions);
     EXPECT_FALSE(opts.loadClusterIndex);
-    EXPECT_TRUE(opts.loadChunkIndex);
+    EXPECT_TRUE(opts.loadChunkStats);
     EXPECT_TRUE(
         containsSection(opts.preloadOptionalSections, nimble::kSchemaSection));
     EXPECT_FALSE(
@@ -4990,10 +4990,10 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
   {
     SCOPED_TRACE("both disabled");
     readerOptions.setLoadClusterIndex(false);
-    readerOptions.setLoadChunkIndex(false);
+    readerOptions.setLoadChunkStats(false);
     auto opts = nimble::TabletReader::configureOptions(readerOptions);
     EXPECT_FALSE(opts.loadClusterIndex);
-    EXPECT_FALSE(opts.loadChunkIndex);
+    EXPECT_FALSE(opts.loadChunkStats);
     EXPECT_TRUE(
         containsSection(opts.preloadOptionalSections, nimble::kSchemaSection));
     EXPECT_FALSE(
@@ -5005,10 +5005,10 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
   {
     SCOPED_TRACE("cluster only");
     readerOptions.setLoadClusterIndex(true);
-    readerOptions.setLoadChunkIndex(false);
+    readerOptions.setLoadChunkStats(false);
     auto opts = nimble::TabletReader::configureOptions(readerOptions);
     EXPECT_TRUE(opts.loadClusterIndex);
-    EXPECT_FALSE(opts.loadChunkIndex);
+    EXPECT_FALSE(opts.loadChunkStats);
     EXPECT_FALSE(
         containsSection(opts.preloadOptionalSections, nimble::kIndexSection));
     EXPECT_FALSE(containsSection(
@@ -5018,10 +5018,10 @@ TEST_P(TabletTest, configureOptionsIndexFlags) {
   {
     SCOPED_TRACE("chunk only");
     readerOptions.setLoadClusterIndex(false);
-    readerOptions.setLoadChunkIndex(true);
+    readerOptions.setLoadChunkStats(true);
     auto opts = nimble::TabletReader::configureOptions(readerOptions);
     EXPECT_FALSE(opts.loadClusterIndex);
-    EXPECT_TRUE(opts.loadChunkIndex);
+    EXPECT_TRUE(opts.loadChunkStats);
     EXPECT_FALSE(
         containsSection(opts.preloadOptionalSections, nimble::kIndexSection));
     EXPECT_TRUE(containsSection(
@@ -6935,10 +6935,10 @@ TEST_P(TabletTest, footerReadTrackedInMetadataIoStats) {
   }
 }
 
-// Verifies that cache warm path works for chunk index group metadata that is
+// Verifies that cache warm path works for chunk stats group metadata that is
 // Zstd-compressed. This exercises the uncompressed_size fix in ChunkStats
 // FlatBuffer serialization — without it, resolveUncompressedSize() returns
-// nullopt for chunk index groups, causing orphaned cache entries and
+// nullopt for chunk stats groups, causing orphaned cache entries and
 // unnecessary file IO on warm reads.
 TEST_P(TabletWithIndexTest, cacheWarmPathCompressedChunkIndex) {
   if (GetParam() != BufferedInputMode::kCachedBufferedInput) {
@@ -6955,7 +6955,7 @@ TEST_P(TabletWithIndexTest, cacheWarmPathCompressedChunkIndex) {
       {SortOrder{.ascending = true}},
       /*enforceKeyOrder=*/true);
 
-  // 500 streams per stripe -> chunk index group metadata exceeds 64KB,
+  // 500 streams per stripe -> chunk stats group metadata exceeds 64KB,
   // triggering Zstd compression.
   constexpr int kNumStripes = 5;
   constexpr int kNumStreams = 500;
@@ -7006,7 +7006,7 @@ TEST_P(TabletWithIndexTest, cacheWarmPathCompressedChunkIndex) {
     for (uint32_t i = 0; i < kNumStripes; ++i) {
       auto stripeId = coldReader->stripeIdentifier(i);
       EXPECT_NE(stripeId.stripeGroup(), nullptr);
-      EXPECT_NE(stripeId.chunkIndex(), nullptr);
+      EXPECT_NE(stripeId.chunkStats(), nullptr);
     }
   }
 
@@ -7018,7 +7018,7 @@ TEST_P(TabletWithIndexTest, cacheWarmPathCompressedChunkIndex) {
   indexIoStats_ = std::make_shared<velox::io::IoStatistics>();
   readerOptions_.reset();
 
-  // Warm path: all metadata (including compressed chunk index group)
+  // Warm path: all metadata (including compressed chunk stats group)
   // should be served from cache with zero file IO and zero evictions.
   {
     auto warmReader = createTabletReader(readFile, options);
@@ -7031,7 +7031,7 @@ TEST_P(TabletWithIndexTest, cacheWarmPathCompressedChunkIndex) {
     for (uint32_t i = 0; i < kNumStripes; ++i) {
       auto stripeId = warmReader->stripeIdentifier(i);
       EXPECT_NE(stripeId.stripeGroup(), nullptr);
-      EXPECT_NE(stripeId.chunkIndex(), nullptr);
+      EXPECT_NE(stripeId.chunkStats(), nullptr);
     }
   }
 

--- a/dwio/nimble/tablet/tests/TabletTestUtils.h
+++ b/dwio/nimble/tablet/tests/TabletTestUtils.h
@@ -71,9 +71,9 @@ class TabletReaderTestHelper {
     return cachedStripeGroupCount() == 1 && hasStripeGroupCached(0);
   }
 
-  /// Returns the number of cached chunk index groups.
+  /// Returns the number of cached chunk stats groups.
   size_t cachedChunkStatsGroupCount() const {
-    return tabletReader_->chunkIndexCache_.testingCacheCount();
+    return tabletReader_->chunkStatsCache_.testingCacheCount();
   }
 
   /// Returns statistics for cluster-index reads.
@@ -81,14 +81,14 @@ class TabletReaderTestHelper {
     return tabletReader_->ioOptions_.indexIoStats();
   }
 
-  /// Returns true if the chunk index group at the given index is cached.
+  /// Returns true if the chunk stats group at the given index is cached.
   bool hasChunkStatsGroupCached(uint32_t groupIndex) const {
-    return tabletReader_->chunkIndexCache_.hasCacheEntry(groupIndex);
+    return tabletReader_->chunkStatsCache_.hasCacheEntry(groupIndex);
   }
 
-  /// Returns true if the first chunk index group is cached and it's the only
-  /// one. This is useful for verifying that when the chunk index is covered by
-  /// footer IO, the first chunk index group is pre-populated in the cache
+  /// Returns true if the first chunk stats group is cached and it's the only
+  /// one. This is useful for verifying that when the chunk stats is covered by
+  /// footer IO, the first chunk stats group is pre-populated in the cache
   /// without additional reads.
   bool hasOnlyFirstChunkStatsGroupCached() const {
     return cachedChunkStatsGroupCount() == 1 && hasChunkStatsGroupCached(0);

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -270,6 +270,14 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
     "nimble.chunk.index.enabled",
     false);
 
+/// Enable per-chunk value statistics (null counts); requires
+/// ENABLE_CHUNK_INDEX.
+// EXPERIMENTAL: Not production-ready. Do not enable for production tables
+// without consulting the Nimble team (oncall: dwios).
+/* static */ Config::Entry<bool> Config::ENABLE_CHUNK_STATS(
+    "nimble.chunk.stats.enabled",
+    false);
+
 /// Threshold to trigger chunking to relieve memory pressure.
 /* static */ Config::Entry<uint64_t>
     Config::CHUNKING_WRITER_MEMORY_HIGH_THRESHOLD(

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -262,7 +262,7 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
     true);
 
 /// Enable chunk index for chunk-level seeking and per-chunk statistics
-/// for filter pushdown. When enabled, a chunk index optional section is
+/// for filter pushdown. When enabled, the chunk stats optional section is
 /// written alongside chunk position data in the file.
 // EXPERIMENTAL: Not production-ready. Do not enable for production tables
 // without consulting the Nimble team (oncall: dwios).

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -60,6 +60,10 @@ class Config : public velox::config::ConfigBase {
   // EXPERIMENTAL: Not production-ready. Do not enable for production tables
   // without consulting the Nimble team (oncall: dwios).
   static Entry<bool> ENABLE_CHUNK_INDEX;
+  // EXPERIMENTAL: Not production-ready. Do not enable for production tables
+  // without consulting the Nimble team (oncall: dwios).
+  // @lint-ignore CLANGTIDY facebook-hte-NonPodStaticDeclaration
+  static Entry<bool> ENABLE_CHUNK_STATS;
   static Entry<uint64_t> CHUNKING_WRITER_MEMORY_HIGH_THRESHOLD;
   static Entry<uint64_t> CHUNKING_WRITER_MEMORY_LOW_THRESHOLD;
   static Entry<uint64_t> CHUNKING_WRITER_TARGET_STRIPE_STORAGE_SIZE;

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -898,7 +898,7 @@ VeloxWriter::VeloxWriter(
            .streamDeduplicationEnabled =
                context_->options().enableStreamDeduplication,
            .enableChunkIndex = context_->options().enableChunkIndex,
-           .chunkIndexMinAvgChunks = context_->options().chunkIndexMinAvgChunks,
+           .chunkStatsMinAvgChunks = context_->options().chunkStatsMinAvgChunks,
            .stripeGroupEncodingLayout =
                context_->options().experimentalStripeGroupEncodingLayout,
            .stripeGroupEncodingLayoutReadFactors =

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -898,6 +898,7 @@ VeloxWriter::VeloxWriter(
            .streamDeduplicationEnabled =
                context_->options().enableStreamDeduplication,
            .enableChunkIndex = context_->options().enableChunkIndex,
+           .enableChunkStats = context_->options().enableChunkStats,
            .chunkStatsMinAvgChunks = context_->options().chunkStatsMinAvgChunks,
            .stripeGroupEncodingLayout =
                context_->options().experimentalStripeGroupEncodingLayout,
@@ -1514,7 +1515,7 @@ uint32_t VeloxWriter::encodeChunk(
   uint32_t chunkBytes{0};
   chunk.rowCount = chunkView.rowCount();
   // Per-chunk null count, precomputed by the chunker.
-  if (context_->options().enableChunkIndex) {
+  if (context_->options().enableChunkStats) {
     chunk.nullCount = static_cast<uint32_t>(chunkView.numNulls());
   }
   ChunkedStreamWriter chunkWriter{

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -69,12 +69,14 @@ struct VeloxWriterOptions {
   /// chunk index is always enabled regardless of this flag.
   /// EXPERIMENTAL: Not production-ready. Do not enable for production tables
   /// without consulting the Nimble team (oncall: dwios).
+  // TODO: keeps the chunkIndex name for now; rename to the chunkStats naming
+  // once per-chunk null/min/max stats are fully rolled out.
   bool enableChunkIndex{false};
 
-  /// Skip writing chunk index for a stripe group if the average number
-  /// of chunks per stream is below this threshold. 0 disables chunk index
+  /// Skip writing chunk stats for a stripe group if the average number
+  /// of chunks per stream is below this threshold. 0 disables chunk stats
   /// skipping.
-  float chunkIndexMinAvgChunks{2};
+  float chunkStatsMinAvgChunks{2};
 
   /// NOTE: !!! This is under experimentation and please do not turn on in
   /// production use case !!!

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -73,6 +73,9 @@ struct VeloxWriterOptions {
   // once per-chunk null/min/max stats are fully rolled out.
   bool enableChunkIndex{false};
 
+  /// Write per-chunk value statistics (null counts); requires enableChunkIndex.
+  bool enableChunkStats{false};
+
   /// Skip writing chunk stats for a stripe group if the average number
   /// of chunks per stream is below this threshold. 0 disables chunk stats
   /// skipping.

--- a/dwio/nimble/velox/selective/ReaderBase.cpp
+++ b/dwio/nimble/velox/selective/ReaderBase.cpp
@@ -228,8 +228,8 @@ std::shared_ptr<index::StreamIndex> StripeStreams::streamIndex(
     int streamId) const {
   NIMBLE_CHECK(stripeIdentifier_.has_value());
 
-  const auto& chunkIndex = stripeIdentifier_->chunkIndex();
-  if (chunkIndex == nullptr) {
+  const auto& chunkStats = stripeIdentifier_->chunkStats();
+  if (chunkStats == nullptr) {
     return nullptr;
   }
   // A stream absent from this stripe group (e.g. added by later schema
@@ -242,7 +242,7 @@ std::shared_ptr<index::StreamIndex> StripeStreams::streamIndex(
   }
   const uint32_t streamSize =
       readerBase_->tablet().streamSize(*stripeIdentifier_, streamId);
-  return chunkIndex->createStreamIndex(stripe_, streamId, streamSize);
+  return chunkStats->createStreamIndex(stripe_, streamId, streamSize);
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -639,13 +639,13 @@ class ChunkedDecoderDataTest : public index::test::ClusterIndexTestBase,
 
     testIndexBuffers_ =
         createTestClusterIndex(indexColumns, minKey, stripes, stripeGroups);
-    testChunkIndex_ = createChunkIndex(testIndexBuffers_, 0);
-    return testChunkIndex_->createStreamIndex(0, 0, /*streamSize=*/1000);
+    testChunkStats_ = createChunkStats(testIndexBuffers_, 0);
+    return testChunkStats_->createStreamIndex(0, 0, /*streamSize=*/1000);
   }
 
  private:
   IndexBuffers testIndexBuffers_;
-  std::shared_ptr<index::ChunkStatsGroup> testChunkIndex_;
+  std::shared_ptr<index::ChunkStatsGroup> testChunkStats_;
   EncodingFactory encodingFactory_;
 };
 

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -2739,7 +2739,7 @@ TEST_F(VeloxWriterTest, chunkNullCountsForStructNullStream) {
       {
           .enableChunkIndex = true,
           // Never skip the stripe group, so the section is always written.
-          .chunkIndexMinAvgChunks = 0,
+          .chunkStatsMinAvgChunks = 0,
           .minStreamChunkRawSize = 0,
           .flushPolicyFactory =
               [&]() {
@@ -2763,7 +2763,7 @@ TEST_F(VeloxWriterTest, chunkNullCountsForStructNullStream) {
   ASSERT_EQ(1, tablet->stripeCount());
 
   auto stripeIdentifier = tablet->stripeIdentifier(0);
-  auto chunkStats = stripeIdentifier.chunkIndex();
+  auto chunkStats = stripeIdentifier.chunkStats();
   ASSERT_NE(chunkStats, nullptr)
       << "columnar.chunk.stats section should be present";
 
@@ -5325,13 +5325,13 @@ class VeloxWriterIndexTest
          ++stripeIdx) {
       const auto stripeId = tablet.stripeIdentifier(stripeIdx);
 
-      if (stripeId.chunkIndex() == nullptr) {
+      if (stripeId.chunkStats() == nullptr) {
         // Group was skipped (no streams with >1 chunk). Skip verification.
         continue;
       }
 
       nimble::index::test::ChunkStatsTestHelper chunkHelper(
-          stripeId.chunkIndex().get());
+          stripeId.chunkStats().get());
 
       const uint32_t stripeOffsetInGroup =
           stripeIdx - chunkHelper.firstStripe();

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -2738,6 +2738,7 @@ TEST_F(VeloxWriterTest, chunkNullCountsForStructNullStream) {
       *rootPool_,
       {
           .enableChunkIndex = true,
+          .enableChunkStats = true,
           // Never skip the stripe group, so the section is always written.
           .chunkStatsMinAvgChunks = 0,
           .minStreamChunkRawSize = 0,
@@ -2806,6 +2807,98 @@ TEST_F(VeloxWriterTest, chunkNullCountsForStructNullStream) {
   EXPECT_TRUE(sawNonZeroChunk)
       << "per-chunk null counts for the struct null stream must be non-zero";
   EXPECT_EQ(6, totalChunkNullCount);
+}
+
+// enableChunkIndex on, enableChunkStats off: positional index is written but
+// null counts are omitted (reader sees them absent, not zero).
+TEST_F(VeloxWriterTest, chunkNullCountsAbsentWithoutChunkStats) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+
+  auto nullsVector =
+      vectorMaker.rowVector({"c1"}, {vectorMaker.flatVector<int32_t>({})});
+  nullsVector->appendNulls(5);
+  auto someNullsVector = vectorMaker.rowVector(
+      {"c1"}, {vectorMaker.flatVector<int32_t>({1, 2, 3})});
+  someNullsVector->setNull(1, /*isNull=*/true);
+
+  const auto& type = nullsVector->type();
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  bool flushDecision = false;
+  nimble::VeloxWriter writer(
+      type,
+      std::move(writeFile),
+      *rootPool_,
+      {
+          .enableChunkIndex = true,
+          .chunkStatsMinAvgChunks = 0,
+          .minStreamChunkRawSize = 0,
+          .flushPolicyFactory =
+              [&]() {
+                return std::make_unique<nimble::LambdaFlushPolicy>(
+                    /*flushLambda=*/[&](auto&) { return false; },
+                    /*chunkLambda=*/[&](auto&) { return flushDecision; });
+              },
+          .enableChunking = true,
+      });
+
+  flushDecision = true;
+  writer.write(nullsVector);
+  writer.write(someNullsVector);
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = nimble::TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+  ASSERT_EQ(1, tablet->stripeCount());
+
+  auto stripeIdentifier = tablet->stripeIdentifier(0);
+  auto chunkStats = stripeIdentifier.chunkStats();
+  ASSERT_NE(chunkStats, nullptr)
+      << "positional chunk index section should still be written when "
+         "enableChunkIndex is set, even with chunk stats disabled";
+
+  const uint32_t streamCount = tablet->streamCount(stripeIdentifier);
+  bool sawIndexedStream = false;
+  for (uint32_t streamId = 0; streamId < streamCount; ++streamId) {
+    auto streamIndex = chunkStats->createStreamIndex(
+        0, streamId, tablet->streamSize(stripeIdentifier, streamId));
+    if (streamIndex == nullptr) {
+      continue; // single-chunk (<=1) streams are not indexed
+    }
+    const uint32_t rows = streamIndex->rowCount();
+    if (rows == 0) {
+      continue;
+    }
+    sawIndexedStream = true;
+    const uint32_t firstChunk = streamIndex->lookupChunk(0).chunkIndex;
+    const uint32_t lastChunk = streamIndex->lookupChunk(rows - 1).chunkIndex;
+    EXPECT_LE(firstChunk, lastChunk);
+    for (uint32_t ci = firstChunk; ci <= lastChunk; ++ci) {
+      EXPECT_FALSE(streamIndex->chunkNullCount(ci).has_value())
+          << "chunk " << ci << " of stream " << streamId
+          << " must report null count as absent when chunk stats are disabled";
+    }
+  }
+  EXPECT_TRUE(sawIndexedStream)
+      << "expected an indexed (multi-chunk) null stream";
+}
+
+// enableChunkStats without enableChunkIndex must fail loudly at construction.
+TEST_F(VeloxWriterTest, chunkStatsRequiresChunkIndex) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto vector = vectorMaker.rowVector(
+      {"c1"}, {vectorMaker.flatVector<int64_t>({1, 2, 3})});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  EXPECT_ANY_THROW(
+      nimble::VeloxWriter(
+          vector->type(),
+          std::move(writeFile),
+          *rootPool_,
+          {.enableChunkStats = true}));
 }
 
 TEST_F(VeloxWriterTest, chunkedStreamsRowNoNullsNoChunks) {


### PR DESCRIPTION
Summary:

Introduces nimble.chunk.stats.enabled (VeloxWriterOptions::enableChunkStats)
as a second, independent knob for per-chunk value statistics. Per-chunk null
counts are now written only when BOTH chunk.index.enabled AND
chunk.stats.enabled are set:

- The chunk stats section (positional index) is still created on
  enableChunkIndex alone, so the positional index can roll out independently
  of the more expensive per-chunk value stats.
- The null-count value is computed only when index && stats (VeloxWriter).
- ChunkStatsWriter omits the null_counts array unless stats are enabled, so an
  index-only file reports null counts as absent (reader returns nullopt)
  rather than writing bogus zeros. Direct ChunkStatsWriter users keep the
  enableStats=true default.

Stacked on the chunkIndex -> chunkStats rename (D113984664).

Differential Revision: D113995300
