### PR TITLE
misc: Advance Velox hash (#1048)

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Nimble integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/14779a1a9de69c6bd222396ab2f4bfe14e85fd48...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/dbde3f27f3ab9167182809f4ab3317f17dd4f779...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary:

Advance the Nimble OSS Velox submodule pin to
dbde3f27f3ab9167182809f4ab3317f17dd4f779 to pick up
facebookincubator/velox#18328 (the ReaderOptions loadChunkIndex ->
loadChunkStats rename), fixing the OSS Nimble CMake build, which now references
loadChunkStats. Updates velox.submodule.txt and the README compare link in
lockstep (the check-velox-readme pre-commit hook requires the two SHAs to
match). fbcode builds against the in-repo velox/, so this only affects the OSS
GitHub build; validation runs in OSS GitHub CI after landing.

Differential Revision: D114249402
