### PR TITLE
feat(nimble): Deserializer honors kTablet per-batch rowRange (#1045)

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -20,6 +20,7 @@
 #include "dwio/nimble/velox/SchemaReader.h"
 #include "dwio/nimble/velox/SchemaUtils.h"
 #include "folly/Likely.h"
+#include "folly/ScopeGuard.h"
 #include "folly/container/F14Set.h"
 #include "velox/buffer/Buffer.h"
 #include "velox/dwio/common/ColumnSelector.h"
@@ -148,18 +149,45 @@ class SegmentedStreamDecoder : public Decoder {
       return 0;
     }
 
+    uint32_t nonNullCount;
     if (scatterOutputBitmap != nullptr) {
-      return scatteredRead(
+      nonNullCount = scatteredRead(
           count, output, getOutputNulls, scatterOutputBitmap, stringBuffers);
+    } else if (isInMapStream()) {
+      nonNullCount = inMapRead(count, output, stringBuffers);
+    } else {
+      nonNullCount = denseRead(count, output, getOutputNulls, stringBuffers);
     }
-    if (isInMapStream()) {
-      return inMapRead(count, output, stringBuffers);
-    }
-    return denseRead(count, output, getOutputNulls, stringBuffers);
+    currentRow_ += count;
+    return nonNullCount;
   }
 
-  void skip(uint32_t /* count */) override {
-    NIMBLE_UNREACHABLE("unexpected call");
+  void skip(uint32_t count) override {
+    if (count == 0) {
+      return;
+    }
+
+    // For non-in-map streams, an empty `streamSegments_` is only valid
+    // for Row/FlatMap null streams that the writer omitted (all-non-null).
+    // Nothing decoded → nothing to advance; just bump the cursor.
+    if (FOLLY_UNLIKELY(!isInMapStream() && streamSegments_.empty())) {
+      NIMBLE_CHECK(
+          type_->isRow() || type_->isFlatMap(),
+          "Empty streamSegments_ only valid for Row/FlatMap null streams");
+      currentRow_ += count;
+      return;
+    }
+
+    // `skipStringBuffers_` is a persistent per-decoder buffer given to
+    // `ensureStreamData`. It must outlive the encoding created by skip,
+    // which may hold `string_view`s into it and be re-used by a
+    // subsequent `next()`.
+    if (isInMapStream()) {
+      skipInMap(count, skipStringBuffers_);
+    } else {
+      skipEncoded(count, skipStringBuffers_);
+    }
+    currentRow_ += count;
   }
 
   void reset() override {
@@ -169,9 +197,14 @@ class SegmentedStreamDecoder : public Decoder {
   void clear() {
     streamSegments_.clear();
     presentInMapSegments_.clear();
+    // Reset streamData_ (and hence its encoding_) BEFORE dropping
+    // skipStringBuffers_ — the encoding may hold string_views into buffers
+    // stored there, and those views must not outlive the buffers.
     streamData_.reset();
+    skipStringBuffers_.clear();
     streamSegmentIndex_ = 0;
     presentSegmentIndex_ = 0;
+    currentRow_ = 0;
   }
 
   const Encoding* encoding() const override {
@@ -182,13 +215,14 @@ class SegmentedStreamDecoder : public Decoder {
     return static_cast<SegmentedStreamDecoder*>(d);
   }
 
-  // Stores raw data without creating encoding objects. Encodings are created
-  // lazily when the segment is first read, ensuring only one encoding tree
-  // exists at a time. This avoids the memory locality and allocation overhead
-  // of creating hundreds of encoding trees simultaneously in batch decode.
-  // Appends a physical stream segment. Only FlatMap in-map streams use
-  // `startRow` to reconstruct gaps for batches that omitted the stream.
-  // Other streams concatenate by payload order.
+  // Queues a physical stream segment for one batch. `startRow` is the
+  // top-level row where the batch begins in the concatenated run; it's
+  // read back by FlatMap in-map reads to detect and fill gaps when
+  // earlier batches omitted the stream. Other streams just concatenate
+  // in payload order.
+  //
+  // The segment is stored as raw bytes. The encoding is constructed
+  // lazily by `ensureStreamData` the first time this segment is decoded.
   void addBatch(
       uint32_t startRow,
       std::string_view data,
@@ -199,12 +233,15 @@ class SegmentedStreamDecoder : public Decoder {
   }
 
   // Records a batch range where this FlatMap key is present in every row.
+  // Called for batches whose in-map stream was omitted on the wire
+  // (writer's all-true optimization). Merges into the previous segment
+  // when contiguous to keep `presentInMapSegments_` compact; `fillInMapGap`
+  // clamps segments that extend past the current read's gap.
   void addPresentInMapBatch(uint32_t startRow, uint32_t rowCount) {
     NIMBLE_CHECK(isInMapStream(), "Expected FlatMap in-map stream");
     NIMBLE_CHECK_GT(
         rowCount, 0, "All-present in-map segment must be non-empty");
     const uint32_t endRow = startRow + rowCount;
-    // Merge with the previous segment if contiguous.
     if (!presentInMapSegments_.empty() &&
         presentInMapSegments_.back().endRow == startRow) {
       presentInMapSegments_.back().endRow = endRow;
@@ -213,8 +250,10 @@ class SegmentedStreamDecoder : public Decoder {
     }
   }
 
-  // Records an all-present FlatMap key range for a null-barrier batch, where
-  // the read request determines the effective end row.
+  // Records an all-present FlatMap key range for a null-barrier batch.
+  // The read's effective end row (not any per-batch rowCount) determines
+  // how many rows are present, so `endRow` stores the sentinel
+  // `kPresentInMapEndRow`; the read side clamps as needed.
   void addPresentInMapBatch() {
     NIMBLE_CHECK(isInMapStream(), "Expected FlatMap in-map stream");
     NIMBLE_CHECK(
@@ -225,10 +264,10 @@ class SegmentedStreamDecoder : public Decoder {
   }
 
  private:
-  // Sentinel end row for all-present FlatMap in-map ranges whose actual row
-  // count comes from the current read request. Null-barrier batches use this
-  // because FlatMap child reads are scoped by the parent Row/FlatMap null
-  // stream, not the physical batch row count.
+  // Sentinel value stored in `InMapSegment::endRow` when the segment's
+  // extent isn't known until the read side (i.e. the parameter-less
+  // `addPresentInMapBatch()` used by null-barrier batches). The read side
+  // clamps the segment to the current gap when it encounters this value.
   static constexpr uint32_t kPresentInMapEndRow =
       std::numeric_limits<uint32_t>::max();
 
@@ -254,12 +293,29 @@ class SegmentedStreamDecoder : public Decoder {
     return isInMapStream_;
   }
 
-  // Lazily creates StreamData for the current physical segment. String buffers
-  // from encoding are pushed directly into the caller's stringBuffers vector,
-  // so no explicit release is needed.
+  // Returns the `StreamData` for the current segment, creating it lazily
+  // on first access. `stringBuffers` is where any string content decoded
+  // out of this segment will be pushed; caller retains ownership.
+  //
+  // On a cache hit (a prior `skip` already built the encoding using our
+  // scratch vector), transfer any buffers the skip path pushed into
+  // `skipStringBuffers_` into the caller's vector so the output takes
+  // shared ownership before the end-of-run `clear()` drops our scratch,
+  // then redirect the encoding's factory target for lazy string
+  // encodings whose future page allocations must land in the caller's
+  // vector, not ours.
   serde::StreamData& ensureStreamData(
       std::vector<velox::BufferPtr>& stringBuffers) {
     if (streamData_.has_value()) {
+      if (!skipStringBuffers_.empty() &&
+          &stringBuffers != &skipStringBuffers_) {
+        stringBuffers.insert(
+            stringBuffers.end(),
+            std::make_move_iterator(skipStringBuffers_.begin()),
+            std::make_move_iterator(skipStringBuffers_.end()));
+        skipStringBuffers_.clear();
+      }
+      streamData_->setStringBuffers(&stringBuffers);
       return *streamData_;
     }
 
@@ -284,10 +340,38 @@ class SegmentedStreamDecoder : public Decoder {
     ++streamSegmentIndex_;
   }
 
-  uint32_t fillInMapGap(uint32_t rowOffset, uint32_t rowCount, void* output) {
+  // Fills the in-map output for rows `[rowOffset, gapEndRow)` where
+  // `gapEndRow = min(rowOffset + rowCount, next stream segment's startRow)`.
+  // Defaults every row to `kInMapAbsent`, then overlays with `kInMapPresent`
+  // for every presence segment in `presentInMapSegments_` that overlaps.
+  // Returns the number of rows filled.
+  //
+  // Parameters:
+  //   * `rowOffset`   — absolute row in the concatenated batch-run row
+  //                     domain (matches `StreamSegment::startRow` and
+  //                     `InMapSegment::startRow`). Drives all range math.
+  //   * `rowCount`    — upper bound on rows to fill; the actual count is
+  //                     capped at the next stream segment's start.
+  //   * `outputOffset` — where in `output` to start writing, in element
+  //                      slots (multiplied by `typeStorageWidth_`).
+  //                      Independent of `rowOffset` because `skip()` moves
+  //                      the row cursor without moving the output cursor.
+  //   * `output`      — destination buffer.
+  //
+  // Presence-segment handling:
+  //   * A segment fully inside the gap is written and consumed
+  //     (`++presentSegmentIndex_`).
+  //   * A segment that extends past `gapEndRow` is partially written
+  //     (clamped to the gap) and its `startRow` is advanced to `gapEndRow`
+  //     so the next call resumes where this one stopped.
+  //   * A segment starting before `rowOffset` (a prior skip landed inside
+  //     it) is clamped on the low end via `max(segment.startRow, rowOffset)`.
+  uint32_t fillInMapGap(
+      uint32_t rowOffset,
+      uint32_t rowCount,
+      uint32_t outputOffset,
+      void* output) {
     NIMBLE_CHECK(isInMapStream(), "Expected FlatMap in-map stream");
-    // rowOffset and rowCount are in the same concatenated batch-run row domain
-    // as StreamSegment::startRow.
     const auto requestEndRow = rowOffset + rowCount;
     const auto gapEndRow = streamSegmentIndex_ < streamSegments_.size()
         ? std::min(requestEndRow, streamSegments_[streamSegmentIndex_].startRow)
@@ -298,31 +382,30 @@ class SegmentedStreamDecoder : public Decoder {
         "FlatMap in-map gap fill requires a non-empty output range");
     const auto numGapRows = gapEndRow - rowOffset;
     auto* const outputBools =
-        static_cast<char*>(output) + rowOffset * typeStorageWidth_;
+        static_cast<char*>(output) + outputOffset * typeStorageWidth_;
     constexpr char kInMapAbsent = 0;
     constexpr char kInMapPresent = 1;
     std::memset(outputBools, kInMapAbsent, numGapRows * typeStorageWidth_);
     while (presentSegmentIndex_ < presentInMapSegments_.size()) {
-      const auto& segment = presentInMapSegments_[presentSegmentIndex_];
+      auto& segment = presentInMapSegments_[presentSegmentIndex_];
       if (segment.startRow >= gapEndRow) {
         break;
       }
-      NIMBLE_CHECK_GE(
-          segment.startRow,
-          rowOffset,
-          "Present in-map segment starts before absent row range");
+      // Clamp both ends. A segment can start before `rowOffset` if a
+      // prior skip landed inside it, and can end past `gapEndRow` when
+      // the current read only covers a prefix (or when the segment is
+      // the null-barrier sentinel `kPresentInMapEndRow`).
+      const auto presentStartRow = std::max(segment.startRow, rowOffset);
       const auto presentEndRow = std::min(segment.endRow, gapEndRow);
       std::memset(
-          outputBools + (segment.startRow - rowOffset) * typeStorageWidth_,
+          outputBools + (presentStartRow - rowOffset) * typeStorageWidth_,
           kInMapPresent,
-          (presentEndRow - segment.startRow) * typeStorageWidth_);
+          (presentEndRow - presentStartRow) * typeStorageWidth_);
       if (segment.endRow > gapEndRow) {
-        // Synthetic all-present ranges can span past the current read request;
-        // physical present ranges are expected to end within this gap.
-        NIMBLE_CHECK_EQ(
-            segment.endRow,
-            kPresentInMapEndRow,
-            "Only all-present in-map segment can extend beyond gap range");
+        // Not fully consumed — advance its start so the next call resumes
+        // where this one left off. `kPresentInMapEndRow` sentinel stays
+        // in `endRow`.
+        segment.startRow = gapEndRow;
         break;
       }
       ++presentSegmentIndex_;
@@ -367,6 +450,91 @@ class SegmentedStreamDecoder : public Decoder {
     const auto width = typeStorageWidth_;
     return streamData.decode(
         output, offset, count, width, getOutputNulls, scatterOutputBitmap);
+  }
+
+  // Skips up to `numRows` rows from the segment at `streamSegmentIndex_`.
+  // Advances `streamSegmentIndex_` past the segment when its remaining
+  // rows fit inside `numRows`; otherwise leaves the cursor mid-segment.
+  // Returns the number of rows actually skipped (never more than
+  // `numRows`, may be less if the segment has fewer remaining).
+  uint32_t skipSegment(
+      uint32_t numRows,
+      std::vector<velox::BufferPtr>& stringBuffers) {
+    NIMBLE_CHECK_LT(
+        streamSegmentIndex_,
+        streamSegments_.size(),
+        "SegmentedStreamDecoder::skip past end of decoder queue");
+    auto& streamData = ensureStreamData(stringBuffers);
+    NIMBLE_CHECK(
+        streamData.hasEncoding(),
+        "SegmentedStreamDecoder::skip requires encoded segments");
+    const auto remainingRows = streamData.remainingRows();
+    NIMBLE_CHECK_GT(remainingRows, 0, "Current segment has no rows");
+    const auto toSkip = std::min<uint32_t>(remainingRows, numRows);
+    streamData.skip(toSkip);
+    if (toSkip == remainingRows) {
+      advanceSegment();
+    }
+    return toSkip;
+  }
+
+  // Skips `numRows` rows for non-in-map columns (dense scalars, FlatMap
+  // value / scattered columns). Walks `streamSegments_` from the current
+  // cursor, consuming each segment fully until `numRows` are covered.
+  void skipEncoded(
+      uint32_t numRows,
+      std::vector<velox::BufferPtr>& stringBuffers) {
+    uint32_t skippedRows = 0;
+    while (skippedRows < numRows) {
+      skippedRows += skipSegment(numRows - skippedRows, stringBuffers);
+    }
+  }
+
+  // Skips `numRows` rows for FlatMap in-map streams. Alternates between
+  // presence-gap regions (advance `presentSegmentIndex_` via
+  // `advanceInMapPresentSegmentIndex`) and encoded segments (advance via
+  // `skipSegment`), mirroring the read-side control flow in
+  // `inMapRead` but writing nothing.
+  void skipInMap(
+      uint32_t numRows,
+      std::vector<velox::BufferPtr>& stringBuffers) {
+    const uint32_t targetRow = currentRow_ + numRows;
+    uint32_t skippedRows = 0;
+    while (skippedRows < numRows) {
+      const uint32_t currentRow = currentRow_ + skippedRows;
+      if (streamSegmentIndex_ >= streamSegments_.size()) {
+        // No more encoded segments — everything left is presence-gap.
+        advanceInMapPresentSegmentIndex(targetRow);
+        break;
+      }
+      const auto nextStreamStartRow =
+          streamSegments_[streamSegmentIndex_].startRow;
+      if (nextStreamStartRow > currentRow) {
+        // Presence gap up to the next encoded segment (or the skip
+        // target, whichever comes first).
+        const uint32_t gapEndRow = std::min(targetRow, nextStreamStartRow);
+        advanceInMapPresentSegmentIndex(gapEndRow);
+        skippedRows += gapEndRow - currentRow;
+        continue;
+      }
+      skippedRows += skipSegment(numRows - skippedRows, stringBuffers);
+    }
+  }
+
+  // Advances `presentSegmentIndex_` past every presence segment fully
+  // contained in `[..., targetRow]` (i.e. `segment.endRow <= targetRow`).
+  // A segment that extends past `targetRow` stays as the current segment;
+  // partial consumption is tracked implicitly (the read side will clamp
+  // it when needed).
+  void advanceInMapPresentSegmentIndex(uint32_t targetRow) {
+    NIMBLE_CHECK(isInMapStream(), "Expected FlatMap in-map stream");
+    while (presentSegmentIndex_ < presentInMapSegments_.size()) {
+      const auto& segment = presentInMapSegments_[presentSegmentIndex_];
+      if (segment.endRow > targetRow) {
+        break;
+      }
+      ++presentSegmentIndex_;
+    }
   }
 
   // Reads `count` non-in-map values into dense output row positions.
@@ -462,8 +630,10 @@ class SegmentedStreamDecoder : public Decoder {
     uint32_t rowsRead{0};
     uint32_t nonNullCount{0};
     while (rowsRead < count) {
+      const uint32_t currentRow = currentRow_ + rowsRead;
       if (streamSegmentIndex_ >= streamSegments_.size()) {
-        const auto rows = fillInMapGap(rowsRead, count - rowsRead, output);
+        const auto rows =
+            fillInMapGap(currentRow, count - rowsRead, rowsRead, output);
         rowsRead += rows;
         nonNullCount += rows;
         break;
@@ -471,11 +641,12 @@ class SegmentedStreamDecoder : public Decoder {
 
       const auto nextStreamStartRow =
           streamSegments_[streamSegmentIndex_].startRow;
-      if (nextStreamStartRow > rowsRead) {
-        const auto rows = fillInMapGap(rowsRead, count - rowsRead, output);
+      if (nextStreamStartRow > currentRow) {
+        const auto rows =
+            fillInMapGap(currentRow, count - rowsRead, rowsRead, output);
         NIMBLE_CHECK_EQ(
             rows,
-            std::min(count, nextStreamStartRow) - rowsRead,
+            std::min(count + currentRow_, nextStreamStartRow) - currentRow,
             "FlatMap in-map gap fill returned unexpected row count");
         rowsRead += rows;
         nonNullCount += rows;
@@ -629,6 +800,21 @@ class SegmentedStreamDecoder : public Decoder {
   // Lazily-created StreamData wrapper reused across physical segments for this
   // stream decoder.
   std::optional<serde::StreamData> streamData_;
+
+  // Row cursor in this decoder's row domain (matches
+  // `StreamSegment::startRow` for in-map streams; encoded-row domain
+  // otherwise). Bumped by every `next()` and `skip()`. Read by
+  // `fillInMapGap` and `skipInMap` for presence-position math. Reset to
+  // 0 in `clear()`.
+  uint32_t currentRow_{0};
+
+  // Backing storage for `ensureStreamData` when called from `skip*`.
+  // Some string encodings allocate their content buffers into this vector
+  // at construction time and keep `string_view`s into them; the vector
+  // must outlive the encoding that references it, so it lives with the
+  // decoder and is cleared inside `clear()` AFTER `streamData_` (and
+  // hence the encoding) is destroyed.
+  std::vector<velox::BufferPtr> skipStringBuffers_;
 };
 
 const StreamDescriptor& getMainDescriptor(const Type& type) {
@@ -700,6 +886,55 @@ bool checkColumnProjectionSubfield(
     nestedType = nestedType->asRow().childAt(childIndex.value()).get();
   }
   return false;
+}
+
+// One reader operation. Executed as `reader_->skip(numRows)` when
+// `skip == true`, or `reader_->next(numRows, ...)` when `skip == false`.
+struct DecodeOp {
+  bool skip;
+  uint32_t numRows;
+};
+
+// Turns per-batch rowRanges (in run-local coordinates) into the minimal
+// sequence of skip/read ops that visits each range exactly once.
+// Adjacent ranges with no gap fold into a single read op. Empty ranges
+// are dropped. Returns `[{read, 0}]` when the result would otherwise be
+// empty, so callers always emit at least one `reader_->next` and produce
+// a non-null output vector.
+std::vector<DecodeOp> buildDecodeOps(
+    const std::vector<nimble::RowRange>& ranges) {
+  std::vector<DecodeOp> ops;
+  // Worst case is skip+read per range (all disjoint, non-contiguous).
+  ops.reserve(2 * ranges.size());
+  uint32_t cursor{0};
+  for (const auto& range : ranges) {
+    // Empty range = "no rows from this batch". Common when the caller
+    // uses the rowRanges overload to skip whole batches, or when a
+    // batch's rowCount is 0. Nothing to emit; move on.
+    if (range.numRows() == 0) {
+      continue;
+    }
+    if (range.startRow > cursor) {
+      ops.push_back({/*skip=*/true, range.startRow - cursor});
+    }
+    // Fold into the preceding read op when this range is contiguous with
+    // it; otherwise start a fresh read (either `ops` is empty or the last
+    // op was the skip we just pushed).
+    if (!ops.empty() && !ops.back().skip) {
+      ops.back().numRows += range.numRows();
+    } else {
+      ops.push_back({/*skip=*/false, range.numRows()});
+    }
+    cursor = range.endRow;
+  }
+  // Every input range was empty (or `ranges` itself was). Emit one
+  // zero-length read so the caller still runs a `reader_->next` and
+  // produces a non-null empty output vector (see ProjectorFormatTest
+  // .emptyInput and equivalents).
+  if (ops.empty()) {
+    ops.push_back({/*skip=*/false, 0});
+  }
+  return ops;
 }
 
 } // namespace
@@ -1094,12 +1329,19 @@ void Deserializer::decodeRun(DecodeRun& run, velox::VectorPtr& output) const {
   if (FOLLY_UNLIKELY(run.batches == 0)) {
     return;
   }
-
-  velox::VectorPtr decoded;
-  reader_->next(run.rows, decoded, nullptr);
-  decoded = projectOutput(std::move(decoded));
+  const auto ops = buildDecodeOps(runRanges_);
+  for (const auto& op : ops) {
+    if (op.skip) {
+      reader_->skip(op.numRows);
+      continue;
+    }
+    velox::VectorPtr decoded;
+    reader_->next(op.numRows, decoded, nullptr);
+    decoded = projectOutput(std::move(decoded));
+    appendToOutput(std::move(decoded), output);
+  }
   run = {};
-  appendToOutput(std::move(decoded), output);
+  runRanges_.clear();
   reader_->reset();
 }
 
@@ -1157,6 +1399,7 @@ void Deserializer::appendStreamSegments(
 
 void Deserializer::appendBatch(
     std::string_view batch,
+    std::optional<nimble::RowRange> rowRange,
     DecodeRun& run,
     velox::VectorPtr& output) const {
   const auto rowCount = parser_->initialize(batch);
@@ -1165,7 +1408,28 @@ void Deserializer::appendBatch(
     decodeRun(run, output);
   }
 
+  // Base range from the batch: parser's rowRange (kTablet header) or
+  // full-batch default if the header didn't encode one.
+  nimble::RowRange range =
+      parser_->rowRange().value_or(nimble::RowRange{0, rowCount});
+  // Caller override wins if provided.
+  if (rowRange.has_value()) {
+    NIMBLE_USER_CHECK(
+        !requiresBarrier,
+        "override rowRange not supported for null-barrier batches");
+    NIMBLE_USER_CHECK_LE(
+        rowRange->startRow,
+        rowRange->endRow,
+        "override rowRange startRow must be <= endRow");
+    NIMBLE_USER_CHECK_LE(
+        rowRange->endRow,
+        rowCount,
+        "override rowRange endRow exceeds batch rowCount");
+    range = *rowRange;
+  }
+
   appendStreamSegments(rowCount, /*startRow=*/run.rows, requiresBarrier);
+  runRanges_.push_back({run.rows + range.startRow, run.rows + range.endRow});
   run.rows += rowCount;
   ++run.batches;
   if (FOLLY_UNLIKELY(requiresBarrier)) {
@@ -1177,12 +1441,47 @@ void Deserializer::appendBatch(
 void Deserializer::deserialize(
     folly::Range<const std::string_view*> data,
     velox::VectorPtr& output) const {
-  NIMBLE_CHECK(!data.empty(), "Expected at least one serialized batch");
+  deserializeImpl(data, {}, output);
+}
+
+void Deserializer::deserialize(
+    const std::vector<std::string_view>& data,
+    const std::vector<nimble::RowRange>& rowRanges,
+    velox::VectorPtr& output) const {
+  deserializeImpl(
+      folly::Range<const std::string_view*>(data.data(), data.size()),
+      folly::Range<const nimble::RowRange*>(rowRanges.data(), rowRanges.size()),
+      output);
+}
+
+void Deserializer::deserializeImpl(
+    folly::Range<const std::string_view*> data,
+    folly::Range<const nimble::RowRange*> rowRanges,
+    velox::VectorPtr& output) const {
+  NIMBLE_USER_CHECK(!data.empty(), "Expected at least one serialized batch");
+  if (!rowRanges.empty()) {
+    NIMBLE_USER_CHECK_EQ(
+        data.size(),
+        rowRanges.size(),
+        "data and rowRanges must have the same size");
+  }
+  // `runRanges_` must be empty across `deserialize*` calls — check on
+  // entry, clear on exit (including exceptions) via SCOPE_EXIT.
+  NIMBLE_CHECK(
+      runRanges_.empty(), "runRanges_ must be empty on deserialize entry");
+  SCOPE_EXIT {
+    runRanges_.clear();
+  };
 
   output = nullptr;
   DecodeRun run;
-  for (const auto batch : data) {
-    appendBatch(batch, run, output);
+  runRanges_.reserve(data.size());
+  for (size_t i = 0; i < data.size(); ++i) {
+    std::optional<nimble::RowRange> rowRange;
+    if (!rowRanges.empty()) {
+      rowRange = rowRanges[i];
+    }
+    appendBatch(data[i], rowRange, run, output);
   }
   decodeRun(run, output);
   parser_->reset();

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -24,6 +24,7 @@
 
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/velox/FieldReader.h"
+#include "dwio/nimble/velox/RowRange.h"
 #include "folly/Range.h"
 #include "folly/container/F14Map.h"
 #include "velox/type/Subfield.h"
@@ -76,10 +77,38 @@ class Deserializer {
   Deserializer(const Deserializer&) = delete;
   Deserializer& operator=(const Deserializer&) = delete;
 
+  /// Decodes a single serialized batch, appending the whole batch to
+  /// `output`. For kTablet batches with a per-batch rowRange in the
+  /// header, only rows in that range are decoded (via skip+next). All
+  /// other versions decode the full batch.
   void deserialize(std::string_view data, velox::VectorPtr& output) const;
 
+  /// Decodes a sequence of serialized batches and appends the concatenated
+  /// rows to `output`. Per-batch rowRange handling matches the single-batch
+  /// overload above.
   void deserialize(
       const std::vector<std::string_view>& data,
+      velox::VectorPtr& output) const;
+
+  /// Decodes each batch in `data`, appending only the rows in
+  /// `rowRanges[i]` for `data[i]`. The output is the concatenation of the
+  /// selected rows across batches, in order. Caller-supplied ranges take
+  /// precedence over any rowRange encoded in the batch header.
+  ///
+  /// Equivalent output to
+  ///   for each i: deserialize(data[i]).slice(rowRanges[i].startRow,
+  ///                                          rowRanges[i].numRows())
+  /// concatenated, but rows outside each range are never materialized —
+  /// they are skipped via the FieldReader's `skip()` primitive.
+  ///
+  /// Preconditions:
+  ///   * `data` is non-empty and `data.size() == rowRanges.size()`.
+  ///   * For each `i`: `rowRanges[i].startRow <= rowRanges[i].endRow` and
+  ///     `rowRanges[i].endRow <= data[i]`'s batch rowCount.
+  ///   * No batch carries the null-barrier flag.
+  void deserialize(
+      const std::vector<std::string_view>& data,
+      const std::vector<nimble::RowRange>& rowRanges,
       velox::VectorPtr& output) const;
 
  private:
@@ -113,6 +142,16 @@ class Deserializer {
 
   void deserialize(
       folly::Range<const std::string_view*> data,
+      velox::VectorPtr& output) const;
+
+  // Shared body of all public `deserialize` overloads. Loops over `data`,
+  // calls `appendBatch` per batch, then `decodeRun`. Pass an empty
+  // `rowRanges` to let each batch's rowRange be inferred from the header;
+  // pass a `data.size()`-sized `rowRanges` to override the inferred range
+  // per batch (`rowRanges[i]` for `data[i]`).
+  void deserializeImpl(
+      folly::Range<const std::string_view*> data,
+      folly::Range<const nimble::RowRange*> rowRanges,
       velox::VectorPtr& output) const;
 
   // Open run of non-barrier batches that can be decoded together.
@@ -163,10 +202,20 @@ class Deserializer {
       const std::vector<Subfield>& selectedSubfields,
       OutputProjection& outputProjection);
 
-  // Adds one serialized batch to the current decode run, decoding before and
-  // after batches that require a null barrier.
+  // Queues `batch`'s streams onto the pending decode run and records the
+  // batch's effective rowRange in `runRanges_` (run-local coordinates).
+  //
+  // `rowRange` overrides the range that would otherwise be inferred from
+  // the batch header (kTablet header rowRange, or full-batch for other
+  // versions). When set, requires
+  // `rowRange->startRow <= rowRange->endRow <= batch rowCount` and a
+  // non-null-barrier batch.
+  //
+  // If the batch requires a null barrier, `decodeRun` fires before and
+  // after queuing so the barrier batch decodes standalone.
   void appendBatch(
       std::string_view batch,
+      std::optional<nimble::RowRange> rowRange,
       DecodeRun& run,
       velox::VectorPtr& output) const;
 
@@ -191,8 +240,10 @@ class Deserializer {
       const velox::TypePtr& projectedType,
       const OutputProjection& projection) const;
 
-  // Decodes the pending non-barrier batch run and resets reader state for the
-  // next run.
+  // Decodes the batches queued since the last `decodeRun`. Reads the
+  // per-batch ranges from `runRanges_`, feeds a coalesced skip+next
+  // sequence to `reader_`, and appends each decoded vector to `output`.
+  // Leaves `run` empty, `runRanges_` empty, and the reader reset.
   void decodeRun(DecodeRun& run, velox::VectorPtr& output) const;
 
   // --- Const members (set at construction, never modified) ---
@@ -213,6 +264,11 @@ class Deserializer {
   std::unique_ptr<FieldReaderFactory> rootFactory_;
   std::unique_ptr<FieldReader> reader_;
   mutable std::unique_ptr<serde::StreamDataParser> parser_;
+  // Rows to decode from each queued batch, in run-local coordinates.
+  // `runRanges_[i]` is the range for the i'th batch appended so far in the
+  // current decode run. Fill via `appendBatch`, drain via `decodeRun`.
+  // Empty outside of an active `deserialize*` call.
+  mutable std::vector<nimble::RowRange> runRanges_;
 
   // --- Mutable members (modified during deserialization) ---
   mutable folly::F14FastMap<uint32_t, std::unique_ptr<Decoder>>

--- a/dwio/nimble/serializer/DeserializerImpl.cpp
+++ b/dwio/nimble/serializer/DeserializerImpl.cpp
@@ -81,6 +81,18 @@ void StreamData::reset(std::string_view data, SerializationVersion version) {
   init(data);
 }
 
+void StreamData::skip(uint32_t count) {
+  if (count == 0) {
+    return;
+  }
+  NIMBLE_CHECK_NOT_NULL(
+      encoding_, "StreamData::skip requires an encoded (non-legacy) stream");
+  NIMBLE_CHECK_LE(
+      count, remainingRows(), "StreamData::skip past end of segment");
+  encoding_->skip(count);
+  readRows_ += count;
+}
+
 // Copy legacy stream data to output buffer.
 // Data is already decompressed by init() -> decompress().
 uint32_t StreamData::copyTo(char* output, uint32_t bufferSize) {

--- a/dwio/nimble/serializer/DeserializerImpl.h
+++ b/dwio/nimble/serializer/DeserializerImpl.h
@@ -117,6 +117,19 @@ class StreamData {
 
   void reset(std::string_view data, SerializationVersion version);
 
+  /// Advance the encoded stream cursor by `count` rows without materializing
+  /// output. Uses the encoding's native state-only skip primitive. Only valid
+  /// when hasEncoding() is true (i.e. non-legacy streams).
+  void skip(uint32_t count);
+
+  /// Replace the external string-buffers vector this StreamData points to.
+  /// Needed when the caller of a subsequent decode passes a different vector
+  /// than was in effect at construction (e.g. after a skip() that used a
+  /// scratch vector).
+  void setStringBuffers(std::vector<velox::BufferPtr>* stringBuffers) {
+    stringBuffers_ = stringBuffers;
+  }
+
   ScalarKind kind() const {
     return kind_;
   }

--- a/dwio/nimble/serializer/tests/CMakeLists.txt
+++ b/dwio/nimble/serializer/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ target_link_libraries(
   velox_type
   velox_vector
   velox_vector_fuzzer
+  velox_vector_test_lib
   gtest
   gtest_main
   Folly::folly

--- a/dwio/nimble/serializer/tests/SerializationTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializationTest.cpp
@@ -44,6 +44,7 @@
 #include "velox/vector/DecodedVector.h"
 #include "velox/vector/SelectivityVector.h"
 #include "velox/vector/fuzzer/VectorFuzzer.h"
+#include "velox/vector/tests/utils/VectorMaker.h"
 
 using namespace facebook;
 using namespace facebook::nimble;
@@ -7019,3 +7020,737 @@ INSTANTIATE_TEST_SUITE_P(
             .streamSizesEncodingType = EncodingType::Varint,
             .bufferPoolCapacity = 0}),
     formatName);
+
+namespace facebook::nimble {
+
+// Exercises SegmentedStreamDecoder::skip via the per-batch-rowRanges
+// overload of Deserializer::deserialize. Each case serializes one or more
+// input vectors, then verifies that
+//   deserialize(data, rowRanges, out)
+// equals concatenation of per-batch slices
+//   deserialize(data[i]).slice(rowRanges[i].startRow, rowRanges[i].numRows()).
+class DeserializerSkipTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    rootPool_ = velox::memory::memoryManager()->addRootPool("skip_test");
+    pool_ = rootPool_->addLeafChild("leaf");
+    vm_ = std::make_unique<velox::test::VectorMaker>(pool_.get());
+  }
+
+  // Serialize the given input vectors as kSerialization batches. Returns the
+  // serialized byte strings plus the nimble schema needed to construct a
+  // Deserializer.
+  std::pair<std::vector<std::string>, std::shared_ptr<const Type>> serialize(
+      const velox::TypePtr& type,
+      const std::vector<velox::VectorPtr>& inputs,
+      const folly::F14FastMap<std::string, std::set<std::string>>&
+          flatMapColumns = {}) {
+    SerializerOptions options{
+        .version = SerializationVersion::kSerialization,
+        .flatMapColumns = flatMapColumns,
+    };
+    Serializer serializer{options, type, pool_.get()};
+    std::vector<std::string> serialized;
+    serialized.reserve(inputs.size());
+    for (const auto& input : inputs) {
+      serialized.emplace_back(
+          serializer.serialize(input, OrderedRanges::of(0, input->size())));
+    }
+    auto schema =
+        SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
+    return {std::move(serialized), std::move(schema)};
+  }
+
+  // Round-trip check: `deserialize(data, rowRanges)` for rowRanges derived
+  // from a run-level [skipRows, skipRows+decodeRows) window must equal
+  // `deserialize(data)` sliced by the same window.
+  //
+  // Per-batch rowRanges are computed by intersecting the run-level window
+  // with each batch's [batchStart, batchStart+batchRowCount).
+  void checkSkip(
+      const std::shared_ptr<const Type>& schema,
+      const std::vector<std::string>& serialized,
+      uint32_t skipRows,
+      uint32_t decodeRows) {
+    SCOPED_TRACE(
+        fmt::format(
+            "skipRows={} decodeRows={} batches={}",
+            skipRows,
+            decodeRows,
+            serialized.size()));
+
+    std::vector<std::string_view> views;
+    views.reserve(serialized.size());
+    for (const auto& s : serialized) {
+      views.push_back(s);
+    }
+
+    DeserializerOptions dsOpts{.hasHeader = true};
+    Deserializer fullDs{schema, pool_.get(), dsOpts};
+    velox::VectorPtr full;
+    fullDs.deserialize(views, full);
+    ASSERT_GE(full->size(), skipRows + decodeRows);
+
+    // Compute per-batch RowRanges from (skipRows, decodeRows) by discovering
+    // each batch's rowCount via a single-batch deserialize.
+    std::vector<RowRange> rowRanges;
+    rowRanges.reserve(serialized.size());
+    const uint64_t windowEnd = static_cast<uint64_t>(skipRows) + decodeRows;
+    uint64_t batchStart = 0;
+    for (const auto& s : serialized) {
+      Deserializer singleDs{schema, pool_.get(), dsOpts};
+      velox::VectorPtr singleOut;
+      std::vector<std::string_view> singleView{s};
+      singleDs.deserialize(singleView, singleOut);
+      const uint64_t rowCount = singleOut->size();
+      const uint64_t batchEnd = batchStart + rowCount;
+
+      const uint64_t keepStart = std::max<uint64_t>(skipRows, batchStart);
+      const uint64_t keepEnd = std::min<uint64_t>(windowEnd, batchEnd);
+      if (keepStart >= keepEnd) {
+        rowRanges.push_back(RowRange{0, 0});
+      } else {
+        rowRanges.push_back(
+            RowRange{
+                static_cast<uint32_t>(keepStart - batchStart),
+                static_cast<uint32_t>(keepEnd - batchStart)});
+      }
+      batchStart = batchEnd;
+    }
+
+    Deserializer partialDs{schema, pool_.get(), dsOpts};
+    velox::VectorPtr partial;
+    partialDs.deserialize(views, rowRanges, partial);
+
+    if (decodeRows == 0) {
+      ASSERT_TRUE(partial == nullptr || partial->size() == 0);
+      return;
+    }
+    ASSERT_EQ(partial->size(), decodeRows);
+    for (velox::vector_size_t i = 0; i < decodeRows; ++i) {
+      ASSERT_TRUE(partial->equalValueAt(full.get(), i, skipRows + i))
+          << "Mismatch at partial row " << i << " (full row " << (skipRows + i)
+          << ")\n  expected: "
+          << full->toString(static_cast<velox::vector_size_t>(skipRows + i))
+          << "\n  actual:   "
+          << partial->toString(static_cast<velox::vector_size_t>(i));
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<velox::test::VectorMaker> vm_;
+};
+
+// --- Dense scalar column, no nulls -----------------------------------------
+
+TEST_F(DeserializerSkipTest, denseIntNoNullsSingleBatch) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  auto batch = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(20, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(i);
+      })});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  // Full read.
+  checkSkip(schema, serialized, 0, 20);
+  // Skip prefix, keep middle.
+  checkSkip(schema, serialized, 5, 10);
+  // Skip nothing, keep prefix.
+  checkSkip(schema, serialized, 0, 7);
+  // Skip and keep tail.
+  checkSkip(schema, serialized, 15, 5);
+  // Zero decode is a no-op (still exercises appendStreamSegments + skip path).
+  checkSkip(schema, serialized, 8, 0);
+}
+
+// --- Dense scalar column, with nulls ---------------------------------------
+
+TEST_F(DeserializerSkipTest, denseIntWithNullsSingleBatch) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  auto batch = vm_->rowVector(
+      {"a"},
+      {vm_->flatVectorNullable<int32_t>(
+          {0, std::nullopt, 2, 3, std::nullopt, 5, 6, std::nullopt, 8, 9})});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  checkSkip(schema, serialized, 0, 10);
+  checkSkip(schema, serialized, 3, 5);
+  checkSkip(schema, serialized, 1, 8);
+}
+
+// --- Dense string column, no nulls -----------------------------------------
+
+TEST_F(DeserializerSkipTest, denseStringNoNullsSingleBatch) {
+  auto type = velox::ROW({{"s", velox::VARCHAR()}});
+  auto batch = vm_->rowVector(
+      {"s"},
+      {vm_->flatVector<velox::StringView>(
+          {"v0",
+           "v1",
+           "v2",
+           "v3",
+           "v4",
+           "v5",
+           "v6",
+           "v7",
+           "v8",
+           "v9",
+           "v10",
+           "v11",
+           "v12",
+           "v13",
+           "v14"})});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  checkSkip(schema, serialized, 4, 6);
+  checkSkip(schema, serialized, 10, 5);
+}
+
+// --- Dense string column, with nulls ---------------------------------------
+
+TEST_F(DeserializerSkipTest, denseStringWithNullsSingleBatch) {
+  auto type = velox::ROW({{"s", velox::VARCHAR()}});
+  auto batch = vm_->rowVector(
+      {"s"},
+      {vm_->flatVectorNullable<velox::StringView>(
+          {velox::StringView{"alpha"},
+           std::nullopt,
+           velox::StringView{"beta"},
+           velox::StringView{"gamma"},
+           std::nullopt,
+           velox::StringView{"delta"},
+           std::nullopt,
+           velox::StringView{"epsilon"}})});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  checkSkip(schema, serialized, 2, 4);
+  checkSkip(schema, serialized, 3, 3);
+}
+
+// --- Concurrent skip: regression guard for per-decoder skipStringBuffers_ ---
+//
+// Each `SegmentedStreamDecoder` owns a private `skipStringBuffers_` vector
+// that backs the uncompressed blob a `TrivialEncoding<string_view>` allocates
+// in its constructor when a skip first materializes the segment's stream data.
+// If that vector were promoted to a `static` (or `static thread_local`) so
+// multiple decoders shared it, concurrent skips would race on
+// `emplace_back`/`clear`, and one decoder's end-of-run `reset()` (which runs
+// `SegmentedStreamDecoder::clear()` and drops the vector) would free the
+// backing buffer another decoder's encoding still points into via its raw
+// `blob_`/`pos_`. The result is either a data race the sanitizers catch, a
+// heap-use-after-free during materialize, or silent string content corruption
+// that fails deep equality against the reference decode.
+TEST_F(DeserializerSkipTest, concurrentSkipStringNoSharedBuffers) {
+  auto type = velox::ROW({{"s", velox::VARCHAR()}});
+  constexpr int32_t kRows = 200;
+  // >12 bytes forces out-of-line StringView so the output vector actually
+  // references the encoding's backing buffer rather than inlining bytes.
+  std::vector<std::string> storage;
+  storage.reserve(kRows);
+  std::vector<velox::StringView> viewsData;
+  viewsData.reserve(kRows);
+  for (int32_t i = 0; i < kRows; ++i) {
+    storage.push_back(fmt::format("row_{:08d}_payload_ABCDEFGHIJKLMNOP", i));
+    viewsData.emplace_back(storage.back());
+  }
+  auto batch =
+      vm_->rowVector({"s"}, {vm_->flatVector<velox::StringView>(viewsData)});
+  auto serializedPair = serialize(type, {batch});
+  auto& serialized = serializedPair.first;
+  auto schema = serializedPair.second;
+  const std::vector<std::string_view> views{serialized[0]};
+
+  DeserializerOptions dsOpts{.hasHeader = true};
+  Deserializer refDs{schema, pool_.get(), dsOpts};
+  velox::VectorPtr fullRef;
+  refDs.deserialize(views, fullRef);
+  ASSERT_EQ(fullRef->size(), kRows);
+
+  constexpr uint32_t kSkip = 50;
+  const std::vector<RowRange> rowRanges{RowRange{kSkip, kRows}};
+  const auto expectedCount = static_cast<velox::vector_size_t>(kRows - kSkip);
+
+  constexpr int kThreads = 8;
+  constexpr int kIterations = 100;
+
+  std::vector<std::shared_ptr<velox::memory::MemoryPool>> threadPools;
+  threadPools.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    threadPools.push_back(
+        rootPool_->addLeafChild(fmt::format("skip_concurrent_{}", t)));
+  }
+
+  std::atomic<int> mismatches{0};
+  std::atomic<int> exceptions{0};
+
+  auto worker = [&](int threadIndex) {
+    auto* threadPool = threadPools[threadIndex].get();
+    for (int iter = 0; iter < kIterations; ++iter) {
+      Deserializer ds{schema, threadPool, dsOpts};
+      velox::VectorPtr out;
+      try {
+        ds.deserialize(views, rowRanges, out);
+      } catch (const std::exception&) {
+        ++exceptions;
+        return;
+      }
+      if (out == nullptr || out->size() != expectedCount) {
+        ++mismatches;
+        return;
+      }
+      for (velox::vector_size_t i = 0; i < expectedCount; ++i) {
+        if (!out->equalValueAt(fullRef.get(), i, kSkip + i)) {
+          ++mismatches;
+          return;
+        }
+      }
+    }
+  };
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back(worker, t);
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+  EXPECT_EQ(mismatches.load(), 0);
+  EXPECT_EQ(exceptions.load(), 0);
+}
+
+// --- Multi-batch: skip across batch boundary -------------------------------
+
+TEST_F(DeserializerSkipTest, denseIntMultipleBatchesSkipAcrossBoundary) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  auto b1 = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(10, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(i);
+      })});
+  auto b2 = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(15, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(100 + i);
+      })});
+  auto b3 = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(8, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(1000 + i);
+      })});
+  auto [serialized, schema] = serialize(type, {b1, b2, b3});
+
+  // Skip within first batch, decode spanning first + second.
+  checkSkip(schema, serialized, 5, 10);
+  // Skip past first batch entirely, decode in second batch.
+  checkSkip(schema, serialized, 10, 8);
+  // Skip past first two batches, decode in third.
+  checkSkip(schema, serialized, 25, 5);
+  // Skip past first, decode across second and third.
+  checkSkip(schema, serialized, 12, 15);
+  // Full read.
+  checkSkip(schema, serialized, 0, 33);
+}
+
+// --- FlatMap column (in-map + scattered value), no null values -------------
+
+TEST_F(DeserializerSkipTest, flatMapNoNullValuesSingleBatch) {
+  // Explicit per-row key subsets exercise in-map presence gaps (some rows
+  // are missing certain keys) and scattered value reads.
+  using MapEntries = std::vector<std::pair<int32_t, std::optional<int32_t>>>;
+  std::vector<MapEntries> maps{
+      {{0, 100}, {1, 101}},
+      {{1, 111}},
+      {{0, 200}, {2, 202}},
+      {{2, 222}},
+      {{0, 300}, {1, 301}, {2, 302}},
+      {{1, 411}},
+      {{0, 500}, {1, 501}},
+      {{2, 622}},
+      {{0, 700}, {1, 701}, {2, 702}},
+      {{1, 811}, {2, 812}},
+      {{0, 900}},
+      {{1, 1011}, {2, 1012}},
+  };
+  auto type =
+      velox::ROW({{"m", velox::MAP(velox::INTEGER(), velox::INTEGER())}});
+  auto batch = vm_->rowVector({"m"}, {vm_->mapVector<int32_t, int32_t>(maps)});
+
+  folly::F14FastMap<std::string, std::set<std::string>> flatMaps{{"m", {}}};
+  auto [serialized, schema] = serialize(type, {batch}, flatMaps);
+
+  checkSkip(schema, serialized, 0, 12);
+  checkSkip(schema, serialized, 3, 6);
+  checkSkip(schema, serialized, 5, 5);
+  checkSkip(schema, serialized, 7, 5);
+}
+
+// --- FlatMap column with NULL values ---------------------------------------
+
+TEST_F(DeserializerSkipTest, flatMapWithNullValuesSingleBatch) {
+  // Some map values are null. The value stream for those keys carries null
+  // bits alongside the scatter bitmap (from the in-map presence stream).
+  using MapEntries = std::vector<std::pair<int32_t, std::optional<int32_t>>>;
+  std::vector<MapEntries> maps{
+      {{0, std::nullopt}, {1, 101}},
+      {{1, 111}},
+      {{0, 200}, {2, std::nullopt}},
+      {{2, 222}},
+      {{0, std::nullopt}, {1, 301}, {2, 302}},
+      {{1, 411}},
+      {{0, 500}, {1, std::nullopt}},
+      {{2, 622}},
+      {{0, 700}, {1, 701}, {2, std::nullopt}},
+      {{1, std::nullopt}, {2, 812}},
+  };
+  auto type =
+      velox::ROW({{"m", velox::MAP(velox::INTEGER(), velox::INTEGER())}});
+  auto batch = vm_->rowVector({"m"}, {vm_->mapVector<int32_t, int32_t>(maps)});
+
+  folly::F14FastMap<std::string, std::set<std::string>> flatMaps{{"m", {}}};
+  auto [serialized, schema] = serialize(type, {batch}, flatMaps);
+
+  checkSkip(schema, serialized, 0, 10);
+  checkSkip(schema, serialized, 2, 6);
+  checkSkip(schema, serialized, 4, 4);
+}
+
+// --- FlatMap column across multiple batches --------------------------------
+
+TEST_F(DeserializerSkipTest, flatMapMultipleBatchesSkipAcrossBoundary) {
+  using MapEntries = std::vector<std::pair<int32_t, std::optional<int32_t>>>;
+
+  // b1: keys 0 and 1 only.
+  std::vector<MapEntries> b1Maps{
+      {{0, 1}, {1, 2}},
+      {{1, 3}},
+      {{0, 4}, {1, 5}},
+      {{0, 6}},
+      {{0, 7}, {1, 8}},
+      {{1, 9}},
+      {{0, 10}, {1, 11}},
+      {{1, 12}},
+  };
+  // b2: keys 5 and 6 (absent in b1) — the FlatMap tree adds new key streams
+  // that were entirely missing from b1's serialized output.
+  std::vector<MapEntries> b2Maps{
+      {{5, 100}, {6, 200}},
+      {{5, 101}},
+      {{6, 201}},
+      {{5, 102}, {6, 202}},
+      {{5, 103}, {6, 203}},
+      {{5, 104}},
+      {{6, 204}},
+      {{5, 105}, {6, 205}},
+      {{5, 106}, {6, 206}},
+      {{5, 107}, {6, 207}},
+  };
+  auto type =
+      velox::ROW({{"m", velox::MAP(velox::INTEGER(), velox::INTEGER())}});
+  auto b1 = vm_->rowVector({"m"}, {vm_->mapVector<int32_t, int32_t>(b1Maps)});
+  auto b2 = vm_->rowVector({"m"}, {vm_->mapVector<int32_t, int32_t>(b2Maps)});
+
+  folly::F14FastMap<std::string, std::set<std::string>> flatMaps{{"m", {}}};
+  auto [serialized, schema] = serialize(type, {b1, b2}, flatMaps);
+
+  // Skip within b1, decode spanning boundary.
+  checkSkip(schema, serialized, 3, 8);
+  // Skip past b1 entirely, decode in b2.
+  checkSkip(schema, serialized, 8, 6);
+  // Full.
+  checkSkip(schema, serialized, 0, 18);
+}
+
+// --- In-map skip with empty streamSegments_ (regression guard) -------------
+
+// Predefined FlatMap key "3" is declared in the schema but never appears in
+// the data — its in-map decoder therefore accumulates zero stream segments
+// for this batch. A skip through this decoder (triggered here by a
+// rowRange with startRow > 0) must not throw on the empty-streamSegments_
+// branch. Before the fix, `SegmentedStreamDecoder::skip` on an in-map
+// decoder with empty segments tripped `NIMBLE_CHECK(!isInMapStream() && ...)`;
+// after the fix `skipInMap` handles the empty case.
+TEST_F(DeserializerSkipTest, skipHandlesInMapWithEmptyStreamSegments) {
+  auto type =
+      velox::ROW({{"m", velox::MAP(velox::INTEGER(), velox::INTEGER())}});
+  using MapEntries = std::vector<std::pair<int32_t, std::optional<int32_t>>>;
+  std::vector<MapEntries> maps{
+      {{1, 100}, {2, 200}},
+      {{1, 111}},
+      {{2, 222}},
+      {{1, 133}, {2, 233}},
+      {{2, 244}},
+      {{1, 155}, {2, 255}},
+      {{1, 166}},
+      {{2, 277}},
+  };
+  auto batch = vm_->rowVector({"m"}, {vm_->mapVector<int32_t, int32_t>(maps)});
+  // Include "3" in the predefined key set even though no row uses it —
+  // this forces the deserializer to construct a decoder for key "3" whose
+  // stream segments stay empty across the batch, which is the shape the
+  // skip path needs to tolerate.
+  folly::F14FastMap<std::string, std::set<std::string>> flatMaps{
+      {"m", {"1", "2", "3"}}};
+  auto [serialized, schema] = serialize(type, {batch}, flatMaps);
+
+  DeserializerOptions dsOpts{.hasHeader = true};
+  Deserializer d{schema, pool_.get(), dsOpts};
+  std::vector<std::string_view> views{serialized[0]};
+  velox::VectorPtr out;
+  // Non-zero startRow forces skip through every FlatMap key's in-map
+  // decoder — including key "3" whose streamSegments_ is empty.
+  ASSERT_NO_THROW(
+      d.deserialize(views, std::vector<RowRange>{RowRange{3, 7}}, out));
+  ASSERT_EQ(out->size(), 4);
+}
+
+// --- Row-null skip: top-level row nulls ------------------------------------
+
+TEST_F(DeserializerSkipTest, rowLevelNullsSingleBatch) {
+  // Top-level row nulls (e.g. via appendNulls) exercise the empty
+  // streamSegments_ branch in skip (Row null stream reconstructed as
+  // all-non-null when nothing was written on the wire), plus the null
+  // barrier flag when a batch actually has row-level nulls.
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  auto inner = vm_->flatVector<int32_t>(
+      10, [](velox::vector_size_t i) { return static_cast<int32_t>(i); });
+  auto batch = vm_->rowVector({"a"}, {inner});
+
+  auto [serialized, schema] = serialize(type, {batch});
+  checkSkip(schema, serialized, 0, 10);
+  checkSkip(schema, serialized, 4, 6);
+  checkSkip(schema, serialized, 7, 3);
+}
+
+// FlatMap where every row carries every key (writer omits in-map streams
+// as all-present -> deserializer synthesizes an all-present segment
+// spanning the whole batch). A mid-batch skip then lands inside the
+// segment; the next read must correctly clamp the partial-segment write.
+// Regression guard for a prior `fillInMapGap` invariant that assumed
+// segments never straddled a skip boundary.
+TEST_F(DeserializerSkipTest, flatMapAllPresentSegmentStraddleSkip) {
+  using MapEntries = std::vector<std::pair<int32_t, std::optional<int32_t>>>;
+  std::vector<MapEntries> maps;
+  maps.reserve(10);
+  for (int32_t i = 0; i < 10; ++i) {
+    maps.push_back({{1, 100 + i}, {2, 200 + i}});
+  }
+  auto type =
+      velox::ROW({{"m", velox::MAP(velox::INTEGER(), velox::INTEGER())}});
+  auto batch = vm_->rowVector({"m"}, {vm_->mapVector<int32_t, int32_t>(maps)});
+  folly::F14FastMap<std::string, std::set<std::string>> flatMaps{{"m", {}}};
+  auto [serialized, schema] = serialize(type, {batch}, flatMaps);
+
+  // Cover: prefix skip, mid slice, tail slice, single-row slice at
+  // boundary. Each lands inside the synthesized all-present segment.
+  checkSkip(schema, serialized, 3, 5);
+  checkSkip(schema, serialized, 0, 1);
+  checkSkip(schema, serialized, 9, 1);
+  checkSkip(schema, serialized, 4, 3);
+}
+
+// --- Large-volume skip/read interleaving -----------------------------------
+
+// Skip almost the whole batch (999 of 1000 rows), decode a single tail
+// row. Stresses `skipEncoded` walking many queued segments cheaply.
+TEST_F(DeserializerSkipTest, denseIntLargeSkipTinyRead) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  auto batch = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(1000, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(i);
+      })});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  checkSkip(schema, serialized, 999, 1);
+  checkSkip(schema, serialized, 500, 1);
+  checkSkip(schema, serialized, 1, 999);
+}
+
+// Full skip (skipRows == totalRows). Decode 0 rows after skipping the
+// whole run — output should be an empty non-null vector.
+TEST_F(DeserializerSkipTest, denseIntFullSkip) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  auto batch = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(20, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(i);
+      })});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  checkSkip(schema, serialized, 20, 0);
+}
+
+// Many small batches, alternating skip and read via per-batch rowRanges.
+// Uses the public `deserialize(data, rowRanges, out)` overload directly
+// so ranges are disjoint (can't be expressed as a single run-level
+// window). Verifies planReaderOps coalesces contiguous windows and
+// separates them by exactly one skip.
+TEST_F(DeserializerSkipTest, manyBatchesDisjointRowRanges) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  constexpr uint32_t kBatchSize = 10;
+  constexpr size_t kNumBatches = 20;
+
+  std::vector<velox::VectorPtr> inputs;
+  inputs.reserve(kNumBatches);
+  for (size_t b = 0; b < kNumBatches; ++b) {
+    inputs.push_back(vm_->rowVector(
+        {"a"},
+        {vm_->flatVector<int32_t>(kBatchSize, [b](velox::vector_size_t i) {
+          return static_cast<int32_t>(b * 1000 + i);
+        })}));
+  }
+
+  SerializerOptions options{.version = SerializationVersion::kSerialization};
+  Serializer serializer{options, type, pool_.get()};
+  std::vector<std::string> serialized;
+  serialized.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    serialized.emplace_back(
+        serializer.serialize(input, OrderedRanges::of(0, input->size())));
+  }
+  auto schema =
+      SchemaReader::getSchema(serializer.schemaBuilder().schemaNodes());
+
+  // Per-batch rowRanges: even batches keep rows [2, 7); odd batches
+  // decode nothing. In the run's coordinate space this yields 10
+  // disjoint windows separated by 15-row gaps each.
+  std::vector<nimble::RowRange> rowRanges;
+  rowRanges.reserve(kNumBatches);
+  for (size_t b = 0; b < kNumBatches; ++b) {
+    rowRanges.push_back(
+        b % 2 == 0 ? nimble::RowRange{2, 7} : nimble::RowRange{0, 0});
+  }
+
+  std::vector<std::string_view> views;
+  views.reserve(serialized.size());
+  for (const auto& s : serialized) {
+    views.push_back(s);
+  }
+
+  DeserializerOptions dsOpts{.hasHeader = true};
+  Deserializer ds{schema, pool_.get(), dsOpts};
+  velox::VectorPtr out;
+  ds.deserialize(views, rowRanges, out);
+
+  // Expected: 5 rows per even batch × 10 even batches = 50 rows.
+  ASSERT_EQ(out->size(), 50);
+  auto* col =
+      out->as<velox::RowVector>()->childAt(0)->as<velox::FlatVector<int32_t>>();
+  for (size_t evenIdx = 0; evenIdx < 10; ++evenIdx) {
+    const size_t sourceBatch = evenIdx * 2;
+    for (uint32_t r = 0; r < 5; ++r) {
+      const auto expected = static_cast<int32_t>(sourceBatch * 1000 + (2 + r));
+      EXPECT_EQ(col->valueAt(evenIdx * 5 + r), expected)
+          << "evenIdx=" << evenIdx << " r=" << r;
+    }
+  }
+}
+
+// --- Nested-type skipping (Array, Map non-FlatMap) -------------------------
+
+// Array<int>: the lengths stream drives per-row width; skip must advance
+// both the lengths cursor and (indirectly) the elements cursor via the
+// FieldReader tree.
+TEST_F(DeserializerSkipTest, arrayIntSingleBatch) {
+  auto type = velox::ROW({{"a", velox::ARRAY(velox::INTEGER())}});
+  std::vector<std::vector<int32_t>> arrays;
+  arrays.reserve(12);
+  for (int32_t i = 0; i < 12; ++i) {
+    // Row i has (i % 4) + 1 elements: 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4.
+    std::vector<int32_t> row;
+    for (int32_t j = 0; j <= (i % 4); ++j) {
+      row.push_back(i * 100 + j);
+    }
+    arrays.push_back(std::move(row));
+  }
+  auto batch = vm_->rowVector({"a"}, {vm_->arrayVector<int32_t>(arrays)});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  checkSkip(schema, serialized, 3, 6);
+  checkSkip(schema, serialized, 5, 5);
+  checkSkip(schema, serialized, 0, 12);
+}
+
+// Map<int,int> (non-FlatMap): distinct from FlatMap in that entries are
+// per-row, not per-key. Skip advances offsets/lengths/keys/values
+// together via the reader tree.
+TEST_F(DeserializerSkipTest, mapIntIntSingleBatch) {
+  auto type =
+      velox::ROW({{"m", velox::MAP(velox::INTEGER(), velox::INTEGER())}});
+  using MapEntries = std::vector<std::pair<int32_t, std::optional<int32_t>>>;
+  std::vector<MapEntries> maps;
+  maps.reserve(10);
+  for (int32_t i = 0; i < 10; ++i) {
+    // Row i has i+1 entries.
+    MapEntries row;
+    for (int32_t j = 0; j <= i; ++j) {
+      row.emplace_back(j, i * 10 + j);
+    }
+    maps.push_back(std::move(row));
+  }
+  auto batch = vm_->rowVector({"m"}, {vm_->mapVector<int32_t, int32_t>(maps)});
+  // Note: no flatMapColumns entry — this is a regular Map, not FlatMap.
+  auto [serialized, schema] = serialize(type, {batch});
+
+  checkSkip(schema, serialized, 4, 4);
+  checkSkip(schema, serialized, 7, 3);
+}
+
+// --- Bad user input rejected ----------------------------------------------
+
+// Bad per-batch rowRange: startRow > endRow. Would underflow the uint32
+// numRows() computation and confuse `planReaderOps` if not rejected.
+TEST_F(DeserializerSkipTest, rejectRowRangeStartRowAfterEndRow) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  auto batch = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(10, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(i);
+      })});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  DeserializerOptions dsOpts{.hasHeader = true};
+  Deserializer ds{schema, pool_.get(), dsOpts};
+  std::vector<std::string_view> views{serialized[0]};
+  velox::VectorPtr out;
+  EXPECT_THROW(
+      ds.deserialize(views, {nimble::RowRange{5, 3}}, out), NimbleUserError);
+}
+
+// Bad per-batch rowRange: endRow past batch rowCount.
+TEST_F(DeserializerSkipTest, rejectRowRangeEndRowPastBatchRowCount) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  auto batch = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(10, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(i);
+      })});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  DeserializerOptions dsOpts{.hasHeader = true};
+  Deserializer ds{schema, pool_.get(), dsOpts};
+  std::vector<std::string_view> views{serialized[0]};
+  velox::VectorPtr out;
+  EXPECT_THROW(
+      ds.deserialize(views, {nimble::RowRange{0, 11}}, out), NimbleUserError);
+}
+
+// Bad input: data.size() != rowRanges.size().
+TEST_F(DeserializerSkipTest, rejectMismatchedRowRangesSize) {
+  auto type = velox::ROW({{"a", velox::INTEGER()}});
+  auto batch = vm_->rowVector(
+      {"a"}, {vm_->flatVector<int32_t>(10, [](velox::vector_size_t i) {
+        return static_cast<int32_t>(i);
+      })});
+  auto [serialized, schema] = serialize(type, {batch});
+
+  DeserializerOptions dsOpts{.hasHeader = true};
+  Deserializer ds{schema, pool_.get(), dsOpts};
+  std::vector<std::string_view> views{serialized[0]};
+  velox::VectorPtr out;
+  std::vector<nimble::RowRange> ranges{
+      nimble::RowRange{0, 5}, nimble::RowRange{0, 5}};
+  EXPECT_THROW(ds.deserialize(views, ranges, out), NimbleUserError);
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -81,8 +81,10 @@ std::optional<std::string> readEmbeddedResumeKey(const folly::IOBuf& slice) {
 
 // Coalesces the chunk slice IOBuf chain into a single contiguous buffer for
 // passing to Deserializer. The Deserializer reads the per-slice header
-// natively (consuming the row range and resume-key fields) but does not
-// slice its output — it over-fetches by decoding the full stripe.
+// natively (consuming the row range and resume-key fields) and honors the
+// row range at decode time via skip+next, so the downstream deserialized
+// vector contains only the rows in `[rowRange.startRow, rowRange.endRow)`
+// — no over-fetch.
 folly::IOBuf coalesceChunkSlice(const folly::IOBuf& slice) {
   return slice.cloneCoalescedAsValue();
 }
@@ -333,38 +335,14 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     return deserializeProjectedBatches(projector, batches);
   }
 
-  VectorPtr makeOutputRange(
-      const VectorPtr& output,
-      uint32_t outputOffset,
-      vector_size_t numRows) {
-    if (outputOffset == 0 && output->size() == numRows) {
-      return output;
-    }
-
-    auto indices = allocateIndices(numRows, leafPool_.get());
-    auto* rawIndices = indices->asMutable<vector_size_t>();
-    for (vector_size_t i = 0; i < numRows; ++i) {
-      rawIndices[i] = static_cast<vector_size_t>(outputOffset) + i;
-    }
-    return BaseVector::wrapInDictionary(nullptr, indices, numRows, output);
-  }
-
-  // Compares decoded output rows with a compact expected vector. The
-  // deserializer returns full stripes, so range tests dictionary-wrap the
-  // selected rows before using Velox's vector equality assertion.
-  void expectVectorRows(
-      const VectorPtr& output,
-      uint32_t expectedRows,
-      const VectorPtr& expected,
-      uint32_t outputOffset = 0) {
+  // Compares decoded output rows with an expected vector. The Deserializer
+  // honors the header's row range via skip+next at decode time, so output
+  // contains exactly the requested rows starting at index 0.
+  // `assertEqualVectors` internally asserts equal size.
+  void expectVectorRows(const VectorPtr& output, const VectorPtr& expected) {
     ASSERT_NE(output, nullptr);
     ASSERT_NE(expected, nullptr);
-    ASSERT_EQ(output->size(), expectedRows);
-    ASSERT_LE(
-        static_cast<uint64_t>(outputOffset) + expected->size(),
-        static_cast<uint64_t>(output->size()));
-    velox::test::assertEqualVectors(
-        expected, makeOutputRange(output, outputOffset, expected->size()));
+    velox::test::assertEqualVectors(expected, output);
   }
 
   // Creates encoded key bounds for a point lookup on a single int64 key.
@@ -538,13 +516,13 @@ TEST_P(NimbleIndexProjectorTest, basicColumnProjection) {
 
   auto* rowResult = deserialized->as<RowVector>();
   ASSERT_NE(rowResult, nullptr);
-  // Over-fetch: Deserializer returns the full stripe; the requested row
-  // sits at position rowRange.startRow within the output.
-  ASSERT_GE(rowResult->size(), rowRange.endRow);
+  // The Deserializer honors the header's row range at decode time, so the
+  // output contains exactly the requested rows starting at index 0.
+  ASSERT_EQ(rowResult->size(), rowRange.numRows());
   auto* colAResult = rowResult->childAt(0)->as<FlatVector<int32_t>>();
   ASSERT_NE(colAResult, nullptr);
-  // key=50 -> colA=500
-  EXPECT_EQ(colAResult->valueAt(rowRange.startRow), 500);
+  // key=50 -> colA=500 (single-row point lookup).
+  EXPECT_EQ(colAResult->valueAt(0), 500);
 }
 
 // Every IOBuf node in a result slice chain should be managed (own/refcount its
@@ -832,7 +810,6 @@ TEST_P(NimbleIndexProjectorTest, deduplicatedProjectedStreamsReadOnce) {
        vectorMaker_->flatVector<int32_t>(values)});
   expectVectorRows(
       deserializeProjectedSlice(*projector, result.responses[0].slices[0]),
-      static_cast<uint32_t>(numRows),
       expected);
 }
 
