### PR TITLE
feat: Add PFOR native slice support

### DIFF
--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -255,11 +255,6 @@ class BlockBitPackingEncoding final
         varint::varintSize(firstBlockRows);
   }
 
-  static void writeSizedChild(std::string_view value, char*& pos) {
-    varint::writeVarint(static_cast<uint32_t>(value.size()), &pos);
-    encoding::writeBytes(value, pos);
-  }
-
   template <typename MetadataType>
   static uint64_t estimateMetadataSize(uint32_t rowCount) {
     const auto trivialSize =
@@ -609,20 +604,11 @@ void BlockBitPackingEncoding<T>::writeBlockSlicesPayload(
         static_cast<uint64_t>(blockSlice.rowOffset) * blockSlice.bitWidth;
     const auto sliceBits =
         static_cast<uint64_t>(blockSlice.rowCount) * blockSlice.bitWidth;
-    if (sourceBitOffset % 8 == 0 && sliceBits % 8 == 0) {
-      std::memcpy(
-          pos + dataOffset,
-          packedData.data() + blockSlice.packedOffset + sourceBitOffset / 8,
-          blockSlice.packedSize);
-    } else {
-      velox::bits::copyBits(
-          reinterpret_cast<const uint64_t*>(
-              packedData.data() + blockSlice.packedOffset),
-          sourceBitOffset,
-          reinterpret_cast<uint64_t*>(pos + dataOffset),
-          /*targetOffset=*/0,
-          sliceBits);
-    }
+    encoding::copyPackedBits(
+        packedData.substr(blockSlice.packedOffset),
+        sourceBitOffset,
+        sliceBits,
+        pos + dataOffset);
     dataOffset += blockSlice.packedSize;
   };
 
@@ -1219,9 +1205,9 @@ std::string_view BlockBitPackingEncoding<T>::encode(
       static_cast<char>(compressionEncoder.compressionType()), pos);
   varint::writeVarint(blockSize, &pos);
   varint::writeVarint(numBlocks, &pos);
-  writeSizedChild(encodedBaselines, pos);
-  writeSizedChild(encodedBitWidths, pos);
-  writeSizedChild(encodedOffsets, pos);
+  encoding::writeVarintString(encodedBaselines, pos);
+  encoding::writeVarintString(encodedBitWidths, pos);
+  encoding::writeVarintString(encodedOffsets, pos);
   varint::writeVarint(firstBlockRows, &pos);
   compressionEncoder.write(pos);
 
@@ -1365,9 +1351,9 @@ std::string_view BlockBitPackingEncoding<T>::slice(
   encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
   varint::writeVarint(source.blockSize, &pos);
   varint::writeVarint(numBlocks, &pos);
-  writeSizedChild(encodedBaselines, pos);
-  writeSizedChild(encodedBitWidths, pos);
-  writeSizedChild(encodedOffsets, pos);
+  encoding::writeVarintString(encodedBaselines, pos);
+  encoding::writeVarintString(encodedBitWidths, pos);
+  encoding::writeVarintString(encodedOffsets, pos);
   varint::writeVarint(firstBlockRows, &pos);
 
   writeBlockSlicesPayload(

--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -29,6 +29,7 @@
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
+#include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -212,6 +213,19 @@ std::string_view sliceBlockBitPacking(
           encoded, offset, length, buffer, options));
 }
 
+std::string_view slicePFOR(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_NUMERIC_DATA_TYPE(
+      dataType,
+      T,
+      PFOREncoding<T>::slice(encoded, offset, length, buffer, options));
+}
+
 std::string_view sliceALP(
     std::string_view encoded,
     DataType dataType,
@@ -263,6 +277,8 @@ std::string_view EncodingSliceFactory::slice(
     case EncodingType::BlockBitPacking:
       return sliceBlockBitPacking(
           encoded, dataType, offset, length, buffer, options);
+    case EncodingType::PFOR:
+      return slicePFOR(encoded, dataType, offset, length, buffer, options);
     case EncodingType::ALP:
       return sliceALP(encoded, dataType, offset, length, buffer, options);
     case EncodingType::Nullable:

--- a/dwio/nimble/encodings/FixedBitWidthEncoding.h
+++ b/dwio/nimble/encodings/FixedBitWidthEncoding.h
@@ -467,16 +467,7 @@ std::string_view FixedBitWidthEncoding<T>::slice(
     std::memset(pos, 0, packedBytes);
     const auto sourceBitOffset = static_cast<uint64_t>(offset) * bitWidth;
     const auto sliceBits = static_cast<uint64_t>(length) * bitWidth;
-    if (sourceBitOffset % 8 == 0 && sliceBits % 8 == 0) {
-      std::memcpy(pos, packedData.data() + sourceBitOffset / 8, packedBytes);
-    } else {
-      velox::bits::copyBits(
-          reinterpret_cast<const uint64_t*>(packedData.data()),
-          sourceBitOffset,
-          reinterpret_cast<uint64_t*>(pos),
-          /*targetOffset=*/0,
-          sliceBits);
-    }
+    encoding::copyPackedBits(packedData, sourceBitOffset, sliceBits, pos);
     pos += packedBytes;
   }
 

--- a/dwio/nimble/encodings/PFOREncoding.h
+++ b/dwio/nimble/encodings/PFOREncoding.h
@@ -23,6 +23,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
 #include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -57,12 +58,12 @@ namespace facebook::nimble {
 ///   sizeof(physicalType) bytes : baseline (a.k.a. min value)
 ///   1 byte                    : baseBitWidth (bits per bitpacked residual;
 ///                               range [0, 64])
-///   4 bytes                   : numExceptions (uint32_t, fixed width)
-///   4 bytes + N bytes         : exception positions sub-stream -- a 4-byte
+///   varint                    : numExceptions
+///   varint + N bytes          : exception positions sub-stream -- a varint
 ///                               size prefix followed by a nested encoding of
 ///                               the strictly ascending positions (size 0 and
 ///                               no encoding when there are no exceptions)
-///   4 bytes + N bytes         : exception values sub-stream -- a 4-byte size
+///   varint + N bytes          : exception values sub-stream -- a varint size
 ///                               prefix followed by a nested encoding of the
 ///                               full residuals, i.e. value - baseline (size 0
 ///                               and no encoding when there are no exceptions)
@@ -100,6 +101,13 @@ class PFOREncoding final
       Buffer& buffer,
       const Encoding::Options& options = {});
 
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
   std::string debugString(int offset) const final;
 
   static uint64_t estimateSize(
@@ -128,8 +136,9 @@ class PFOREncoding final
         TrivialEncoding<physicalType>::estimateSize(numExceptions),
         FixedBitWidthEncoding<physicalType>::estimateSize(
             numExceptions, statistics, options));
-    const uint64_t outerEncodingSize =
-        EncodingPrefix::kFixedPrefixSize + kPrefixSize;
+    const uint64_t outerEncodingSize = EncodingPrefix::kFixedPrefixSize +
+        kFixedHeaderSize + varint::varintSize(numExceptions) +
+        varint::varintSize(positionsSize) + varint::varintSize(valuesSize);
     return outerEncodingSize + baseValuesSize + positionsSize + valuesSize;
   }
 
