### PR TITLE
fix(encoding): fix OSS build link error for RandomEncodingSelectionPolicy

### DIFF
--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -11,7 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-add_library(nimble_encodings_tests_utils TestUtils.cpp)
+add_library(
+  nimble_encodings_tests_utils
+  TestUtils.cpp
+  ../selection/tests/RandomEncodingSelectionPolicy.cpp
+)
 target_link_libraries(nimble_encodings_tests_utils nimble_encodings)
 
 add_library(nimble_encoding_layout_test_helper EncodingLayoutTestHelper.cpp)


### PR DESCRIPTION
Summary:
D113727235 added `VeloxWriterTest.cpp` usage of
`nimble::testing::RandomEncodingSelectionPolicyFactory`, whose non-inline
definitions live in
`dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.cpp`. That
file is compiled into no OSS CMake library (its `selection/tests/` directory has
no `CMakeLists.txt` and is not `add_subdirectory()`'d), so the OSS build
(clang++-15) fails to link `nimble_velox_tests` with undefined references to
`RandomEncodingSelectionPolicyFactory::defaultEncodingChoices()`, its 3-arg
constructor, and `createPolicy()`.

Mirror the internal Buck dependency
(`//dwio/nimble/encodings/selection/tests:random_encoding_selection_policy`,
already a dep of the velox tests target) by compiling that `.cpp` into
`nimble_encodings_tests_utils`, which `nimble_velox_tests` already links. The
file depends only on `nimble_encodings` (+ Folly, linked transitively), so no
new link edge is needed. OSS-CMake-only change; the internal Buck build is
unaffected.

Differential Revision: D114068351