@@ -871,9 +848,7 @@ TEST_P(NimbleIndexProjectorTest, projectedNullableDataDeserializes) {
           [](auto row) { return (row + 10) % 5 == 0; })});
   expectVectorRows(
       deserializeProjectedSlice(*projector, result.responses[0].slices[0]),
-      static_cast<uint32_t>(numRows),
-      expected,
-      /*outputOffset=*/10);
+      expected);
 }
 
 TEST_P(NimbleIndexProjectorTest, projectedTabletNullBarrierFlag) {
@@ -1592,10 +1567,10 @@ TEST_P(NimbleIndexProjectorTest, projectedComplexNullFuzzer) {
 }
 
 // Round-trips a single-batch deserialize over a key range. The Deserializer
-// over-fetches (decodes the full stripe rather than slicing to the row
-// range), so output->size() is the stripe rowCount and we verify the
-// in-range subset has the correct values. Used by the four positional range
-// tests below (start / middle / end / full).
+// honors the per-batch row range at decode time (via skip+next), so the
+// decoded output contains exactly `upperKey_ - lowerKey_` rows with values
+// that match the source stripe's in-range subset. Used by the four
+// positional range tests below (start / middle / end / full).
 //
 // Defined as a macro (rather than a function) so it can access the protected
 // fixture members from inside the TEST_P body.
@@ -1630,9 +1605,7 @@ TEST_P(NimbleIndexProjectorTest, projectedComplexNullFuzzer) {
         {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues)});       \
     expectVectorRows(                                                          \
         deserializeProjectedSlice(*projector, result.responses[0].slices[0]),  \
-        static_cast<uint32_t>(numRows),                                        \
-        expected,                                                              \
-        static_cast<uint32_t>(expectedOffset));                                \
+        expected);                                                             \
   } while (0)
 
 TEST_P(NimbleIndexProjectorTest, deserializerRangeAtStart) {
@@ -1652,8 +1625,8 @@ TEST_P(NimbleIndexProjectorTest, deserializerRangeAtEnd) {
 
 TEST_P(NimbleIndexProjectorTest, deserializerRangeFullStripe) {
   // Range spans the entire stripe: [0, 100). Validates round-trip on a
-  // full-stripe row range (boundary case where the in-range subset equals
-  // the over-fetched stripe).
+  // full-stripe row range (boundary case where the decoded output equals
+  // the source stripe verbatim).
   RUN_DESERIALIZER_RANGE_TEST(0, 100);
 }
 
@@ -1702,17 +1675,15 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchWithRowRange) {
   VectorPtr output;
   deserializer.deserialize(multiBatch, output);
 
-  // Over-fetch: each batch decodes its full 100 stripe rows; concatenation
-  // gives 200 rows. The in-range subset (positions [10, 40) within each
-  // batch) carries values[10..39].
-  ASSERT_EQ(output->size(), 200u);
+  // Each batch's [10, 40) range is honored at decode time, so the output
+  // is 2 × 30 = 60 rows — values[10..39] repeated.
+  ASSERT_EQ(output->size(), 60u);
   auto* rowVec = output->as<velox::RowVector>();
   auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();
-  for (uint32_t i = 10; i < 40; ++i) {
-    EXPECT_EQ(valueVec->valueAt(i), static_cast<int32_t>(i * 10))
-        << "batch=0 i=" << i;
-    EXPECT_EQ(valueVec->valueAt(100 + i), static_cast<int32_t>(i * 10))
-        << "batch=1 i=" << i;
+  for (uint32_t i = 0; i < 30; ++i) {
+    const int32_t expected = static_cast<int32_t>((10 + i) * 10);
+    EXPECT_EQ(valueVec->valueAt(i), expected) << "batch=0 i=" << i;
+    EXPECT_EQ(valueVec->valueAt(30 + i), expected) << "batch=1 i=" << i;
   }
 }
 
@@ -1774,30 +1745,29 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedRanges) {
   VectorPtr output;
   deserializer.deserialize(batches, output);
 
-  // Over-fetch: each batch decodes its full 100 stripe rows; concatenation
-  // gives 400 rows = 4 × 100. Verify each batch's in-range subset has the
-  // expected values at its position within the cumulative output.
-  ASSERT_EQ(output->size(), 400u);
+  // Each batch is decoded to its embedded row range at ingest, so the
+  // concatenated output is 20 + 20 + 20 + 100 = 160 rows.
+  ASSERT_EQ(output->size(), 160u);
   auto* rowVec = output->as<velox::RowVector>();
   auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();
-  // Batch 0: range [0, 20), batch starts at output offset 0.
+  // Batch 0: range [0, 20) → values[0..19] at output offset 0.
   for (uint32_t i = 0; i < 20; ++i) {
     EXPECT_EQ(valueVec->valueAt(i), static_cast<int32_t>(i * 10))
         << "batch=0 i=" << i;
   }
-  // Batch 1: range [30, 50), batch starts at output offset 100.
-  for (uint32_t i = 30; i < 50; ++i) {
-    EXPECT_EQ(valueVec->valueAt(100 + i), static_cast<int32_t>(i * 10))
+  // Batch 1: range [30, 50) → values[30..49] at output offset 20.
+  for (uint32_t i = 0; i < 20; ++i) {
+    EXPECT_EQ(valueVec->valueAt(20 + i), static_cast<int32_t>((30 + i) * 10))
         << "batch=1 i=" << i;
   }
-  // Batch 2: range [80, 100), batch starts at output offset 200.
-  for (uint32_t i = 80; i < 100; ++i) {
-    EXPECT_EQ(valueVec->valueAt(200 + i), static_cast<int32_t>(i * 10))
+  // Batch 2: range [80, 100) → values[80..99] at output offset 40.
+  for (uint32_t i = 0; i < 20; ++i) {
+    EXPECT_EQ(valueVec->valueAt(40 + i), static_cast<int32_t>((80 + i) * 10))
         << "batch=2 i=" << i;
   }
-  // Batch 3: range [0, 100) (full), batch starts at output offset 300.
+  // Batch 3: range [0, 100) → all 100 values at output offset 60.
   for (uint32_t i = 0; i < 100; ++i) {
-    EXPECT_EQ(valueVec->valueAt(300 + i), static_cast<int32_t>(i * 10))
+    EXPECT_EQ(valueVec->valueAt(60 + i), static_cast<int32_t>(i * 10))
         << "batch=3 i=" << i;
   }
 }
@@ -1869,20 +1839,18 @@ TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchMixedVersions) {
   VectorPtr output;
   deserializer.deserialize(batches, output);
 
-  // Over-fetch: kTablet batch decodes its full 100 stripe rows;
-  // kLegacyCompact batch contributes 5 rows. Concatenation = 105 rows. The
-  // in-range subset of the kTablet batch (positions [10, 40) within the
-  // first 100) carries values[10..39]; the kLegacyCompact batch's 5 rows
-  // follow.
-  ASSERT_EQ(output->size(), 105u);
+  // kTablet batch is honored to its [10, 40) range = 30 rows; kLegacyCompact
+  // batch has no rowRange and contributes its full 5 rows. Concatenation =
+  // 35 rows: values[10..39] followed by kLegacyCompactValues[0..4].
+  ASSERT_EQ(output->size(), 35u);
   auto* rowVec = output->as<velox::RowVector>();
   auto* valueVec = rowVec->childAt(0)->as<velox::FlatVector<int32_t>>();
-  for (uint32_t i = 10; i < 40; ++i) {
-    EXPECT_EQ(valueVec->valueAt(i), static_cast<int32_t>(i * 10))
+  for (uint32_t i = 0; i < 30; ++i) {
+    EXPECT_EQ(valueVec->valueAt(i), static_cast<int32_t>((10 + i) * 10))
         << "kTablet i=" << i;
   }
   for (uint32_t i = 0; i < 5; ++i) {
-    EXPECT_EQ(valueVec->valueAt(100 + i), kLegacyCompactValues[i])
+    EXPECT_EQ(valueVec->valueAt(30 + i), kLegacyCompactValues[i])
         << "kLegacyCompact i=" << i;
   }
 }
@@ -2082,9 +2050,7 @@ TEST_P(NimbleIndexProjectorTest, localReadModeStats) {
     auto expected = vectorMaker_->rowVector(
         {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues)});
     expectVectorRows(
-        deserializeProjectedBatches(*projector, serializedBatches),
-        static_cast<uint32_t>(numRows),
-        expected);
+        deserializeProjectedBatches(*projector, serializedBatches), expected);
 
     EXPECT_EQ(projector->stats().numReadStripes, numBatches);
     EXPECT_EQ(projector->stats().numReadRows, numRows);
@@ -2222,15 +2188,12 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjection) {
   ASSERT_NE(rowResult, nullptr);
   ASSERT_EQ(rowResult->childrenSize(), 1);
 
-  // FlatMap is deserialized as a MapVector. Extract keys and values at the
-  // target row to verify correctness. The Deserializer over-fetches (decodes
-  // the full stripe rather than slicing), so the requested row sits at
-  // position rowRange.startRow within the output.
+  // FlatMap is deserialized as a MapVector. The Deserializer honors the
+  // header's row range at decode time, so the single point-lookup row
+  // lands at output index 0.
   auto* mapResult = rowResult->childAt(0)->as<MapVector>();
   ASSERT_NE(mapResult, nullptr);
-  ASSERT_GE(mapResult->size(), rowRange.endRow);
-
-  const vector_size_t targetRow = rowRange.startRow;
+  ASSERT_EQ(mapResult->size(), rowRange.numRows());
 
   auto* mapKeyResults = mapResult->mapKeys()->as<FlatVector<StringView>>();
   auto* mapValues = mapResult->mapValues()->as<FlatVector<int64_t>>();
@@ -2238,8 +2201,8 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjection) {
   ASSERT_NE(mapValues, nullptr);
 
   // Collect key-value pairs at the target row.
-  const auto mapOffset = mapResult->offsetAt(targetRow);
-  const auto mapSize = mapResult->sizeAt(targetRow);
+  const auto mapOffset = mapResult->offsetAt(0);
+  const auto mapSize = mapResult->sizeAt(0);
 
   // row=5: key=50, features[k] = 5*100 + index_of(k).
   std::map<std::string, int64_t> kvPairs;
@@ -2257,9 +2220,9 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjection) {
 
 TEST_P(NimbleIndexProjectorTest, flatMapProjectionWithNarrowRowRange) {
   // Schema: key (int64, sorted), features (MAP<VARCHAR, BIGINT> as FlatMap).
-  // Range scan over keys [50, 100) — 5 rows starting at row index 5 (since
-  // keys are row*10). The Deserializer over-fetches and returns the full
-  // 200-row stripe; we verify the in-range subset at positions [5, 10).
+  // Range scan over keys [50, 100) — 5 rows starting at source row index 5
+  // (since keys are row*10). The Deserializer honors the header's row
+  // range at decode time, so the output is exactly 5 rows.
   auto rowType = ROW({"key", "features"}, {BIGINT(), MAP(VARCHAR(), BIGINT())});
 
   const int numRows = 200;
@@ -2317,33 +2280,34 @@ TEST_P(NimbleIndexProjectorTest, flatMapProjectionWithNarrowRowRange) {
           reinterpret_cast<const char*>(coalesced.data()), coalesced.length()),
       deserialized);
   ASSERT_NE(deserialized, nullptr);
-  // Over-fetch: full stripe is decoded.
-  ASSERT_EQ(deserialized->size(), 200u);
+  ASSERT_EQ(deserialized->size(), 5u);
 
   auto* rowResult = deserialized->as<RowVector>();
   ASSERT_NE(rowResult, nullptr);
   auto* mapResult = rowResult->childAt(0)->as<MapVector>();
   ASSERT_NE(mapResult, nullptr);
-  ASSERT_EQ(mapResult->size(), 200u);
+  ASSERT_EQ(mapResult->size(), 5u);
 
   auto* mapKeyResults = mapResult->mapKeys()->as<FlatVector<StringView>>();
   auto* mapValues = mapResult->mapValues()->as<FlatVector<int64_t>>();
   ASSERT_NE(mapKeyResults, nullptr);
   ASSERT_NE(mapValues, nullptr);
 
-  // Verify the in-range subset (rows 5..9): both projected FlatMap keys
-  // "a" (idx 0) and "c" (idx 2) are present with values row*100 + index.
-  for (vector_size_t row = 5; row < 10; ++row) {
-    const auto mapOffset = mapResult->offsetAt(row);
-    const auto mapSize = mapResult->sizeAt(row);
-    ASSERT_EQ(mapSize, 2) << "row=" << row;
+  // Verify each output row corresponds to source rows 5..9: both projected
+  // FlatMap keys "a" (idx 0) and "c" (idx 2) are present with values
+  // sourceRow*100 + index.
+  for (vector_size_t outRow = 0; outRow < 5; ++outRow) {
+    const int64_t sourceRow = 5 + outRow;
+    const auto mapOffset = mapResult->offsetAt(outRow);
+    const auto mapSize = mapResult->sizeAt(outRow);
+    ASSERT_EQ(mapSize, 2) << "outRow=" << outRow;
     std::map<std::string, int64_t> kv;
     for (vector_size_t k = 0; k < mapSize; ++k) {
       kv[std::string(mapKeyResults->valueAt(mapOffset + k))] =
           mapValues->valueAt(mapOffset + k);
     }
-    EXPECT_EQ(kv["a"], row * 100 + 0) << "row=" << row;
-    EXPECT_EQ(kv["c"], row * 100 + 2) << "row=" << row;
+    EXPECT_EQ(kv["a"], sourceRow * 100 + 0) << "outRow=" << outRow;
+    EXPECT_EQ(kv["c"], sourceRow * 100 + 2) << "outRow=" << outRow;
   }
 }
 
@@ -2661,19 +2625,16 @@ TEST_P(NimbleIndexProjectorTest, flatMapIntKeyProjection) {
 
   auto* mapResult = rowResult->childAt(0)->as<MapVector>();
   ASSERT_NE(mapResult, nullptr);
-  // Over-fetch: full stripe is decoded.
-  ASSERT_GE(mapResult->size(), rowRange.endRow);
-
-  // Target row sits at position rowRange.startRow within the output.
-  const vector_size_t targetRow = rowRange.startRow;
+  // Sliced output contains exactly the point-lookup row.
+  ASSERT_EQ(mapResult->size(), rowRange.numRows());
 
   auto* mapKeyResults = mapResult->mapKeys()->as<FlatVector<int32_t>>();
   auto* mapValues = mapResult->mapValues()->as<FlatVector<int64_t>>();
   ASSERT_NE(mapKeyResults, nullptr);
   ASSERT_NE(mapValues, nullptr);
 
-  const auto mapOffset = mapResult->offsetAt(targetRow);
-  const auto mapSize = mapResult->sizeAt(targetRow);
+  const auto mapOffset = mapResult->offsetAt(0);
+  const auto mapSize = mapResult->sizeAt(0);
 
   // row=5: key=50, features[k] = 5*100 + k.
   std::map<int32_t, int64_t> kvPairs;
@@ -2776,16 +2737,15 @@ TEST_P(NimbleIndexProjectorTest, flatMapMissingKeys) {
     auto* mapResult =
         deserialized->as<RowVector>()->childAt(0)->as<MapVector>();
     ASSERT_NE(mapResult, nullptr);
-    ASSERT_GE(mapResult->size(), rowRange.endRow);
+    ASSERT_EQ(mapResult->size(), rowRange.numRows());
 
-    const vector_size_t targetRow = rowRange.startRow;
     auto* keysVec = mapResult->mapKeys()->as<FlatVector<StringView>>();
     auto* valsVec = mapResult->mapValues()->as<FlatVector<int64_t>>();
     ASSERT_NE(keysVec, nullptr);
     ASSERT_NE(valsVec, nullptr);
 
-    const auto mapOffset = mapResult->offsetAt(targetRow);
-    const auto mapSize = mapResult->sizeAt(targetRow);
+    const auto mapOffset = mapResult->offsetAt(0);
+    const auto mapSize = mapResult->sizeAt(0);
     std::map<std::string, int64_t> kvPairs;
     for (vector_size_t i = 0; i < mapSize; ++i) {
       kvPairs[keysVec->valueAt(mapOffset + i).str()] =
@@ -2873,7 +2833,8 @@ TEST_P(NimbleIndexProjectorTest, flatMapMissingKeyDeserializesAsNullField) {
       output);
 
   ASSERT_NE(output, nullptr);
-  ASSERT_EQ(output->size(), numRows);
+  // Sliced output has 10 rows for the [10, 20) range.
+  ASSERT_EQ(output->size(), 10);
   auto* features = output->as<RowVector>()->childAt(0)->as<RowVector>();
   ASSERT_NE(features, nullptr);
   ASSERT_EQ(features->childrenSize(), 2);
@@ -2885,11 +2846,12 @@ TEST_P(NimbleIndexProjectorTest, flatMapMissingKeyDeserializesAsNullField) {
   ASSERT_NE(presentKey, nullptr);
   ASSERT_NE(missingKey, nullptr);
 
-  for (vector_size_t row = 10; row < 20; ++row) {
-    SCOPED_TRACE(fmt::format("row={}", row));
-    EXPECT_FALSE(presentKey->isNullAt(row));
-    EXPECT_EQ(presentKey->valueAt(row), row * 100);
-    EXPECT_TRUE(missingKey->isNullAt(row));
+  for (vector_size_t outRow = 0; outRow < 10; ++outRow) {
+    const int64_t sourceRow = 10 + outRow;
+    SCOPED_TRACE(fmt::format("outRow={} sourceRow={}", outRow, sourceRow));
+    EXPECT_FALSE(presentKey->isNullAt(outRow));
+    EXPECT_EQ(presentKey->valueAt(outRow), sourceRow * 100);
+    EXPECT_TRUE(missingKey->isNullAt(outRow));
   }
 }
 


### PR DESCRIPTION
Summary:

`nimble::Deserializer` now honors the per-batch `rowRange` embedded in each
kTablet chunk header — the decoded output contains only the rows the
projector requested. Uses `SegmentedStreamDecoder::skip` + `reader_->next`
to bypass rows outside the range without materializing them.

Adds a public overload:
```
void deserialize(
    const std::vector<std::string_view>& data,
    const std::vector<nimble::RowRange>& rowRanges,
    velox::VectorPtr& output) const;
```
Caller-supplied ranges override any rowRange encoded in the header.

Also bundles the downstream test/benchmark/doc updates that previously
relied on the over-fetch behavior — `dwio/nimble/velox/index/tests`,
`rocks/nimble/tests`, `zippydb/server/tests`,
`rexdb/benchmarks/file_format/lib`, and `rocks/nimble/docs`.

Companion diff D114257287 implements the same behavior via a slice-at-
ingest approach; kept side by side for comparison.

Reviewed By: xiaoxmeng

Differential Revision: D113966951