@@ -166,9 +175,28 @@ class PFOREncoding final
     return {maxBitWidth, 0};
   }
 
-  /// Fixed-size header: baseline + baseBitWidth(1 byte) + numExceptions(4).
-  static constexpr int kPrefixSize =
-      sizeof(physicalType) + sizeof(uint8_t) + sizeof(uint32_t);
+  /// Fixed-size part of the PFOR header: baseline + baseBitWidth(1 byte).
+  static constexpr int kFixedHeaderSize =
+      sizeof(physicalType) + sizeof(uint8_t);
+
+  // Sliced exception child streams plus the exception count written to the
+  // sliced PFOR header.
+  struct ExceptionSlice {
+    std::string_view positions;
+    std::string_view values;
+    uint32_t count{0};
+  };
+
+  static ExceptionSlice sliceExceptions(
+      std::string_view exceptionPositions,
+      std::string_view exceptionValues,
+      uint32_t numExceptions,
+      uint32_t offset,
+      uint32_t length,
+      velox::memory::MemoryPool* pool,
+      Buffer& scratchBuffer,
+      const Encoding::Options& options);
+
   // Patches any exceptions whose absolute position falls inside
   // [row_, row_ + count) onto `output`, where output[k] corresponds to
   // absolute position row_ + k. Advances exceptionCursor_ past consumed
