### PR TITLE
refactor(encoding): Remove dead preserveDictionaryEncoding flag and plumbing (#1043)

### DIFF
--- a/dwio/nimble/encodings/RLEEncoding.h
+++ b/dwio/nimble/encodings/RLEEncoding.h
@@ -501,25 +501,38 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
       vector_size_t numSelected,
       const vector_size_t* scatterRows);
 
-  /// RLE wraps an inner Dictionary encoding. The dictionary is identical
-  /// to the inner encoding's dictionary.
   bool dictionaryEnabled() const override {
-    return dictValues_ != nullptr;
+    if (dictValues_ != nullptr) {
+      return true;
+    }
+    if (valuesEncoding_ == nullptr) {
+      return false;
+    }
+    return valuesEncoding_->dictionaryEnabled();
   }
 
   uint32_t dictionarySize() const override {
-    NIMBLE_CHECK_NOT_NULL(dictValues_);
-    return dictValues_->dictionarySize();
+    if (dictValues_ != nullptr) {
+      return dictValues_->dictionarySize();
+    }
+    NIMBLE_CHECK(
+        valuesEncoding_ != nullptr,
+        "dictionary metadata unavailable — flat mode was already initialized");
+    return valuesEncoding_->dictionarySize();
   }
 
   const void* dictionaryEntry(uint32_t index) const override {
-    NIMBLE_CHECK_NOT_NULL(dictValues_);
     return static_cast<const physicalType*>(dictionaryEntries()) + index;
   }
 
   const void* dictionaryEntries() const override {
-    NIMBLE_CHECK_NOT_NULL(dictValues_);
-    return dictValues_->dictionaryEntries();
+    if (dictValues_ != nullptr) {
+      return dictValues_->dictionaryEntries();
+    }
+    NIMBLE_CHECK(
+        valuesEncoding_ != nullptr,
+        "dictionary metadata unavailable — flat mode was already initialized");
+    return valuesEncoding_->dictionaryEntries();
   }
 
   /// Materializes composed dictionary indices for rowCount dense non-null rows.