@@ -222,12 +250,12 @@ PFOREncoding<T>::PFOREncoding(
   } else {
     const char* pos = data.data() + this->dataOffset();
 
-    // Parse the fixed-size header: baseline, baseBitWidth, numExceptions.
+    // Parse the header: baseline, baseBitWidth, numExceptions.
     baseline_ = encoding::read<physicalType>(pos);
     baseBitWidth_ = static_cast<uint8_t>(encoding::readChar(pos));
     NIMBLE_CHECK_LE(
         baseBitWidth_, 64, "Pfor base bit width must be in [0, 64].");
-    numExceptions_ = encoding::readUint32(pos);
+    numExceptions_ = varint::readVarint32(&pos);
     NIMBLE_CHECK_LE(
         numExceptions_,
         this->rowCount_,
@@ -235,8 +263,10 @@ PFOREncoding<T>::PFOREncoding(
 
     auto readExceptionStream = [&](auto& subStream) {
       subStream.resize(numExceptions_);
-      const uint32_t size = encoding::readUint32(pos);
-      if (numExceptions_ > 0) {
+      const uint32_t size = varint::readVarint32(&pos);
+      if (numExceptions_ == 0) {
+        NIMBLE_CHECK_EQ(size, 0, "Empty Pfor exception stream has data.");
+      } else {
         auto subEncoding = EncodingFactory(options).create(
             pool, {pos, size}, stringBufferFactory);
         subEncoding->materialize(numExceptions_, subStream.data());
@@ -389,120 +419,257 @@ std::string_view PFOREncoding<T>::encode(
   if constexpr (!isIntegralType<physicalType>()) {
     NIMBLE_INCOMPATIBLE_ENCODING(
         "Pfor encoding only supports integral data types.");
-  } else {
-    static_assert(
-        std::is_same_v<
-            typename std::make_unsigned<physicalType>::type,
-            physicalType>,
-        "Pfor physical type must be unsigned.");
-    const bool useVarint = options.useVarintRowCount;
-    NIMBLE_CHECK(!values.empty(), "Pfor encoding cannot be used with 0 rows.");
-
-    const uint32_t rowCount = static_cast<uint32_t>(values.size());
-    const physicalType baseline = selection.statistics().min();
-    const physicalType maxValue = selection.statistics().max();
-    const physicalType fullRange =
-        static_cast<physicalType>(maxValue - baseline);
-    const uint8_t maxBitWidth =
-        static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
-
-    const auto [selectedBaseBitWidth, expectedExceptions] = selectBaseBitWidth(
-        selection.statistics().bucketCounts(), rowCount, maxBitWidth);
-
-    // Single pass: compute residuals, identify exceptions that overflow
-    // baseBitWidth, and zero-mask exception slots in the residual array.
-    constexpr uint32_t kBitsPerPhysicalType = sizeof(physicalType) * 8;
-    const physicalType baseMask = selectedBaseBitWidth == 0
-        ? physicalType{0}
-        : static_cast<physicalType>(velox::bits::lowMask(selectedBaseBitWidth));
-
-    auto* pool = &buffer.getMemoryPool();
-    Vector<uint32_t> exceptionPositions{pool};
-    Vector<physicalType> exceptionValues{pool};
-    // Reserve for expected exceptions based on the 90% coverage threshold.
-    exceptionPositions.reserve(expectedExceptions);
-    exceptionValues.reserve(expectedExceptions);
-
-    Vector<physicalType> maskedResiduals{pool};
-    maskedResiduals.resize(rowCount);
-    physicalType maxBaseResidual{0};
-    for (auto i = 0; i < rowCount; ++i) {
-      const physicalType residual =
-          static_cast<physicalType>(values[i] - baseline);
-      if (selectedBaseBitWidth < kBitsPerPhysicalType && residual > baseMask) {
-        exceptionPositions.emplace_back(i);
-        exceptionValues.emplace_back(residual);
-        maskedResiduals[i] = physicalType{0};
-      } else {
-        maskedResiduals[i] = residual;
-        maxBaseResidual = std::max(maxBaseResidual, residual);
-      }
-    }
-    const uint32_t numExceptions =
-        static_cast<uint32_t>(exceptionPositions.size());
-    const uint8_t exactBaseBitWidth =
-        static_cast<uint8_t>(velox::bits::bitsRequired(maxBaseResidual));
-    NIMBLE_CHECK_LE(
-        exactBaseBitWidth,
-        selectedBaseBitWidth,
-        "Pfor exact bit width should not exceed selected bit width.");
-    const uint8_t baseBitWidth = options.fixedBitWidthUseExactBits
-        ? exactBaseBitWidth
-        : selectedBaseBitWidth;
-
-    const uint64_t bitpackedSize = baseBitWidth == 0
-        ? 0
-        : FixedBitArray::bufferSize(rowCount, baseBitWidth);
-
-    // PFOR encodes the exception side-channels through recursive encoding
-    // selection so Nimble can pick the best sub-encoding.
-    // The bulk base residuals always stay raw to preserve the fast decode path.
-    ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
-    std::string_view exceptionPositionsEncoded{};
-    std::string_view exceptionValuesEncoded{};
-    if (numExceptions > 0) {
-      exceptionPositionsEncoded = selection.template encodeNested<uint32_t>(
-          EncodingIdentifiers::Pfor::ExceptionPositions,
-          std::span<const uint32_t>(exceptionPositions.data(), numExceptions),
-          scopedBuffer.get(),
-          options);
-      exceptionValuesEncoded = selection.template encodeNested<physicalType>(
-          EncodingIdentifiers::Pfor::ExceptionValues,
-          std::span<const physicalType>(exceptionValues.data(), numExceptions),
-          scopedBuffer.get(),
-          options);
-    }
-    // Two size-prefixed nested streams (positions, values) carry the exception
-    // side-channel.
-    const uint32_t encodingSize = Encoding::serializePrefixSize(
-                                      rowCount, useVarint) +
-        PFOREncoding<T>::kPrefixSize +
-        static_cast<uint32_t>(2 * sizeof(uint32_t) +
-                              exceptionPositionsEncoded.size() +
-                              exceptionValuesEncoded.size() + bitpackedSize);
-    char* reserved = buffer.reserve(encodingSize);
-    char* pos = reserved;
-    Encoding::serializePrefix(
-        EncodingType::PFOR, TypeTraits<T>::dataType, rowCount, useVarint, pos);
-    encoding::write(baseline, pos);
-    encoding::writeChar(static_cast<char>(baseBitWidth), pos);
-    encoding::writeUint32(numExceptions, pos);
-    encoding::writeString(exceptionPositionsEncoded, pos);
-    encoding::writeString(exceptionValuesEncoded, pos);
-    if (baseBitWidth > 0) {
-      std::memset(pos, 0, bitpackedSize);
-      FixedBitArray fba(pos, baseBitWidth);
-      fba.bulkSetWithBaseline(
-          /*start=*/0,
-          /*length=*/rowCount,
-          maskedResiduals.data(),
-          /*baseline=*/physicalType{0});
-      pos += bitpackedSize;
-    }
-    NIMBLE_CHECK_EQ(
-        pos - reserved, encodingSize, "Pfor encoding size mismatch.");
-    return {reserved, encodingSize};
   }
+
+  const bool useVarint = options.useVarintRowCount;
+  NIMBLE_CHECK(!values.empty(), "Pfor encoding cannot be used with 0 rows.");
+
+  const uint32_t rowCount = static_cast<uint32_t>(values.size());
+  const physicalType baseline = selection.statistics().min();
+  const physicalType maxValue = selection.statistics().max();
+  const physicalType fullRange = static_cast<physicalType>(maxValue - baseline);
+  const uint8_t maxBitWidth =
+      static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
+
+  const auto [selectedBaseBitWidth, expectedExceptions] = selectBaseBitWidth(
+      selection.statistics().bucketCounts(), rowCount, maxBitWidth);
+
+  // Single pass: compute residuals, identify exceptions that overflow
+  // baseBitWidth, and zero-mask exception slots in the residual array.
+  constexpr uint32_t kBitsPerPhysicalType = sizeof(physicalType) * 8;
+  const physicalType baseMask = selectedBaseBitWidth == 0
+      ? physicalType{0}
+      : static_cast<physicalType>(velox::bits::lowMask(selectedBaseBitWidth));
+
+  auto* pool = &buffer.getMemoryPool();
+  Vector<uint32_t> exceptionPositions{pool};
+  Vector<physicalType> exceptionValues{pool};
+  // Reserve for expected exceptions based on the 90% coverage threshold.
+  exceptionPositions.reserve(expectedExceptions);
+  exceptionValues.reserve(expectedExceptions);
+
+  Vector<physicalType> maskedResiduals{pool};
+  maskedResiduals.resize(rowCount);
+  physicalType maxBaseResidual{0};
+  for (auto i = 0; i < rowCount; ++i) {
+    const physicalType residual =
+        static_cast<physicalType>(values[i] - baseline);
+    if (selectedBaseBitWidth < kBitsPerPhysicalType && residual > baseMask) {
+      exceptionPositions.emplace_back(i);
+      exceptionValues.emplace_back(residual);
+      maskedResiduals[i] = physicalType{0};
+    } else {
+      maskedResiduals[i] = residual;
+      maxBaseResidual = std::max(maxBaseResidual, residual);
+    }
+  }
+  const uint32_t numExceptions =
+      static_cast<uint32_t>(exceptionPositions.size());
+  const uint8_t exactBaseBitWidth =
+      static_cast<uint8_t>(velox::bits::bitsRequired(maxBaseResidual));
+  NIMBLE_CHECK_LE(
+      exactBaseBitWidth,
+      selectedBaseBitWidth,
+      "Pfor exact bit width should not exceed selected bit width.");
+  const uint8_t baseBitWidth = options.fixedBitWidthUseExactBits
+      ? exactBaseBitWidth
+      : selectedBaseBitWidth;
+
+  const uint64_t bitpackedSize =
+      baseBitWidth == 0 ? 0 : FixedBitArray::bufferSize(rowCount, baseBitWidth);
+
+  // PFOR encodes the exception side-channels through recursive encoding
+  // selection so Nimble can pick the best sub-encoding.
+  // The bulk base residuals always stay raw to preserve the fast decode path.
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  std::string_view exceptionPositionsEncoded{};
+  std::string_view exceptionValuesEncoded{};
+  if (numExceptions > 0) {
+    exceptionPositionsEncoded = selection.template encodeNested<uint32_t>(
+        EncodingIdentifiers::Pfor::ExceptionPositions,
+        std::span<const uint32_t>(exceptionPositions.data(), numExceptions),
+        scopedBuffer.get(),
+        options);
+    exceptionValuesEncoded = selection.template encodeNested<physicalType>(
+        EncodingIdentifiers::Pfor::ExceptionValues,
+        std::span<const physicalType>(exceptionValues.data(), numExceptions),
+        scopedBuffer.get(),
+        options);
+  }
+  const auto exceptionPositionsEncodedSize =
+      static_cast<uint32_t>(exceptionPositionsEncoded.size());
+  const auto exceptionValuesEncodedSize =
+      static_cast<uint32_t>(exceptionValuesEncoded.size());
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, useVarint) +
+      PFOREncoding<T>::kFixedHeaderSize + varint::varintSize(numExceptions) +
+      varint::varintSize(exceptionPositionsEncodedSize) +
+      varint::varintSize(exceptionValuesEncodedSize) +
+      exceptionPositionsEncodedSize + exceptionValuesEncodedSize +
+      static_cast<uint32_t>(bitpackedSize);
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::PFOR, TypeTraits<T>::dataType, rowCount, useVarint, pos);
+  encoding::write(baseline, pos);
+  encoding::writeChar(static_cast<char>(baseBitWidth), pos);
+  varint::writeVarint(numExceptions, &pos);
+  encoding::writeVarintString(exceptionPositionsEncoded, pos);
+  encoding::writeVarintString(exceptionValuesEncoded, pos);
+  if (baseBitWidth > 0) {
+    std::memset(pos, 0, bitpackedSize);
+    FixedBitArray fba(pos, baseBitWidth);
+    fba.bulkSetWithBaseline(
+        /*start=*/0,
+        /*length=*/rowCount,
+        maskedResiduals.data(),
+        /*baseline=*/physicalType{0});
+    pos += bitpackedSize;
+  }
+  NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Pfor encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+typename PFOREncoding<T>::ExceptionSlice PFOREncoding<T>::sliceExceptions(
+    std::string_view exceptionPositions,
+    std::string_view exceptionValues,
+    uint32_t numExceptions,
+    uint32_t offset,
+    uint32_t length,
+    velox::memory::MemoryPool* pool,
+    Buffer& scratchBuffer,
+    const Encoding::Options& options) {
+  if (numExceptions == 0) {
+    return {};
+  }
+
+  NIMBLE_CHECK_NOT_NULL(pool);
+  ScopedVector<uint32_t> positions{numExceptions, pool, options.bufferPool};
+  auto positionsEncoding =
+      EncodingFactory(options).create(*pool, exceptionPositions, nullptr);
+  positionsEncoding->materialize(numExceptions, positions.data());
+
+  const auto sliceBegin =
+      std::lower_bound(positions.begin(), positions.end(), offset);
+  const auto sliceEnd =
+      std::lower_bound(sliceBegin, positions.end(), offset + length);
+  const auto exceptionOffset =
+      static_cast<uint32_t>(sliceBegin - positions.begin());
+  const auto slicedExceptionCount =
+      static_cast<uint32_t>(sliceEnd - sliceBegin);
+  if (slicedExceptionCount == 0) {
+    return {};
+  }
+
+  ScopedVector<uint32_t> rebasedPositions{
+      slicedExceptionCount, pool, options.bufferPool};
+  for (uint32_t i = 0; i < slicedExceptionCount; ++i) {
+    rebasedPositions[i] = sliceBegin[i] - offset;
+  }
+
+  return {
+      .positions = EncodingFactory::encodeWithCapturedLayout<uint32_t>(
+          exceptionPositions,
+          {rebasedPositions.data(), rebasedPositions.size()},
+          scratchBuffer,
+          options,
+          "Captured PFOR exception positions layout"),
+      .values = EncodingFactory::slice(
+          exceptionValues,
+          exceptionOffset,
+          slicedExceptionCount,
+          scratchBuffer,
+          options),
+      .count = slicedExceptionCount};
+}
+
+template <typename T>
+std::string_view PFOREncoding<T>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+
+  auto* pool = &buffer.getMemoryPool();
+  const char* readPos = encoded.data() +
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  const auto baseline = encoding::read<physicalType>(readPos);
+  const auto baseBitWidth = static_cast<uint8_t>(encoding::readChar(readPos));
+  NIMBLE_CHECK_LE(baseBitWidth, 64, "Pfor base bit width must be in [0, 64].");
+  const auto numExceptions = varint::readVarint32(&readPos);
+  NIMBLE_CHECK_LE(
+      numExceptions, sourceRowCount, "Pfor exception count exceeds row count.");
+  const auto exceptionPositionsSize = varint::readVarint32(&readPos);
+  NIMBLE_CHECK_EQ(
+      numExceptions == 0,
+      exceptionPositionsSize == 0,
+      "Pfor exception positions stream size must match exception count.");
+  const std::string_view exceptionPositions{readPos, exceptionPositionsSize};
+  readPos += exceptionPositionsSize;
+  const auto exceptionValuesSize = varint::readVarint32(&readPos);
+  NIMBLE_CHECK_EQ(
+      numExceptions == 0,
+      exceptionValuesSize == 0,
+      "Pfor exception values stream size must match exception count.");
+  const std::string_view exceptionValues{readPos, exceptionValuesSize};
+  readPos += exceptionValuesSize;
+  const std::string_view packedData{
+      readPos, static_cast<size_t>(encoded.end() - readPos)};
+
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  const auto exceptionSlice = sliceExceptions(
+      exceptionPositions,
+      exceptionValues,
+      numExceptions,
+      offset,
+      length,
+      pool,
+      scopedBuffer.get(),
+      options);
+
+  const uint32_t bitpackedSize = baseBitWidth == 0
+      ? 0
+      : static_cast<uint32_t>(FixedBitArray::bufferSize(length, baseBitWidth));
+  const auto slicedExceptionPositionsSize =
+      static_cast<uint32_t>(exceptionSlice.positions.size());
+  const auto slicedExceptionValuesSize =
+      static_cast<uint32_t>(exceptionSlice.values.size());
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(length, options.useVarintRowCount) +
+      kFixedHeaderSize + varint::varintSize(exceptionSlice.count) +
+      varint::varintSize(slicedExceptionPositionsSize) +
+      varint::varintSize(slicedExceptionValuesSize) +
+      slicedExceptionPositionsSize + slicedExceptionValuesSize + bitpackedSize;
+  char* reserved = buffer.reserve(encodingSize);
+  char* writePos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::PFOR,
+      TypeTraits<T>::dataType,
+      length,
+      options.useVarintRowCount,
+      writePos);
+  encoding::write(baseline, writePos);
+  encoding::writeChar(static_cast<char>(baseBitWidth), writePos);
+  varint::writeVarint(exceptionSlice.count, &writePos);
+  encoding::writeVarintString(exceptionSlice.positions, writePos);
+  encoding::writeVarintString(exceptionSlice.values, writePos);
+  if (baseBitWidth > 0) {
+    std::memset(writePos, 0, bitpackedSize);
+    const auto sourceBitOffset = static_cast<uint64_t>(offset) * baseBitWidth;
+    const auto sliceBits = static_cast<uint64_t>(length) * baseBitWidth;
+    encoding::copyPackedBits(packedData, sourceBitOffset, sliceBits, writePos);
+    writePos += bitpackedSize;
+  }
+  NIMBLE_CHECK_EQ(
+      writePos - reserved, encodingSize, "Pfor encoding size mismatch.");
+  return {reserved, encodingSize};
 }
 
 template <typename T>

--- a/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
@@ -19,6 +19,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
@@ -106,6 +107,16 @@ Vector<double> makeAlpDouble(uint32_t n = kNumElements) {
   return data;
 }
 
+Vector<uint32_t> makePforUint32(uint32_t n = kNumElements) {
+  auto& pool = benchmarkPool();
+  Vector<uint32_t> data{pool.get()};
+  data.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    data[i] = i % 10 == 7 ? 100000 + i : 50 + (i % 64);
+  }
+  return data;
+}
+
 } // namespace
 
 #define SLICE_BENCHMARKS(Name, EncodingT, ValueT, EncodingTypeValue, DataExpr) \
@@ -184,6 +195,12 @@ SLICE_BENCHMARKS(
     uint32_t,
     EncodingType::BlockBitPacking,
     makeIncreasing<uint32_t>());
+SLICE_BENCHMARKS(
+    PFORUint32,
+    PFOREncoding<uint32_t>,
+    uint32_t,
+    EncodingType::PFOR,
+    makePforUint32());
 SLICE_BENCHMARKS(
     ALPDouble,
     ALPEncoding<double>,

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -28,6 +28,8 @@
 #include "velox/dwio/common/ColumnVisitors.h"
 #include "velox/dwio/common/DecoderUtil.h"
 
+#include <algorithm>
+#include <string_view>
 #include <type_traits>
 
 /// The Encoding class defines an interface for interacting with encodings

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -219,12 +219,12 @@ EncodingLayout EncodingLayoutCapture::capture(
       const char* pos = encoding.data() + prefixSize;
       pos += detail::dataTypeSize(dataType); // baseline
       encoding::readChar(pos); // baseBitWidth
-      encoding::readUint32(pos); // numExceptions
+      varint::readVarint32(&pos); // numExceptions
 
       children.reserve(2);
-      const auto positionsBytes = encoding::readUint32(pos);
+      const auto positionsBytes = varint::readVarint32(&pos);
       captureChild(children, pos, positionsBytes, options);
-      const auto valuesBytes = encoding::readUint32(pos);
+      const auto valuesBytes = varint::readVarint32(&pos);
       captureChild(children, pos, valuesBytes, options);
       break;
     }

--- a/dwio/nimble/encodings/common/EncodingPrimitives.h
+++ b/dwio/nimble/encodings/common/EncodingPrimitives.h
@@ -15,11 +15,14 @@
  */
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <string_view>
 
 #include "folly/io/IOBuf.h"
 #include "velox/common/base/BitUtil.h"
+#include "velox/common/base/Exceptions.h"
 
 // Primitives for reading and writing to a stream of bytes.
 
@@ -52,6 +55,40 @@ inline void writeUint64(uint64_t value, char*& pos) {
 inline void writeBytes(std::string_view value, char*& pos) {
   std::copy(value.cbegin(), value.cend(), pos);
   pos += value.size();
+}
+
+inline void writeVarintUint32(uint32_t value, char*& pos) {
+  while (value >= 128) {
+    *pos++ = static_cast<char>(0x80 | (value & 0x7f));
+    value >>= 7;
+  }
+  *pos++ = static_cast<char>(value);
+}
+
+// Varint byte length followed by chars.
+inline void writeVarintString(std::string_view value, char*& pos) {
+  writeVarintUint32(static_cast<uint32_t>(value.size()), pos);
+  writeBytes(value, pos);
+}
+
+// Copies a bit range from a packed source to the start of output. The caller
+// owns destination sizing and zero-filling for any unused trailing bits.
+inline void copyPackedBits(
+    std::string_view source,
+    uint64_t sourceBitOffset,
+    uint64_t bitCount,
+    char* output) {
+  VELOX_CHECK(bitCount > 0, "Cannot copy zero bits.");
+  if (sourceBitOffset % 8 == 0 && bitCount % 8 == 0) {
+    std::memcpy(output, source.data() + sourceBitOffset / 8, bitCount / 8);
+    return;
+  }
+  velox::bits::copyBits(
+      reinterpret_cast<const uint64_t*>(source.data()),
+      sourceBitOffset,
+      reinterpret_cast<uint64_t*>(output),
+      /*targetOffset=*/0,
+      bitCount);
 }
 
 // Just the buffers, no leading length.

--- a/dwio/nimble/encodings/tests/EncodingUtilsTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingUtilsTest.cpp
@@ -15,33 +15,133 @@
  */
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 #include <gtest/gtest.h>
+#include <array>
+#include <vector>
+#include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 using namespace facebook::nimble;
 
-TEST(EncodingUtilsTest, DataTypeSizeOneByte) {
+TEST(EncodingUtilsTest, dataTypeSizeOneByte) {
   EXPECT_EQ(1, detail::dataTypeSize(DataType::Int8));
   EXPECT_EQ(1, detail::dataTypeSize(DataType::Uint8));
   EXPECT_EQ(1, detail::dataTypeSize(DataType::Bool));
 }
 
-TEST(EncodingUtilsTest, DataTypeSizeTwoBytes) {
+TEST(EncodingUtilsTest, dataTypeSizeTwoBytes) {
   EXPECT_EQ(2, detail::dataTypeSize(DataType::Int16));
   EXPECT_EQ(2, detail::dataTypeSize(DataType::Uint16));
 }
 
-TEST(EncodingUtilsTest, DataTypeSizeFourBytes) {
+TEST(EncodingUtilsTest, dataTypeSizeFourBytes) {
   EXPECT_EQ(4, detail::dataTypeSize(DataType::Int32));
   EXPECT_EQ(4, detail::dataTypeSize(DataType::Uint32));
   EXPECT_EQ(4, detail::dataTypeSize(DataType::Float));
 }
 
-TEST(EncodingUtilsTest, DataTypeSizeEightBytes) {
+TEST(EncodingUtilsTest, dataTypeSizeEightBytes) {
   EXPECT_EQ(8, detail::dataTypeSize(DataType::Int64));
   EXPECT_EQ(8, detail::dataTypeSize(DataType::Uint64));
   EXPECT_EQ(8, detail::dataTypeSize(DataType::Double));
 }
 
-TEST(EncodingUtilsTest, DataTypeSizeUnsupported) {
+TEST(EncodingUtilsTest, dataTypeSizeUnsupported) {
   EXPECT_THROW(detail::dataTypeSize(DataType::String), NimbleUserError);
   EXPECT_THROW(detail::dataTypeSize(DataType::Undefined), NimbleUserError);
+}
+
+TEST(EncodingUtilsTest, writeVarintString) {
+  const std::vector<std::string> values{
+      "",
+      "a",
+      std::string(127, 'x'),
+      std::string(128, 'y'),
+      std::string(130, 'z')};
+  size_t totalSize{0};
+  for (const auto& value : values) {
+    totalSize += varint::varintSize(value.size()) + value.size();
+  }
+  std::vector<char> buffer(totalSize);
+  char* writePos = buffer.data();
+
+  for (const auto& value : values) {
+    encoding::writeVarintString(value, writePos);
+  }
+
+  const char* readPos = buffer.data();
+  for (const auto& value : values) {
+    SCOPED_TRACE(testing::Message() << "size=" << value.size());
+    EXPECT_EQ(varint::readVarint32(&readPos), value.size());
+    EXPECT_EQ(std::string_view(readPos, value.size()), value);
+    readPos += value.size();
+  }
+  EXPECT_EQ(readPos, writePos);
+}
+
+TEST(EncodingUtilsTest, copyPackedBits) {
+  struct TestCase {
+    const char* name;
+    uint8_t bitWidth;
+    uint32_t sourceValueCount;
+    uint32_t sourceValueBase;
+    uint64_t sourceBitOffset;
+    uint64_t bitCount;
+    std::vector<uint64_t> expected;
+  };
+
+  for (const auto& testCase : {
+           TestCase{
+               .name = "byteAligned",
+               .bitWidth = 4,
+               .sourceValueCount = 16,
+               .sourceValueBase = 0,
+               .sourceBitOffset = 16,
+               .bitCount = 32,
+               .expected = {4, 5, 6, 7, 8, 9, 10, 11}},
+           TestCase{
+               .name = "misaligned",
+               .bitWidth = 5,
+               .sourceValueCount = 12,
+               .sourceValueBase = 3,
+               .sourceBitOffset = 5,
+               .bitCount = 35,
+               .expected = {4, 5, 6, 7, 8, 9, 10}},
+       }) {
+    SCOPED_TRACE(testCase.name);
+
+    std::array<char, 8> source{};
+    std::array<char, 8> output{};
+    FixedBitArray sourceBits{source.data(), testCase.bitWidth};
+    for (uint32_t i = 0; i < testCase.sourceValueCount; ++i) {
+      sourceBits.set(i, i + testCase.sourceValueBase);
+    }
+
+    encoding::copyPackedBits(
+        {source.data(), source.size()},
+        testCase.sourceBitOffset,
+        testCase.bitCount,
+        output.data());
+
+    FixedBitArray outputBits{output.data(), testCase.bitWidth};
+    std::vector<uint64_t> actual;
+    actual.reserve(testCase.expected.size());
+    for (uint32_t i = 0; i < testCase.expected.size(); ++i) {
+      actual.push_back(outputBits.get(i));
+    }
+    EXPECT_EQ(actual, testCase.expected);
+  }
+}
+
+TEST(EncodingUtilsTest, copyPackedBitsRejectsEmptyRange) {
+  std::array<char, 8> source{};
+  std::array<char, 8> output{};
+  VELOX_ASSERT_THROW(
+      encoding::copyPackedBits(
+          {source.data(), source.size()},
+          /*sourceBitOffset=*/0,
+          /*bitCount=*/0,
+          output.data()),
+      "Cannot copy zero bits.");
 }

--- a/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/PFOREncodingTest.cpp
@@ -21,6 +21,7 @@
 #include <random>
 
 #include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
@@ -50,10 +51,10 @@ PforWireInfo readPforWireInfo(
   const char* pos = encoded.data() + prefixSize;
   pos += sizeof(uint32_t);
   const auto baseBitWidth = static_cast<uint8_t>(encoding::readChar(pos));
-  const auto numExceptions = encoding::readUint32(pos);
-  const auto exceptionPositionsSize = encoding::readUint32(pos);
+  const auto numExceptions = varint::readVarint32(&pos);
+  const auto exceptionPositionsSize = varint::readVarint32(&pos);
   pos += exceptionPositionsSize;
-  const auto exceptionValuesSize = encoding::readUint32(pos);
+  const auto exceptionValuesSize = varint::readVarint32(&pos);
   pos += exceptionValuesSize;
   return {
       .baseBitWidth = baseBitWidth,
@@ -213,6 +214,44 @@ TEST(PFOREncodingBufferPoolTest, reusesExceptionBuffers) {
   EXPECT_EQ(decodePool->stats().numAllocs, numAllocsAfterFirstDecode);
 }
 
+TEST(PFOREncodingBufferPoolTest, sliceReturnsScratchBufferToPool) {
+  using Value = uint64_t;
+  using EncodingType = PFOREncoding<Value>;
+
+  auto pool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  Buffer encodeBuffer{*pool};
+  std::vector<Value> input;
+  input.reserve(300);
+  for (uint32_t i = 0; i < 300; ++i) {
+    input.push_back(
+        i % 10 == 7 ? static_cast<Value>(100000 + i)
+                    : static_cast<Value>(50 + (i % 64)));
+  }
+
+  Vector<Value> values{pool.get()};
+  values.insert(values.end(), input.data(), input.data() + input.size());
+  const auto encoded = Encoder<EncodingType>::encode(encodeBuffer, values);
+  const std::string encodedStorage{encoded};
+
+  velox::BufferPool bufferPool{velox::BufferPool::kDefaultCapacity};
+  const Encoding::Options options{.bufferPool = &bufferPool};
+  Buffer sliceBuffer{*pool};
+  const auto sliced = EncodingType::slice(
+      encodedStorage,
+      /*offset=*/17,
+      /*length=*/128,
+      sliceBuffer,
+      options);
+
+  EXPECT_GT(bufferPool.size(), 0);
+
+  EncodingType encoding{*pool, sliced, nullptr, options};
+  std::vector<Value> output(128);
+  encoding.materialize(static_cast<uint32_t>(output.size()), output.data());
+  EXPECT_EQ(
+      output, std::vector<Value>(input.begin() + 17, input.begin() + 17 + 128));
+}
+
 struct PforBitWidthStorageParam {
   bool fixedBitWidthUseExactBits;
   uint8_t expectedBaseBitWidth;
@@ -353,6 +392,110 @@ TYPED_TEST(PFOREncodingTest, skipAndMaterialize) {
   }
 }
 
+TYPED_TEST(PFOREncodingTest, slice) {
+  using T = TypeParam;
+
+  struct Range {
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  std::vector<T> values;
+  values.reserve(300);
+  for (uint32_t i = 0; i < 300; ++i) {
+    if constexpr (sizeof(T) >= 4) {
+      values.push_back(
+          static_cast<T>(i % 10 == 7 ? 100000 + i : 50 + (i % 64)));
+    } else {
+      values.push_back(static_cast<T>(50 + (i % 64)));
+    }
+  }
+  const auto valueCount = static_cast<uint32_t>(values.size());
+
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(fmt::format("useVarint={}", useVarint));
+    const Encoding::Options options{.useVarintRowCount = useVarint};
+    Buffer buffer{*this->pool_};
+    const auto encoded = EncodingFactory::encode<T>(
+        this->createSelectionPolicy(),
+        std::span<const T>{values.data(), values.size()},
+        buffer,
+        options);
+
+    for (const auto range :
+         {Range{/*offset=*/0, /*length=*/1},
+          Range{/*offset=*/1, /*length=*/37},
+          Range{/*offset=*/127, /*length=*/64},
+          Range{/*offset=*/valueCount - 43, /*length=*/43}}) {
+      SCOPED_TRACE(
+          fmt::format("offset={}, length={}", range.offset, range.length));
+      Buffer sliceBuffer{*this->pool_};
+      const auto sliced = PFOREncoding<T>::slice(
+          encoded, range.offset, range.length, sliceBuffer, options);
+
+      PFOREncoding<T> encoding{*this->pool_, sliced, nullptr, options};
+      EXPECT_EQ(encoding.encodingType(), EncodingType::PFOR);
+      EXPECT_EQ(encoding.dataType(), TypeTraits<T>::dataType);
+      EXPECT_EQ(encoding.rowCount(), range.length);
+
+      std::vector<T> output(range.length);
+      encoding.materialize(range.length, output.data());
+      EXPECT_EQ(
+          output,
+          std::vector<T>(
+              values.begin() + range.offset,
+              values.begin() + range.offset + range.length));
+    }
+  }
+}
+
+TYPED_TEST(PFOREncodingTest, invalidSliceRange) {
+  using T = TypeParam;
+
+  std::vector<T> values;
+  values.reserve(16);
+  for (uint32_t i = 0; i < 16; ++i) {
+    values.push_back(static_cast<T>(i + 1));
+  }
+
+  for (const bool useVarint : {false, true}) {
+    SCOPED_TRACE(fmt::format("useVarint={}", useVarint));
+    const Encoding::Options options{.useVarintRowCount = useVarint};
+    Buffer buffer{*this->pool_};
+    const auto encoded = EncodingFactory::encode<T>(
+        this->createSelectionPolicy(),
+        std::span<const T>{values.data(), values.size()},
+        buffer,
+        options);
+
+    Buffer sliceBuffer{*this->pool_};
+    NIMBLE_ASSERT_THROW(
+        PFOREncoding<T>::slice(
+            encoded,
+            /*offset=*/0,
+            /*length=*/0,
+            sliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        PFOREncoding<T>::slice(
+            encoded,
+            /*offset=*/values.size() + 1,
+            /*length=*/1,
+            sliceBuffer,
+            options),
+        "");
+    NIMBLE_ASSERT_THROW(
+        PFOREncoding<T>::slice(
+            encoded,
+            /*offset=*/values.size() - 1,
+            /*length=*/2,
+            sliceBuffer,
+            options),
+        "");
+  }
+}
+
 TYPED_TEST(PFOREncodingTest, exceptionAtFirstAndLastRow) {
   // Edge case: exceptions land on the first row, the last row, and a
   // middle row. Verifies cursor handling at the bounds.
@@ -453,6 +596,26 @@ class PFOREncodingFuzzerTest : public ::testing::Test {
       for (size_t i = 0; i < values.size(); ++i) {
         ASSERT_EQ(decoded[i], values[i])
             << "iter=" << iter << " i=" << i << " size=" << numValues;
+      }
+
+      std::uniform_int_distribution<uint32_t> offsetDist(0, numValues - 1);
+      const uint32_t sliceOffset = offsetDist(rng);
+      std::uniform_int_distribution<uint32_t> lengthDist(
+          1, numValues - sliceOffset);
+      const uint32_t sliceLength = lengthDist(rng);
+      Buffer sliceBuffer{*pool_};
+      const auto sliced = PFOREncoding<T>::slice(
+          {storage.data(), storage.size()},
+          sliceOffset,
+          sliceLength,
+          sliceBuffer);
+      PFOREncoding<T> slicedEncoding{*pool_, sliced, nullptr};
+      std::vector<T> slicedValues(sliceLength);
+      slicedEncoding.materialize(sliceLength, slicedValues.data());
+      for (uint32_t i = 0; i < sliceLength; ++i) {
+        ASSERT_EQ(slicedValues[i], values[sliceOffset + i])
+            << "iter=" << iter << " sliceOffset=" << sliceOffset << " i=" << i
+            << " sliceLength=" << sliceLength;
       }
 
       // Random skip/materialize sequence.

--- a/dwio/nimble/encodings/views/PFOREncodingView.h
+++ b/dwio/nimble/encodings/views/PFOREncodingView.h
@@ -18,6 +18,7 @@
 #include <algorithm>
 
 #include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
@@ -42,11 +43,16 @@ class PFOREncodingView final : public TypedEncodingView<T> {
     baseline_ = encoding::read<physicalType>(pos);
     baseBitWidth_ = static_cast<uint8_t>(encoding::readChar(pos));
     NIMBLE_CHECK_LE(baseBitWidth_, sizeof(physicalType) * 8);
-    numExceptions_ = encoding::readUint32(pos);
+    numExceptions_ = varint::readVarint32(&pos);
     NIMBLE_CHECK_LE(numExceptions_, this->rowCount_);
 
-    if (numExceptions_ > 0) {
-      const auto exceptionPositionsSize = encoding::readUint32(pos);
+    const auto exceptionPositionsSize = varint::readVarint32(&pos);
+    if (numExceptions_ == 0) {
+      NIMBLE_CHECK_EQ(
+          exceptionPositionsSize,
+          0,
+          "Empty Pfor exception positions stream has data.");
+    } else {
       auto noStringBufferFactory = [](uint32_t) -> void* { return nullptr; };
       auto exceptionPositions = EncodingFactory(options).create(
           *this->pool_, {pos, exceptionPositionsSize}, noStringBufferFactory);
@@ -54,23 +60,24 @@ class PFOREncodingView final : public TypedEncodingView<T> {
       exceptionPositions_.resize(numExceptions_);
       exceptionPositions->materialize(
           numExceptions_, exceptionPositions_.data());
-      pos += exceptionPositionsSize;
-    } else {
-      pos += sizeof(uint32_t);
     }
+    pos += exceptionPositionsSize;
 
-    if (numExceptions_ > 0) {
-      const auto exceptionValuesSize = encoding::readUint32(pos);
+    const auto exceptionValuesSize = varint::readVarint32(&pos);
+    if (numExceptions_ == 0) {
+      NIMBLE_CHECK_EQ(
+          exceptionValuesSize,
+          0,
+          "Empty Pfor exception values stream has data.");
+    } else {
       auto noStringBufferFactory = [](uint32_t) -> void* { return nullptr; };
       auto exceptionValues = EncodingFactory(options).create(
           *this->pool_, {pos, exceptionValuesSize}, noStringBufferFactory);
       NIMBLE_CHECK_NOT_NULL(exceptionValues);
       exceptionValues_.resize(numExceptions_);
       exceptionValues->materialize(numExceptions_, exceptionValues_.data());
-      pos += exceptionValuesSize;
-    } else {
-      pos += sizeof(uint32_t);
     }
+    pos += exceptionValuesSize;
 
     if (baseBitWidth_ > 0) {
       fixedBitArray_ = FixedBitArray{

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -201,14 +201,14 @@ void traverseEncodings(
     }
     case EncodingType::PFOR: {
       // Layout after the common prefix: baseline [dataTypeSize bytes],
-      // baseBitWidth [1 byte], numExceptions [4 bytes], then two
-      // self-describing nested sub-streams, each preceded by a 4-byte size:
+      // baseBitWidth [1 byte], numExceptions [varint], then two
+      // self-describing nested sub-streams, each preceded by a varint size:
       // the exception positions and the exception residual values.
       const char* pos = stream.data() + dataOffset;
       pos += detail::dataTypeSize(dataType); // baseline
       encoding::readChar(pos); // baseBitWidth
-      encoding::readUint32(pos); // numExceptions
-      const uint32_t positionsSize = encoding::readUint32(pos);
+      varint::readVarint32(&pos); // numExceptions
+      const uint32_t positionsSize = varint::readVarint32(&pos);
       if (positionsSize > 0) {
         traverseEncodings(
             {pos, positionsSize},
@@ -219,7 +219,7 @@ void traverseEncodings(
             visitor);
       }
       pos += positionsSize;
-      const uint32_t valuesSize = encoding::readUint32(pos);
+      const uint32_t valuesSize = varint::readVarint32(&pos);
       if (valuesSize > 0) {
         traverseEncodings(
             {pos, valuesSize},

--- a/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
+++ b/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
@@ -94,16 +94,17 @@ class EncodingUtilitiesTest : public ::testing::Test {
   //   bytes 0-5: prefix (EncodingType::PFOR, DataType::Uint32, rowCount)
   //   bytes 6-9: baseline (uint32)
   //   byte 10: baseBitWidth (0)
-  //   bytes 11-14: numExceptions (uint32)
+  //   byte 11+: numExceptions (varint)
   //   then the positions sub-stream and the values sub-stream, each preceded by
-  //   a 4-byte size.
+  //   a varint size.
   std::string buildPforUint32Stream(
       uint32_t numExceptions,
       const std::string& positions,
       const std::string& values) {
     const size_t totalSize = 6 + sizeof(uint32_t) /* baseline */ +
-        1 /* baseBitWidth */ + sizeof(uint32_t) /* numExceptions */ +
-        sizeof(uint32_t) + positions.size() + sizeof(uint32_t) + values.size();
+        1 /* baseBitWidth */ + varint::varintSize(numExceptions) +
+        varint::varintSize(positions.size()) + positions.size() +
+        varint::varintSize(values.size()) + values.size();
     std::string buf(totalSize, '\0');
     char* pos = buf.data();
     encoding::writeChar(static_cast<char>(EncodingType::PFOR), pos);
@@ -111,10 +112,10 @@ class EncodingUtilitiesTest : public ::testing::Test {
     encoding::writeUint32(/* rowCount */ 100, pos);
     encoding::writeUint32(/* baseline */ 0, pos);
     encoding::writeChar(/* baseBitWidth */ 0, pos);
-    encoding::writeUint32(numExceptions, pos);
-    encoding::writeUint32(static_cast<uint32_t>(positions.size()), pos);
+    varint::writeVarint(numExceptions, &pos);
+    varint::writeVarint(static_cast<uint32_t>(positions.size()), &pos);
     encoding::writeBytes(positions, pos);
-    encoding::writeUint32(static_cast<uint32_t>(values.size()), pos);
+    varint::writeVarint(static_cast<uint32_t>(values.size()), &pos);
     encoding::writeBytes(values, pos);
     return buf;
   }


### PR DESCRIPTION
Summary:
Adds native slice support for PFOR-encoded streams.

The slice path parses the PFOR header directly, varint-encodes the exception metadata (`numExceptions` plus the exception-position and exception-value child stream size prefixes), slices and rebases only exception positions that fall inside the requested range, slices the matching exception values child stream, and bit-copies the packed base residual range into the output stream. The packed base residual bytes remain raw payload rather than a nested size-prefixed stream. This avoids materializing the selected row values and re-running PFOR encoding while keeping the sliced output self-contained.

This diff also adds dedicated PFOR slice unit coverage for valid and invalid ranges across supported unsigned integer physical types, buffer-pool scratch reuse coverage, view/layout/tooling parser updates for the varint PFOR metadata, and a PFORUint32 slice benchmark.

Latest opt slice benchmark:
- Native slice: 11.32us
- Materialize + encode: 79.54us
- Speedup: ~7.0x faster.

Differential Revision: D113728377