@@ -527,8 +540,7 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
   /// value→index map, then fills the buffer with that index repeated for
   /// the run length.
   void materializeIndices(uint32_t rowCount, uint32_t* buffer) override {
-    NIMBLE_CHECK_NOT_NULL(dictValues_);
-    NIMBLE_CHECK_NULL(values_);
+    ensureDictValues();
     uint32_t rowsLeft = rowCount;
     uint32_t numOutputRows = 0;
     while (rowsLeft > 0) {
@@ -550,9 +562,7 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
   void readIndicesWithVisitor(
       IndicesVisitor& visitor,
       ReadWithVisitorParams& params) {
-    NIMBLE_CHECK(
-        this->dictionaryEnabled(),
-        "readIndicesWithVisitor requires dictionary-enabled inner encoding");
+    ensureDictValues();
     NIMBLE_CHECK(
         !IndicesVisitor::kHasHook,
         "readIndicesWithVisitor does not support value hooks");
@@ -652,6 +662,43 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
 
   void advanceRunValue();
 
+  void ensureValues() {
+    NIMBLE_CHECK_NULL(
+        dictValues_,
+        "flat mode unavailable — dict mode was already initialized");
+    if (values_) {
+      return;
+    }
+    NIMBLE_CHECK_NOT_NULL(valuesEncoding_);
+    values_ = std::make_unique<detail::BufferedEncoding<physicalType, 128>>(
+        std::move(valuesEncoding_));
+    for (uint32_t i = 0; i < pendingSkips_; ++i) {
+      this->currentValue_ = values_->nextValue();
+    }
+    pendingSkips_ = 0;
+  }
+
+  void ensureDictValues() {
+    NIMBLE_CHECK_NULL(
+        values_, "dict mode unavailable — flat mode was already initialized");
+    if (dictValues_) {
+      return;
+    }
+    NIMBLE_CHECK_NOT_NULL(valuesEncoding_);
+    NIMBLE_CHECK(
+        valuesEncoding_->dictionaryEnabled(),
+        "dict mode unavailable — inner encoding is not dictionary-compatible");
+    dictValues_ =
+        std::make_unique<detail::BufferedDictEncoding<physicalType, 128>>(
+            std::move(valuesEncoding_));
+    alphabet_ =
+        static_cast<const physicalType*>(dictValues_->dictionaryEntries());
+    for (uint32_t i = 0; i < pendingSkips_; ++i) {
+      currentIndex_ = dictValues_->nextIndex();
+    }
+    pendingSkips_ = 0;
+  }
+
   uint32_t advanceRunIndex() {
     currentIndex_ = dictValues_->nextIndex();
     return currentIndex_;
@@ -672,10 +719,14 @@ class RLEEncoding final : public internal::RLEEncodingBase<T, RLEEncoding<T>> {
     return indicesBuffer_->asMutable<uint32_t>();
   }
 
-  // Exactly one of values_ or dictValues_ is active. When the inner
-  // encoding is dictionary-enabled, dictValues_ loads indices in pages
-  // and reconstructs values from the alphabet. Otherwise values_ loads
-  // values directly via materialize().
+  // Exactly one of valuesEncoding_, values_, or dictValues_ is non-null.
+  // valuesEncoding_ holds the raw inner encoding until the first read chooses
+  // flat vs dict mode, then it is moved into values_ or dictValues_.
+  // When the inner encoding is dictionary-enabled, dictValues_ loads indices
+  // in pages and reconstructs values from the alphabet. Otherwise values_
+  // loads values directly via materialize().
+  std::unique_ptr<Encoding> valuesEncoding_;
+  uint32_t pendingSkips_{0};
   std::unique_ptr<detail::BufferedEncoding<physicalType, 128>> values_;
   std::unique_ptr<detail::BufferedDictEncoding<physicalType, 128>> dictValues_;
   const physicalType* alphabet_{nullptr};
@@ -777,18 +828,10 @@ RLEEncoding<T>::RLEEncoding(
       static_cast<size_t>(
           data.end() -
           internal::RLEEncodingBase<T, RLEEncoding<T>>::getValuesStart())};
-  auto valuesEncoding =
+  valuesEncoding_ =
       EncodingFactory(options).create(pool, valuesView, stringBufferFactory);
-  if (options.preserveDictionaryEncoding && isStringType<physicalType>() &&
-      valuesEncoding->dictionaryEnabled()) {
-    dictValues_ =
-        std::make_unique<detail::BufferedDictEncoding<physicalType, 128>>(
-            std::move(valuesEncoding));
-    alphabet_ =
-        static_cast<const physicalType*>(dictValues_->dictionaryEntries());
-  } else {
-    values_ = std::make_unique<detail::BufferedEncoding<physicalType, 128>>(
-        std::move(valuesEncoding));
+  if (!isStringType<physicalType>() || !valuesEncoding_->dictionaryEnabled()) {
+    ensureValues();
   }
   this->reset();
 }
@@ -798,13 +841,7 @@ RLEEncoding<T>::RLEEncoding(
 // advanceRunIndex() is used instead.
 template <typename T>
 void RLEEncoding<T>::advanceRunValue() {
-  if constexpr (isStringType<physicalType>()) {
-    NIMBLE_CHECK_NULL(dictValues_);
-    NIMBLE_CHECK_NOT_NULL(values_);
-  } else {
-    NIMBLE_DCHECK_NULL(dictValues_);
-    NIMBLE_DCHECK_NOT_NULL(values_);
-  }
+  ensureValues();
   this->currentValue_ = values_->nextValue();
 }
 
@@ -826,7 +863,11 @@ void RLEEncoding<T>::skip(uint32_t rowCount) {
     }
     rowsLeft -= this->copiesRemaining_;
     advanceRunLength();
-    if (dictValues_ != nullptr) {
+    if (valuesEncoding_ != nullptr) {
+      // Mode not yet chosen — defer the value consumption until
+      // ensureValues() or ensureDictValues() wraps the encoding.
+      ++pendingSkips_;
+    } else if (dictValues_ != nullptr) {
       advanceRunIndex();
     } else {
       advanceRunValue();
@@ -836,6 +877,7 @@ void RLEEncoding<T>::skip(uint32_t rowCount) {
 
 template <typename T>
 void RLEEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  ensureValues();
   uint32_t rowsLeft = rowCount;
   auto* output = static_cast<physicalType*>(buffer);
   while (rowsLeft > 0) {
@@ -856,44 +898,25 @@ void RLEEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
 
 template <typename T>
 typename RLEEncoding<T>::physicalType RLEEncoding<T>::nextValue() {
-  if constexpr (isStringType<physicalType>()) {
-    NIMBLE_CHECK_NOT_NULL(values_);
-    NIMBLE_CHECK_NULL(dictValues_);
-  } else {
-    NIMBLE_DCHECK_NOT_NULL(values_);
-    NIMBLE_DCHECK_NULL(dictValues_);
-  }
+  ensureValues();
   return values_->nextValue();
 }
 
 template <typename T>
 uint32_t RLEEncoding<T>::nextIndex() {
-  if constexpr (isStringType<physicalType>()) {
-    NIMBLE_CHECK_NOT_NULL(dictValues_);
-    NIMBLE_CHECK_NULL(values_);
-  } else {
-    NIMBLE_DCHECK_NOT_NULL(dictValues_);
-    NIMBLE_DCHECK_NULL(values_);
-  }
+  ensureDictValues();
   return dictValues_->nextIndex();
 }
 
 template <typename T>
 void RLEEncoding<T>::resetValues() {
   if (dictValues_ != nullptr) {
-    if constexpr (isStringType<physicalType>()) {
-      NIMBLE_CHECK_NULL(values_);
-    } else {
-      NIMBLE_DCHECK_NULL(values_);
-    }
     dictValues_->reset();
-  } else {
-    if constexpr (isStringType<physicalType>()) {
-      NIMBLE_CHECK_NOT_NULL(values_);
-    } else {
-      NIMBLE_DCHECK_NOT_NULL(values_);
-    }
+  } else if (values_ != nullptr) {
     values_->reset();
+  } else if (valuesEncoding_ != nullptr) {
+    valuesEncoding_->reset();
+    pendingSkips_ = 0;
   }
 }
 
@@ -931,13 +954,7 @@ void RLEEncoding<T>::bulkScan(
     const vector_size_t* selectedRows,
     vector_size_t numSelected,
     const vector_size_t* scatterRows) {
-  if constexpr (isStringType<physicalType>()) {
-    NIMBLE_CHECK_NULL(
-        dictValues_,
-        "bulkScan should not be called in dictionary mode for string types");
-  } else {
-    NIMBLE_DCHECK_NULL(dictValues_);
-  }
+  ensureValues();
   using DataType = typename V::DataType;
   using ValueType = detail::ValueType<DataType>;
   constexpr bool kScatterValues = kScatter && !V::kHasFilter && !V::kHasHook;
@@ -1017,13 +1034,7 @@ template <typename V>
 void RLEEncoding<T>::readWithVisitor(
     V& visitor,
     ReadWithVisitorParams& params) {
-  if constexpr (isStringType<physicalType>()) {
-    NIMBLE_CHECK_NULL(
-        dictValues_,
-        "readWithVisitor should not be called in dictionary mode for string types");
-  } else {
-    NIMBLE_DCHECK_NULL(dictValues_);
-  }
+  ensureValues();
   auto* nulls = visitor.reader().rawNullsInReadRange();
   if (velox::dwio::common::useFastPath(visitor, nulls)) {
     detail::readWithVisitorFast(*this, visitor, params, nulls);

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -127,12 +127,6 @@ class Encoding {
     /// nested child streams.
     EncodingBufferPool* encodingBufferPool = nullptr;
 
-    /// When true, encodings that support dictionary mode (e.g., RLE) will
-    /// use the dictionary index path when the inner encoding is
-    /// dictionary-enabled. False by default — only the selective
-    /// reader enables this for dictionary vector output.
-    bool preserveDictionaryEncoding = false;
-
     /// FrequencyPartitionEncoding index type (cast to FreqPartIndexType).
     /// 0 = NoIndex (default, backward-compatible), 1 = PerTierBitmaps,
     /// 2 = TierTagArray, 3 = EliasFano.

--- a/dwio/nimble/encodings/tests/EncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingTest.cpp
@@ -1115,11 +1115,8 @@ class DictionaryApiTypedTest : public ::testing::Test {
   }
 
   /// Creates an Encoding from serialized bytes using EncodingFactory.
-  std::unique_ptr<nimble::Encoding> decodeEncoding(
-      std::string_view data,
-      bool preserveDictionaryEncoding = false) {
+  std::unique_ptr<nimble::Encoding> decodeEncoding(std::string_view data) {
     nimble::Encoding::Options options{};
-    options.preserveDictionaryEncoding = preserveDictionaryEncoding;
     return nimble::EncodingFactory(options).create(
         *pool_, data, [this](uint32_t size) {
           stringBuffers_.push_back(
@@ -1292,7 +1289,7 @@ class DictionaryApiTypedTest : public ::testing::Test {
   std::unique_ptr<nimble::Encoding> encodeMainlyConstantDictionary(
       const std::vector<T>& values) {
     auto serialized = serializeMainlyConstantDictionary(values, *buffer_);
-    return decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
+    return decodeEncoding(serialized);
   }
 
   /// Encodes data as Nullable wrapping MainlyConstant wrapping Dictionary.
@@ -1339,9 +1336,7 @@ class DictionaryApiTypedTest : public ::testing::Test {
     nimble::encoding::writeString(serializedMC, pos);
     nimble::encoding::writeBytes(serializedNulls, pos);
 
-    return decodeEncoding(
-        std::string_view(reserved, encodingSize),
-        /*preserveDictionaryEncoding=*/true);
+    return decodeEncoding(std::string_view(reserved, encodingSize));
   }
 
   /// Serializes values as RLE wrapping Dictionary into outputBuffer.
@@ -1403,7 +1398,7 @@ class DictionaryApiTypedTest : public ::testing::Test {
   std::unique_ptr<nimble::Encoding> encodeRleDictionary(
       const std::vector<T>& values) {
     auto serialized = serializeRleDictionary(values, *buffer_);
-    return decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
+    return decodeEncoding(serialized);
   }
 
   std::shared_ptr<velox::memory::MemoryPool> pool_;
@@ -2411,10 +2406,8 @@ TYPED_TEST(DictionaryApiTypedTest, rleMaterializeAfterSkip) {
     }
   }
 
-  // Construct with dict mode disabled — uses flat values path.
   auto serialized = this->serializeRleDictionary(data, *this->buffer_);
   auto encoding = this->decodeEncoding(serialized);
-  ASSERT_FALSE(encoding->dictionaryEnabled());
 
   // Skip exactly to the first run boundary (5 rows).
   encoding->skip(5);
@@ -2545,11 +2538,10 @@ TYPED_TEST(DictionaryApiTypedTest, rleSkipAndMaterializeAlternating) {
   }
 }
 
-// Verifies that preserveDictionaryEncoding=false forces the flat values path
-// when the inner encoding is dictionary-enabled. The encoding should behave
-// identically to a non-dict RLE — materialize returns correct values but
-// dictionaryEnabled() is false.
-TYPED_TEST(DictionaryApiTypedTest, rleDictionaryDisabledByOption) {
+// RLE wrapping a dictionary-enabled inner encoding reports
+// dictionaryEnabled()=true for string types before mode is chosen.
+// materialize() can still be called (lazily enters flat mode).
+TYPED_TEST(DictionaryApiTypedTest, rleDictionaryLazyMaterialize) {
   using T = TypeParam;
   std::vector<T> data;
   if constexpr (std::is_same_v<T, std::string_view>) {
@@ -2572,18 +2564,14 @@ TYPED_TEST(DictionaryApiTypedTest, rleDictionaryDisabledByOption) {
   // Serialize as RLE→Dictionary.
   auto serialized = this->serializeRleDictionary(data, *this->buffer_);
 
-  // Decode without preserveDictionaryEncoding — should use flat values path.
-  nimble::Encoding::Options options{};
-  auto encoding = nimble::EncodingFactory(options).create(
-      *this->pool_, serialized, [this](uint32_t size) {
-        this->stringBuffers_.push_back(
-            velox::AlignedBuffer::allocate<char>(size, this->pool_.get()));
-        return this->stringBuffers_.back()->template asMutable<void>();
-      });
+  auto encoding = this->decodeEncoding(serialized);
 
-  EXPECT_FALSE(encoding->dictionaryEnabled());
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    EXPECT_TRUE(encoding->dictionaryEnabled());
+  } else {
+    EXPECT_FALSE(encoding->dictionaryEnabled());
+  }
 
-  // Materialize should still produce correct values.
   using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
   std::vector<PhysicalType> materialized(data.size());
   encoding->materialize(data.size(), materialized.data());
@@ -2591,6 +2579,256 @@ TYPED_TEST(DictionaryApiTypedTest, rleDictionaryDisabledByOption) {
     EXPECT_EQ(materialized[i], reinterpret_cast<const PhysicalType&>(data[i]))
         << "row " << i;
   }
+}
+
+// Dictionary(alphabet=RLE(runValues=Constant)). With lazy loading, the
+// DictionaryEncoding constructor calls materialize() on the alphabet RLE,
+// which lazily enters flat mode. No crash.
+TYPED_TEST(DictionaryApiTypedTest, nestedDictionaryRleConstantAlphabet) {
+  using T = TypeParam;
+  using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha"};
+    for (int32_t i = 0; i < 8; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+  } else {
+    for (int32_t i = 0; i < 8; ++i) {
+      data.push_back(T(42));
+    }
+  }
+  const auto rowCount = static_cast<uint32_t>(data.size());
+
+  // Alphabet has one entry.
+  nimble::Vector<PhysicalType> alphabet{this->pool_.get()};
+  alphabet.push_back(reinterpret_cast<const PhysicalType&>(data[0]));
+  nimble::Vector<uint32_t> indices{this->pool_.get(), rowCount};
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    indices[i] = 0;
+  }
+
+  // Encode alphabet as RLE(runValues=Constant).
+  nimble::Vector<uint32_t> runLengths{this->pool_.get()};
+  runLengths.push_back(1);
+  auto rlSpan = std::span<const uint32_t>(runLengths.data(), runLengths.size());
+  nimble::Buffer rlBuf{*this->pool_};
+  nimble::EncodingSelection<uint32_t> rlSel{
+      {.encodingType = nimble::EncodingType::Trivial},
+      nimble::Statistics<uint32_t>::create(rlSpan),
+      std::make_unique<TestTrivialEncodingSelectionPolicy<uint32_t>>(
+          false, false)};
+  auto serializedRunLengths =
+      nimble::TrivialEncoding<uint32_t>::encode(rlSel, rlSpan, rlBuf);
+
+  // Run values as Constant (dictionaryEnabled()=true).
+  auto rvSpan = std::span<const PhysicalType>(alphabet.data(), alphabet.size());
+  nimble::Buffer rvBuf{*this->pool_};
+  nimble::EncodingSelection<PhysicalType> rvSel{
+      {.encodingType = nimble::EncodingType::Constant},
+      nimble::Statistics<PhysicalType>::create(rvSpan),
+      std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(false, false)};
+  auto serializedRunValues =
+      nimble::ConstantEncoding<T>::encode(rvSel, rvSpan, rvBuf);
+
+  // Assemble alphabet as RLE binary.
+  nimble::Buffer alpBuf{*this->pool_};
+  const auto alpEncodingSize = static_cast<uint32_t>(
+      nimble::Encoding::kPrefixSize + 4 + serializedRunLengths.size() +
+      serializedRunValues.size());
+  char* alpPos = alpBuf.reserve(alpEncodingSize);
+  char* alpWrite = alpPos;
+  nimble::encoding::writeChar(
+      static_cast<char>(nimble::EncodingType::RLE), alpWrite);
+  nimble::encoding::writeChar(
+      static_cast<char>(nimble::TypeTraits<T>::dataType), alpWrite);
+  nimble::encoding::writeUint32(alphabet.size(), alpWrite);
+  nimble::encoding::writeString(serializedRunLengths, alpWrite);
+  nimble::encoding::writeBytes(serializedRunValues, alpWrite);
+  auto serializedAlphabet = std::string_view(alpPos, alpEncodingSize);
+
+  // Encode indices as Trivial<uint32_t>.
+  auto idxSpan = std::span<const uint32_t>(indices.data(), indices.size());
+  nimble::Buffer idxBuf{*this->pool_};
+  nimble::EncodingSelection<uint32_t> idxSel{
+      {.encodingType = nimble::EncodingType::Trivial},
+      nimble::Statistics<uint32_t>::create(idxSpan),
+      std::make_unique<TestTrivialEncodingSelectionPolicy<uint32_t>>(
+          false, false)};
+  auto serializedIndices =
+      nimble::TrivialEncoding<uint32_t>::encode(idxSel, idxSpan, idxBuf);
+
+  // Assemble outer Dictionary binary.
+  nimble::Buffer dictBuf{*this->pool_};
+  const auto dictSize = static_cast<uint32_t>(
+      nimble::Encoding::kPrefixSize + 4 + serializedAlphabet.size() +
+      serializedIndices.size());
+  char* dictPos = dictBuf.reserve(dictSize);
+  char* dictWrite = dictPos;
+  nimble::encoding::writeChar(
+      static_cast<char>(nimble::EncodingType::Dictionary), dictWrite);
+  nimble::encoding::writeChar(
+      static_cast<char>(nimble::TypeTraits<T>::dataType), dictWrite);
+  nimble::encoding::writeUint32(rowCount, dictWrite);
+  nimble::encoding::writeUint32(
+      static_cast<uint32_t>(serializedAlphabet.size()), dictWrite);
+  std::memcpy(dictWrite, serializedAlphabet.data(), serializedAlphabet.size());
+  dictWrite += serializedAlphabet.size();
+  std::memcpy(dictWrite, serializedIndices.data(), serializedIndices.size());
+  auto serialized = std::string_view(dictPos, dictSize);
+
+  auto encoding = this->decodeEncoding(serialized);
+
+  EXPECT_TRUE(encoding->dictionaryEnabled());
+  EXPECT_EQ(encoding->rowCount(), rowCount);
+
+  std::vector<PhysicalType> materialized(rowCount);
+  encoding->materialize(rowCount, materialized.data());
+  for (uint32_t i = 0; i < rowCount; ++i) {
+    EXPECT_EQ(materialized[i], reinterpret_cast<const PhysicalType&>(data[i]))
+        << "row " << i;
+  }
+}
+
+// Skip then dict read: skip() accumulates pendingSkips_, then
+// materializeIndices() drains them on first ensureDictValues().
+TYPED_TEST(DictionaryApiTypedTest, skipThenMaterializeIndices) {
+  using T = TypeParam;
+  using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo", "charlie"};
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(std::string_view(this->stringPool_[1]));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(std::string_view(this->stringPool_[2]));
+    }
+  } else {
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(T(10));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(T(20));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(T(30));
+    }
+  }
+
+  auto encoding = this->encodeRleDictionary(data);
+  if constexpr (!nimble::isStringType<T>()) {
+    return;
+  }
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+
+  // Skip past the first run (5 rows).
+  encoding->skip(5);
+
+  const auto remaining = static_cast<uint32_t>(data.size() - 5);
+  std::vector<uint32_t> indices(remaining);
+  encoding->materializeIndices(remaining, indices.data());
+
+  const auto* entries =
+      static_cast<const PhysicalType*>(encoding->dictionaryEntries());
+  for (uint32_t i = 0; i < remaining; ++i) {
+    EXPECT_EQ(
+        entries[indices[i]], reinterpret_cast<const PhysicalType&>(data[5 + i]))
+        << "row " << i;
+  }
+}
+
+// Dict metadata is available before mode is chosen (delegates to
+// valuesEncoding_), but unsupported if flat mode is used.
+TYPED_TEST(DictionaryApiTypedTest, dictMetadataBeforeModeChosen) {
+  using T = TypeParam;
+  using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo"};
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(std::string_view(this->stringPool_[1]));
+    }
+  } else {
+    for (int i = 0; i < 5; ++i) {
+      data.push_back(T(10));
+    }
+    for (int i = 0; i < 3; ++i) {
+      data.push_back(T(20));
+    }
+  }
+
+  auto encoding = this->encodeRleDictionary(data);
+  if constexpr (!nimble::isStringType<T>()) {
+    return;
+  }
+
+  // Query metadata before any read — delegates to valuesEncoding_.
+  ASSERT_TRUE(encoding->dictionaryEnabled());
+  EXPECT_EQ(encoding->dictionarySize(), 2);
+  EXPECT_NE(encoding->dictionaryEntries(), nullptr);
+
+  // Verify alphabet entries are correct.
+  const auto* entries =
+      static_cast<const PhysicalType*>(encoding->dictionaryEntries());
+  std::set<PhysicalType> alphabetSet(entries, entries + 2);
+  EXPECT_EQ(alphabetSet.size(), 2);
+
+  // Commit to flat mode — metadata is no longer available.
+  std::vector<PhysicalType> values(data.size());
+  encoding->materialize(data.size(), values.data());
+  EXPECT_FALSE(encoding->dictionaryEnabled());
+  EXPECT_THROW(encoding->dictionarySize(), nimble::NimbleInternalError);
+  EXPECT_THROW(encoding->dictionaryEntries(), nimble::NimbleInternalError);
+}
+
+// Mode conflict guard: calling flat API then dict API on the same instance
+// must fail. The ensureDictValues() check catches the conflict.
+TYPED_TEST(DictionaryApiTypedTest, modeConflictFlatThenDict) {
+  using T = TypeParam;
+
+  std::vector<T> data;
+  if constexpr (std::is_same_v<T, std::string_view>) {
+    this->stringPool_ = {"alpha", "bravo"};
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(std::string_view(this->stringPool_[0]));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(std::string_view(this->stringPool_[1]));
+    }
+  } else {
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(T(10));
+    }
+    for (int i = 0; i < 4; ++i) {
+      data.push_back(T(20));
+    }
+  }
+
+  auto encoding = this->encodeRleDictionary(data);
+  if constexpr (!nimble::isStringType<T>()) {
+    return;
+  }
+
+  // Commit to flat mode.
+  using PhysicalType = typename nimble::TypeTraits<T>::physicalType;
+  std::vector<PhysicalType> values(4);
+  encoding->materialize(4, values.data());
+
+  // Attempting dict API after flat mode must fail.
+  std::vector<uint32_t> indices(4);
+  EXPECT_THROW(
+      encoding->materializeIndices(4, indices.data()),
+      nimble::NimbleInternalError);
 }
 
 TYPED_TEST(DictionaryApiTypedTest, materializeIndicesRleDictionaryFuzz) {
@@ -2731,8 +2969,7 @@ TYPED_TEST(DictionaryApiTypedTest, constantDictionaryBasics) {
           span),
       std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(false, false)};
   auto serialized = nimble::ConstantEncoding<T>::encode(sel, span, encBuf);
-  auto encoding =
-      this->decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
+  auto encoding = this->decodeEncoding(serialized);
 
   EXPECT_TRUE(encoding->dictionaryEnabled());
   EXPECT_EQ(encoding->dictionarySize(), 1);
@@ -2771,8 +3008,7 @@ TYPED_TEST(DictionaryApiTypedTest, buildAlphabetConstant) {
           span),
       std::make_unique<TestTrivialEncodingSelectionPolicy<T>>(false, false)};
   auto serialized = nimble::ConstantEncoding<T>::encode(sel, span, encBuf);
-  auto encoding =
-      this->decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
+  auto encoding = this->decodeEncoding(serialized);
 
   auto alphabet = nimble::buildEncodingDictionaryAlphabet<T>(encoding.get());
   ASSERT_EQ(alphabet.size(), 1);
@@ -2815,8 +3051,7 @@ TYPED_TEST(DictionaryApiTypedTest, mainlyConstantWithSingleOtherValue) {
     } else {
       auto serialized =
           this->serializeMainlyConstantWithConstantOthers(data, mcBuffer);
-      encoding =
-          this->decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
+      encoding = this->decodeEncoding(serialized);
     }
 
     ASSERT_TRUE(encoding->dictionaryEnabled());
@@ -2894,9 +3129,8 @@ TYPED_TEST(DictionaryApiTypedTest, rleWithConstantLeaf) {
   nimble::encoding::writeString(serializedRunLengths, pos);
   nimble::encoding::writeBytes(serializedRunValues, pos);
 
-  auto encoding = this->decodeEncoding(
-      std::string_view(reserved, encodingSize),
-      /*preserveDictionaryEncoding=*/true);
+  auto encoding =
+      this->decodeEncoding(std::string_view(reserved, encodingSize));
   if constexpr (!nimble::isStringType<T>()) {
     EXPECT_FALSE(encoding->dictionaryEnabled());
     std::vector<T> result(totalRows);
@@ -2970,8 +3204,7 @@ TYPED_TEST(DictionaryApiTypedTest, mainlyConstantWithConstantLeafFuzz) {
     nimble::Buffer mcBuffer{*this->pool_};
     auto serialized =
         this->serializeMainlyConstantWithConstantOthers(data, mcBuffer);
-    auto encoding =
-        this->decodeEncoding(serialized, /*preserveDictionaryEncoding=*/true);
+    auto encoding = this->decodeEncoding(serialized);
 
     ASSERT_TRUE(encoding->dictionaryEnabled());
     ASSERT_EQ(encoding->dictionarySize(), 2);
@@ -3064,9 +3297,8 @@ TYPED_TEST(DictionaryApiTypedTest, rleWithConstantLeafFuzz) {
     nimble::encoding::writeString(serializedRunLengths, pos);
     nimble::encoding::writeBytes(serializedRunValues, pos);
 
-    auto encoding = this->decodeEncoding(
-        std::string_view(reserved, encodingSize),
-        /*preserveDictionaryEncoding=*/true);
+    auto encoding =
+        this->decodeEncoding(std::string_view(reserved, encodingSize));
     if constexpr (!nimble::isStringType<T>()) {
       EXPECT_FALSE(encoding->dictionaryEnabled());
       std::vector<T> result(totalRows);

--- a/dwio/nimble/velox/selective/ChunkedDecoder.cpp
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.cpp
@@ -30,9 +30,7 @@ namespace facebook::nimble {
 using namespace facebook::velox;
 using velox::common::testutil::TestValue;
 
-bool ChunkedDecoder::loadNextChunk(
-    bool preserveDictionaryEncoding,
-    const ChunkBoundaryCallback& onChunkLoaded) {
+bool ChunkedDecoder::loadNextChunk(const ChunkBoundaryCallback& onChunkLoaded) {
   auto ret = ensureInput(kChunkHeaderSize);
   NIMBLE_CHECK(ret, "Failed to read chunk header");
   const auto [length, compressionType] = readChunkHeader(inputData_);
@@ -77,7 +75,6 @@ bool ChunkedDecoder::loadNextChunk(
   auto data = std::string_view(chunkData, chunkSize);
   // Copy, not reference.
   auto options = encodingFactory_->options();
-  options.preserveDictionaryEncoding = preserveDictionaryEncoding;
   options.decodingStats = decodingStats_;
   encoding_ =
       encodingFactory_->create(*pool_, data, stringBufferFactory, options);
@@ -275,7 +272,7 @@ void ChunkedDecoder::skipWithoutIndex(
     const ChunkBoundaryCallback& onChunkBoundary) {
   while (numValues > 0) {
     if (FOLLY_UNLIKELY(remainingValues_ == 0)) {
-      loadNextChunk(preserveDictionaryEncoding_, onChunkBoundary);
+      loadNextChunk(onChunkBoundary);
     }
     if (numValues < remainingValues_) {
       encoding_->skip(numValues);
@@ -302,7 +299,7 @@ void ChunkedDecoder::seekToChunk(
   remainingValues_ = 0;
 
   // Load the chunk at this position
-  loadNextChunk(preserveDictionaryEncoding_, onChunkBoundary);
+  loadNextChunk(onChunkBoundary);
 }
 
 std::optional<size_t> ChunkedDecoder::estimateRowCount() const {

--- a/dwio/nimble/velox/selective/ChunkedDecoder.h
+++ b/dwio/nimble/velox/selective/ChunkedDecoder.h
@@ -287,14 +287,13 @@ class ChunkedDecoder {
   // that the caller sees the encoding and remainingValues of the chunk that
   // will actually be read.
   void ensureLoaded(
-      bool preserveDictionaryEncoding = false,
       const ChunkBoundaryCallback& onChunkBoundary = kNoopAtChunkBoundary) {
     if (encoding_ != nullptr && remainingValues_ != 0) {
       return;
     }
 
     if (hasMoreChunks()) {
-      loadNextChunk(preserveDictionaryEncoding, onChunkBoundary);
+      loadNextChunk(onChunkBoundary);
     }
   }
 
@@ -308,17 +307,6 @@ class ChunkedDecoder {
   /// Nullable→Dict, and MC→Dict via virtual dispatch.
   /// Caller must call ensureLoaded() first.
   bool dictionaryConvertible() const;
-
-  /// Controls whether the skip paths (skipWithoutIndex, seekToChunk) load the
-  /// chunk they advance into (the chunk after the skip) with dictionary
-  /// encoding preserved. The string dictionary reader sets this so a
-  /// between-batch skip that lands in a preserve-gated encoding (e.g.
-  /// RLE<Dictionary>) loads that chunk in dictionary mode instead of flattening
-  /// it. All other readers leave it at the default (false), so their skips are
-  /// unaffected.
-  void setPreserveDictionaryEncoding(bool preserve) {
-    preserveDictionaryEncoding_ = preserve;
-  }
 
   int64_t remainingValues() const {
     return remainingValues_;
@@ -481,8 +469,8 @@ class ChunkedDecoder {
       // kReadAllChunks=false) rather than reused from the flat testNulls path.
       // Both paths read one chunk per pass and stop at its boundary; the
       // difference is where the boundary load lives. In the flat path it lives
-      // inside the testNulls bit-scan and is bare: no
-      // preserveDictionaryEncoding, and no seam at which to run onChunkBoundary
+      // inside the testNulls bit-scan and is bare: no seam at which
+      // to run onChunkBoundary
       // (merge the per-chunk alphabet
       // + refresh scan state) or to abandon to the flat fallback when the next
       // chunk is not dictionary-compatible. Hoisting the load here gives those
@@ -493,7 +481,7 @@ class ChunkedDecoder {
         // flat !kHasNulls path does).
         const bool needMoreValues = kHasNulls ? (remainingValues > 0) : true;
         if (needMoreValues) {
-          loadNextChunk(/*preserveDictionaryEncoding=*/true);
+          loadNextChunk();
           if (!onChunkBoundary()) {
             // The new chunk is not dictionary-compatible. readOffset_ has not
             // moved during this read, so it still holds the read's start
@@ -845,15 +833,10 @@ class ChunkedDecoder {
 
   // Loads the next chunk from the input stream and creates a new encoding.
   //
-  // @param preserveDictionaryEncoding When true, creates the encoding with
-  //   dictionary mode enabled so that RLE enters dict index mode. Only the
-  //   string dictionary reader passes true; all other callers use the
-  //   default (false).
   // @param onChunkLoaded Callback invoked after loading. Returns true to
   //   continue reading, false to stop (e.g., the new chunk is not
   //   dictionary-compatible). Defaults to kNoopAtChunkBoundary.
   bool loadNextChunk(
-      bool preserveDictionaryEncoding = false,
       const ChunkBoundaryCallback& onChunkLoaded = kNoopAtChunkBoundary);
 
   void prepareInputBuffer(int32_t size);
@@ -903,11 +886,6 @@ class ChunkedDecoder {
   const bool decodeValuesWithNulls_;
   const EncodingFactory* const encodingFactory_;
   const bool stringDecoderZeroCopy_{false};
-  // When true, the skip paths (skipWithoutIndex, seekToChunk) load the chunk
-  // they advance into (the chunk after the skip) with dictionary encoding
-  // preserved. Set by the string dictionary reader; all other decoders keep the
-  // default so their skips load chunks in flat mode.
-  bool preserveDictionaryEncoding_{false};
   // Optional stream index for accelerating skip operations
   const std::shared_ptr<index::StreamIndex> streamIndex_;
   // Total row count in the stream, set from stream index if available.

--- a/dwio/nimble/velox/selective/StringColumnReader.cpp
+++ b/dwio/nimble/velox/selective/StringColumnReader.cpp
@@ -382,14 +382,6 @@ bool StringColumnReader::readWithDictionary(
       dictionaryPreservable(),
       "readWithDictionary entered when the dictionary is not preservable");
 
-  // Entering the dictionary read path: load any chunk this read advances into
-  // (via prepareRead's skip below) with dictionary encoding preserved, so a
-  // between-batch skip that lands in a preserve-gated encoding (e.g.
-  // RLE<Dictionary>) stays dictionary-convertible instead of being flattened.
-  // abandonDictionaryEncoding sets it back to false when the dictionary path is
-  // given up.
-  decoder_.setPreserveDictionaryEncoding(true);
-
   // A cross-chunk merged alphabet is per-read: getValues() clears it (and snaps
   // its backing into the output DictionaryVector) once the read is consumed.
   // But the parent struct reader skips this column's getValues() when it
@@ -411,22 +403,17 @@ bool StringColumnReader::readWithDictionary(
   // the skip lands exactly on a chunk boundary, the last chunk it skipped
   // through. Loading here rather than before prepareRead ensures the
   // convertibility check below inspects the chunk that will be read, not a
-  // stale one. It loads with dictionary encoding preserved — the same mode the
-  // skip's own chunk loads use (the flag set above) — which is what lets this
-  // move after the skip. The callback clears stale dictionary state so
+  // stale one. The callback clears stale dictionary state so
   // ensureDictionaryState rebuilds from the new chunk.
-  decoder_.ensureLoaded(
-      /*preserveDictionaryEncoding=*/true, [this] {
-        clearDictionaryState();
-        return true;
-      });
+  decoder_.ensureLoaded([this] {
+    clearDictionaryState();
+    return true;
+  });
 
   const auto endReadRow = rows.back() + 1;
-  // Check convertibility once, on that chunk. A between-batch skip may load it
-  // in dictionary mode (preserve flag above), so a dict-convertible chunk stays
-  // convertible here; only a genuinely non-dictionary encoding (e.g. Trivial)
-  // fails it. When it is not convertible, no dictionary indices were
-  // materialized; re-type the value buffer to StringView
+  // Check convertibility once, on that chunk. Only a genuinely non-dictionary
+  // encoding (e.g. Trivial) fails it. When it is not convertible, no dictionary
+  // indices were materialized; re-type the value buffer to StringView
   // (abandonDictionaryEncoding handles numValues_ == 0) so read()'s flat
   // continuation fills it. Crucially, read() must NOT run a second prepareRead
   // in this case — that would advance the null/in-map decoders a second time
@@ -673,9 +660,6 @@ void StringColumnReader::abandonDictionaryEncoding(vector_size_t endReadRow) {
   valueSize_ = sizeof(StringView);
   clearDictionaryState();
   crossChunkRead_ = false;
-  // The dictionary path is given up: subsequent chunk loads (including any
-  // skip) revert to flat mode until the next readWithDictionary re-enters it.
-  decoder_.setPreserveDictionaryEncoding(false);
 }
 
 void StringColumnReader::getValues(const RowSet& rows, VectorPtr* result) {

--- a/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/ChunkedDecoderTest.cpp
@@ -1509,12 +1509,12 @@ TEST_P(ChunkedDecoderDataTest, ensureLoadedFiresCallbackOnReload) {
   };
 
   // First load fires the callback.
-  decoder.ensureLoaded(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
+  decoder.ensureLoaded(onChunkBoundary);
   EXPECT_EQ(callbackCount, 1);
   EXPECT_EQ(decoder.remainingValues(), 3);
 
   // ensureLoaded with remaining > 0 does not fire.
-  decoder.ensureLoaded(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
+  decoder.ensureLoaded(onChunkBoundary);
   EXPECT_EQ(callbackCount, 1);
 
   // Consume chunk 1.
@@ -1522,7 +1522,7 @@ TEST_P(ChunkedDecoderDataTest, ensureLoadedFiresCallbackOnReload) {
   EXPECT_EQ(decoder.remainingValues(), 0);
 
   // ensureLoaded reloads chunk 2, firing the callback.
-  decoder.ensureLoaded(/*preserveDictionaryEncoding=*/false, onChunkBoundary);
+  decoder.ensureLoaded(onChunkBoundary);
   EXPECT_EQ(callbackCount, 2);
   EXPECT_EQ(decoder.remainingValues(), 3);
 }

--- a/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/StringColumnReaderTest.cpp
@@ -1078,8 +1078,8 @@ TEST_P(StringColumnReaderTest, skipAcrossChunkBoundaryDictRecovery) {
 //
 // readWithDictionary checks dictionaryConvertible() on the chunk that is
 // current at entry (chunk1, Dictionary → passes), but then prepareRead<int32_t>
-// runs seekTo → skip, which loads the landed chunk with
-// preserveDictionaryEncoding=false. When that chunk is a non-dict encoding
+// runs seekTo → skip, which loads a new chunk. When that chunk is a non-dict
+// encoding
 // (here Trivial, forced by high-cardinality unique strings), the stale guard no
 // longer matches the current encoding, and ensureDictionaryState() calls
 // buildEncodingDictionaryAlphabet() on it → NIMBLE_CHECK(dictionaryEnabled())
@@ -1415,12 +1415,9 @@ EncodingLayoutTree makeSecondChildRleDictionaryLayoutTree() {
 // readWithDictionary's post-prepareRead dictionaryConvertible() check passes
 // and the chunk is read in dictionary mode across the skip.
 //
-// Before the skip paths honored the preserve flag, skipWithoutIndex/seekToChunk
-// hardcoded loadNextChunk(preserveDictionaryEncoding=false), so a benign
-// dict-convertible chunk was materialized in FLAT mode (dictValues_ null,
-// dictionaryEnabled()==false) and read flat (VectorEncoding FLAT) for the
-// remainder of the chunk — losing the dictionary/zero-copy path even though
-// nothing about the chunk required abandoning it.
+// With lazy dict/flat mode in RLE, the mode is determined by the caller's API
+// choice, not a flag at construction time. skipWithoutIndex/seekToChunk load
+// chunks without committing to a mode; the subsequent read determines it.
 //
 // Mirrors skipAcrossChunkBoundaryDictRecovery scenario 1 (kChunkRows=400,
 // accept [0,349] u [600,799], batchSize=250), but forces BOTH chunks of the


### PR DESCRIPTION
Summary:

Follow-up to D113962429. Remove the now-dead `preserveDictionaryEncoding` flag
and all plumbing that sets it. RLE no longer reads this flag (lazy mode
selection in D113962429 replaced it).

All deleted code is gated by `dictionaryPreservable()` (requires both
`stringDecoderZeroCopy` and `nimblePreserveDictionaryEncoding` session
properties, both off by default). The flat read path is unaffected.

```
StringColumnReader::read()
└── dictionaryPreservable()?     ← GATE
    ├── YES → readWithDictionary()
    │   ├── setPreserveDictionaryEncoding(true)         ← DELETED
    │   ├── prepareRead → skip
    │   │   └── loadNextChunk(preserveDictionaryEncoding_)  ← member + param DELETED
    │   ├── ensureLoaded(/*flag=*/true, cb)             ← param DELETED
    │   │   └── loadNextChunk(flag) → options.preserveDictionaryEncoding = flag  ← field DELETED
    │   ├── readDictionaryIndices
    │   │   └── loadNextChunk(/*flag=*/true)            ← param DELETED
    │   └── abandonDictionaryEncoding
    │       └── setPreserveDictionaryEncoding(false)    ← DELETED
    └── NO → flat path (no deleted code touched)
```

Reviewed By: xiaoxmeng

Differential Revision: D113981241


