### PR TITLE
feat: Add FSST native slice support (#1049)

### DIFF
--- a/dwio/nimble/encodings/BlockBitPackingEncoding.h
+++ b/dwio/nimble/encodings/BlockBitPackingEncoding.h
@@ -289,7 +289,7 @@ class BlockBitPackingEncoding final
 
   // Parsed stream metadata. lastBlockRows is derived from rowCount and the
   // first-block override; it is not serialized.
-  struct SourceHeader {
+  struct Header {
     uint32_t rowCount{0};
     uint16_t blockSize{0};
     uint16_t numBlocks{0};
@@ -302,10 +302,16 @@ class BlockBitPackingEncoding final
     std::string_view packedData;
   };
 
-  static SourceHeader parseSourceHeader(
+  struct BlockPosition {
+    uint32_t blockIndex{0};
+    uint32_t rowOffset{0};
+    uint32_t rowCount{0};
+  };
+
+  static Header parseHeader(
       std::string_view encoded,
       const Encoding::Options& options) {
-    SourceHeader source;
+    Header source;
     source.rowCount =
         EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
     const char* pos = encoded.data() +
@@ -342,26 +348,26 @@ class BlockBitPackingEncoding final
   }
 
   static std::string_view packedDataSource(
-      const SourceHeader& source,
+      const Header& header,
       velox::BufferPtr& uncompressedData,
       velox::memory::MemoryPool* pool,
       const Encoding::Options& options) {
-    if (source.compressionType == CompressionType::Uncompressed) {
-      return source.packedData;
+    if (header.compressionType == CompressionType::Uncompressed) {
+      return header.packedData;
     }
     NIMBLE_CHECK_NOT_NULL(pool);
     uncompressedData = Compression::uncompress(
         *pool,
-        source.compressionType,
+        header.compressionType,
         DataType::Undefined,
-        source.packedData,
+        header.packedData,
         options.decompressCounter(),
         options.bufferPool);
     return {uncompressedData->as<char>(), uncompressedData->size()};
   }
 
   static void readBlockOffsets(
-      const SourceHeader& source,
+      const Header& header,
       uint32_t blockOffset,
       uint32_t blockCount,
       uint32_t packedDataSize,
@@ -373,9 +379,9 @@ class BlockBitPackingEncoding final
     // data size because there is no stored successor offset.
     NIMBLE_CHECK_NOT_NULL(pool);
     const auto numReadBlocks =
-        blockCount + (blockOffset + blockCount < source.numBlocks ? 1 : 0);
+        blockCount + (blockOffset + blockCount < header.numBlocks ? 1 : 0);
     detail::createTypedEncodingView<uint32_t>(
-        source.encodedBlockOffsets, pool, options)
+        header.encodedBlockOffsets, pool, options)
         ->read(blockOffset, numReadBlocks, output.data());
     if (numReadBlocks == blockCount) {
       output[blockCount] = packedDataSize;
@@ -384,16 +390,14 @@ class BlockBitPackingEncoding final
 
   // Sliced streams can preserve a partial first block, so row counts are based
   // on the parsed source header instead of blockIndex * blockSize.
-  static uint32_t blockRowCount(
-      const SourceHeader& source,
-      uint32_t blockIndex) {
+  static uint32_t blockRowCount(const Header& header, uint32_t blockIndex) {
     if (blockIndex == 0) {
-      return source.firstBlockRows;
+      return header.firstBlockRows;
     }
-    if (blockIndex == source.numBlocks - 1) {
-      return source.lastBlockRows;
+    if (blockIndex == header.numBlocks - 1) {
+      return header.lastBlockRows;
     }
-    return source.blockSize;
+    return header.blockSize;
   }
 
   // Returns the number of rows in the given block (may be less than
@@ -409,23 +413,30 @@ class BlockBitPackingEncoding final
   }
 
   // Row offset for sliced streams where the first block may not be full.
-  static uint32_t blockRowOffset(
-      const SourceHeader& source,
-      uint32_t blockIndex) {
+  static uint32_t blockRowOffset(const Header& header, uint32_t blockIndex) {
     if (blockIndex == 0) {
       return 0;
     }
-    return source.firstBlockRows + (blockIndex - 1) * source.blockSize;
+    return header.firstBlockRows + (blockIndex - 1) * header.blockSize;
   }
 
-  static uint32_t blockIndex(const SourceHeader& source, uint32_t row) {
-    if (row < source.firstBlockRows) {
-      return 0;
+  static BlockPosition blockPosition(const Header& header, uint32_t row) {
+    if (row < header.firstBlockRows) {
+      return {
+          .blockIndex = 0,
+          .rowOffset = row,
+          .rowCount = header.firstBlockRows,
+      };
     }
-    const auto blockIndex =
-        1 + (row - source.firstBlockRows) / source.blockSize;
-    NIMBLE_CHECK_LT(blockIndex, source.numBlocks);
-    return blockIndex;
+    const auto relativeRow = row - header.firstBlockRows;
+    const auto index = 1 + relativeRow / header.blockSize;
+    NIMBLE_CHECK_LT(index, header.numBlocks);
+    return {
+        .blockIndex = index,
+        .rowOffset = relativeRow % header.blockSize,
+        .rowCount = index == header.numBlocks - 1 ? header.lastBlockRows
+                                                  : header.blockSize,
+    };
   }
 
   uint32_t blockIndex(uint32_t row) const {
@@ -456,7 +467,7 @@ class BlockBitPackingEncoding final
   }
 
   static void writeBlockSlicesPayload(
-      const SourceHeader& source,
+      const Header& header,
       std::string_view packedData,
       std::span<const BlockSliceInfo> blockSlices,
       std::span<const uint32_t> sliceOffsets,
@@ -584,7 +595,7 @@ BlockBitPackingEncoding<T>::makeBlockInfo(
 
 template <typename T>
 void BlockBitPackingEncoding<T>::writeBlockSlicesPayload(
-    const SourceHeader& source,
+    const Header& header,
     std::string_view packedData,
     std::span<const BlockSliceInfo> blockSlices,
     std::span<const uint32_t> sliceOffsets,
@@ -595,7 +606,7 @@ void BlockBitPackingEncoding<T>::writeBlockSlicesPayload(
   const auto needsBitCopy = [&](const BlockSliceInfo& blockSlice) {
     return !blockSlice.skipEncoding && blockSlice.bitWidth != 0 &&
         (blockSlice.rowOffset != 0 ||
-         blockSlice.rowCount != blockRowCount(source, blockSlice.blockIndex));
+         blockSlice.rowCount != blockRowCount(header, blockSlice.blockIndex));
   };
   const auto copyBlockBitsRange = [&](uint32_t blockIndex) {
     const auto& blockSlice = blockSlices[blockIndex];
@@ -657,7 +668,7 @@ BlockBitPackingEncoding<T>::BlockBitPackingEncoding(
       blockOffsets_{this->template getVectorBuffer<uint32_t>()},
       packedData_{nullptr},
       buffer_{&pool} {
-  const auto source = parseSourceHeader(data, options);
+  const auto source = parseHeader(data, options);
   blockSize_ = source.blockSize;
   numBlocks_ = source.numBlocks;
   firstBlockRows_ = source.firstBlockRows;
@@ -1230,7 +1241,7 @@ std::string_view BlockBitPackingEncoding<T>::slice(
       options.bufferPool->release(std::move(uncompressedSourceData));
     }
   };
-  const auto source = parseSourceHeader(encoded, options);
+  const auto source = parseHeader(encoded, options);
   NIMBLE_CHECK_LE(offset, source.rowCount);
   NIMBLE_CHECK_LE(length, source.rowCount - offset);
   NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
@@ -1238,8 +1249,8 @@ std::string_view BlockBitPackingEncoding<T>::slice(
   const auto packedData =
       packedDataSource(source, uncompressedSourceData, pool, options);
 
-  const auto firstBlock = blockIndex(source, offset);
-  const auto lastBlock = blockIndex(source, offset + length - 1);
+  const auto firstBlock = blockPosition(source, offset).blockIndex;
+  const auto lastBlock = blockPosition(source, offset + length - 1).blockIndex;
   const auto numBlocks = lastBlock - firstBlock + 1;
   NIMBLE_CHECK_LE(
       numBlocks,
@@ -1274,13 +1285,13 @@ std::string_view BlockBitPackingEncoding<T>::slice(
   uint32_t curRow{offset};
   const auto endRow = offset + length;
   for (uint16_t sliceIndex = 0; sliceIndex < numBlocks; ++sliceIndex) {
-    const auto blockIndex = firstBlock + sliceIndex;
-    const auto blockRowCount =
-        BlockBitPackingEncoding::blockRowCount(source, blockIndex);
-    const auto rowOffset = curRow - blockRowOffset(source, blockIndex);
+    const auto position = blockPosition(source, curRow);
+    const auto blockIndex = position.blockIndex;
+    NIMBLE_CHECK_EQ(blockIndex, firstBlock + sliceIndex);
+    const auto rowOffset = position.rowOffset;
     const auto rowCount =
-        std::min<uint32_t>(endRow - curRow, blockRowCount - rowOffset);
-    const auto fullBlock = rowOffset == 0 && rowCount == blockRowCount;
+        std::min<uint32_t>(endRow - curRow, position.rowCount - rowOffset);
+    const auto fullBlock = rowOffset == 0 && rowCount == position.rowCount;
     const auto bitWidth = fullBlock ? uint8_t{0} : getBlockBitWidth(blockIndex);
     const auto skipEncoding = bitWidth == kRawBlockBitWidth;
     const uint32_t packedOffsetAdjustment = skipEncoding

--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -27,6 +27,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/ForEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
@@ -241,6 +242,19 @@ std::string_view sliceSimdForBitpack(
           encoded, offset, length, buffer, options));
 }
 
+std::string_view sliceFOR(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_INTEGER_DATA_TYPE(
+      dataType,
+      T,
+      ForEncoding<T>::slice(encoded, offset, length, buffer, options));
+}
+
 std::string_view sliceALP(
     std::string_view encoded,
     DataType dataType,
@@ -297,6 +311,8 @@ std::string_view EncodingSliceFactory::slice(
     case EncodingType::SimdForBitpack:
       return sliceSimdForBitpack(
           encoded, dataType, offset, length, buffer, options);
+    case EncodingType::FOR:
+      return sliceFOR(encoded, dataType, offset, length, buffer, options);
     case EncodingType::ALP:
       return sliceALP(encoded, dataType, offset, length, buffer, options);
     case EncodingType::Nullable:

--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -28,6 +28,7 @@
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/ForEncoding.h"
+#include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
@@ -255,6 +256,20 @@ std::string_view sliceFOR(
       ForEncoding<T>::slice(encoded, offset, length, buffer, options));
 }
 
+std::string_view sliceFsst(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_CHECK_EQ(
+      dataType,
+      DataType::String,
+      "Trying to slice FsstEncoding with a non-string data type.");
+  return FsstEncoding::slice(encoded, offset, length, buffer, options);
+}
+
 std::string_view sliceALP(
     std::string_view encoded,
     DataType dataType,
@@ -313,6 +328,8 @@ std::string_view EncodingSliceFactory::slice(
           encoded, dataType, offset, length, buffer, options);
     case EncodingType::FOR:
       return sliceFOR(encoded, dataType, offset, length, buffer, options);
+    case EncodingType::Fsst:
+      return sliceFsst(encoded, dataType, offset, length, buffer, options);
     case EncodingType::ALP:
       return sliceALP(encoded, dataType, offset, length, buffer, options);
     case EncodingType::Nullable:

--- a/dwio/nimble/encodings/ForEncoding.h
+++ b/dwio/nimble/encodings/ForEncoding.h
@@ -15,35 +15,41 @@
  */
 #pragma once
 
+#include <array>
 #include <span>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/FixedBitArray.h"
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/Vector.h"
 #include "dwio/nimble/compression/Compression.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
 #include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 
 // Frame of Reference encoding. Divides data into fixed-size frames, storing
 // a reference value per frame and bit-packing the exceptions (value - ref).
-// Supports O(1) random access when BitOffsets are enabled.
+// Stores per-frame bit offsets for O(1) random access.
 //
 // Data layout is:
-// Encoding::kPrefixSize bytes: standard Encoding prefix
+// Standard Encoding prefix
 // 1 byte: compression type
-// 4 bytes: frame size
-// 4 bytes: number of frames
-// 1 byte: enableBitOffsets flag
-// XX bytes: BitWidths array encoding (nested)
-// YY bytes: References array encoding (nested)
-// ZZ bytes: BitOffsets array encoding (nested, optional)
-// WW bytes: bit-packed exceptions data
+// varint: frame size
+// varint: number of frames
+// varint: first frame rows
+// varint + XX bytes: BitWidths array encoding (nested)
+// varint + YY bytes: References array encoding (nested)
+// varint + ZZ bytes: BitOffsets array encoding (nested)
+// varint + WW bytes: bit-packed exceptions data
 
 namespace facebook::nimble {
 
@@ -55,10 +61,6 @@ class ForEncoding final
   using physicalType = typename TypeTraits<T>::physicalType;
 
   static const int kCompressionOffset = Encoding::kPrefixSize;
-  static const int kFrameSizeOffset = kCompressionOffset + 1;
-  static const int kNumFramesOffset = kFrameSizeOffset + 4;
-  static const int kEnableBitOffsetsOffset = kNumFramesOffset + 4;
-  static const int kPrefixSize = kEnableBitOffsetsOffset + 1;
 
   ForEncoding(
       velox::memory::MemoryPool& memoryPool,
@@ -83,6 +85,13 @@ class ForEncoding final
       Buffer& buffer,
       const Encoding::Options& options = {});
 
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
   std::string debugString(int offset) const final;
 
  private:
@@ -93,27 +102,211 @@ class ForEncoding final
     uint32_t size;
   };
 
-  uint32_t frameSize_;
-  uint32_t numFrames_;
-  bool enableBitOffsets_;
-  Vector<FrameInfo> frames_;
-  const char* packedData_;
-  uint32_t currentRow_;
-  velox::BufferPtr uncompressedData_;
-  Vector<physicalType> buffer_;
-
-  uint32_t getFrameIndex(uint32_t row) const {
-    return row / frameSize_;
+  // Counts frames when the first frame may be shorter than frameSize.
+  static uint32_t
+  numFrames(uint32_t rowCount, uint32_t frameSize, uint32_t firstFrameRows) {
+    if (rowCount <= firstFrameRows) {
+      return 1;
+    }
+    return 1 + velox::bits::divRoundUp(rowCount - firstFrameRows, frameSize);
   }
 
-  uint32_t getPositionInFrame(uint32_t row) const {
-    return row % frameSize_;
+  // Parsed stream metadata shared by normal decode and native slice.
+  struct Header {
+    Header() = default;
+
+    Header(
+        uint32_t rowCount,
+        uint32_t frameSize,
+        uint32_t numFrames,
+        uint32_t firstFrameRows,
+        CompressionType compressionType = CompressionType::Uncompressed)
+        : rowCount{rowCount},
+          compressionType{compressionType},
+          frameSize{frameSize},
+          numFrames{numFrames},
+          firstFrameRows{firstFrameRows} {
+      NIMBLE_CHECK_GT(frameSize, 0, "FOR frame size must be positive.");
+      NIMBLE_CHECK_GT(numFrames, 0, "FOR stream must contain frames.");
+      NIMBLE_CHECK_GT(firstFrameRows, 0, "FOR first frame must contain rows.");
+      NIMBLE_CHECK_LE(
+          firstFrameRows,
+          frameSize,
+          "FOR first frame cannot exceed frame size.");
+      NIMBLE_CHECK_EQ(
+          numFrames,
+          ForEncoding<T>::numFrames(rowCount, frameSize, firstFrameRows),
+          "FOR frame count mismatch.");
+
+      const auto lastFrameOffset = numFrames == 1
+          ? uint32_t{0}
+          : firstFrameRows + (numFrames - 2) * frameSize;
+      lastFrameRows = rowCount - lastFrameOffset;
+    }
+
+    // Logical rows represented by this FOR stream.
+    uint32_t rowCount{0};
+    CompressionType compressionType{CompressionType::Uncompressed};
+    // Target frame size for full interior frames.
+    uint32_t frameSize{0};
+    // Number of frame metadata entries and packed frame segments.
+    uint32_t numFrames{0};
+    // Sliced streams may start with a partial frame.
+    uint32_t firstFrameRows{0};
+    // Regular streams only have a partial final frame; sliced streams may have
+    // both partial first and last frames.
+    uint32_t lastFrameRows{0};
+    // Serialized child streams used by encode and native slice output.
+    std::string_view serializedBitWidths;
+    std::string_view serializedReferences;
+    std::string_view serializedBitOffsets;
+    // Byte length of the packed residual payload.
+    uint32_t packedDataSize{0};
+  };
+
+  static std::string_view readVarintString(const char*& pos) {
+    const uint32_t size = varint::readVarint32(&pos);
+    std::string_view result{pos, size};
+    pos += size;
+    return result;
+  }
+
+  static Header parseHeader(
+      std::string_view encoded,
+      const Encoding::Options& options,
+      const char*& pos) {
+    pos = encoded.data() +
+        EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+    const auto compressionType =
+        static_cast<CompressionType>(encoding::readChar(pos));
+    const auto frameSize = varint::readVarint32(&pos);
+    const auto numFrames = varint::readVarint32(&pos);
+    const auto firstFrameRows = varint::readVarint32(&pos);
+    Header header{
+        EncodingPrefix::readRowCount(encoded, options.useVarintRowCount),
+        frameSize,
+        numFrames,
+        firstFrameRows,
+        compressionType};
+    header.serializedBitWidths = readVarintString(pos);
+    header.serializedReferences = readVarintString(pos);
+    header.serializedBitOffsets = readVarintString(pos);
+    header.packedDataSize = varint::readVarint32(&pos);
+    return header;
+  }
+
+  static uint32_t headerSize(const Header& header) {
+    return sizeof(uint8_t) /*compressionType*/ +
+        varint::varintSize(header.frameSize) +
+        varint::varintSize(header.numFrames) +
+        varint::varintSize(header.firstFrameRows) +
+        varint::varintSize(header.serializedBitWidths.size()) +
+        header.serializedBitWidths.size() +
+        varint::varintSize(header.serializedReferences.size()) +
+        header.serializedReferences.size() +
+        varint::varintSize(header.serializedBitOffsets.size()) +
+        header.serializedBitOffsets.size() +
+        varint::varintSize(header.packedDataSize) + header.packedDataSize;
+  }
+
+  template <typename MetadataType>
+  static std::string_view encodeMetadata(
+      std::span<const MetadataType> values,
+      Buffer& buffer,
+      const Encoding::Options& options) {
+    EncodingSelectionResult result{.encodingType = EncodingType::Trivial};
+    EncodingSelection<MetadataType> selection{
+        std::move(result), Statistics<MetadataType>::create(values), nullptr};
+    return TrivialEncoding<MetadataType>::encode(
+        selection, values, buffer, options);
+  }
+
+  // FOR stores residual widths using a fixed set of wire-supported widths.
+  // velox::bits::bitsRequired returns the exact bit count; this rounds that
+  // count up to the nearest width the FOR payload writer can encode.
+  static uint8_t minBitWidth(uint64_t maxValue) {
+    if (maxValue == 0) {
+      return 1;
+    }
+
+    constexpr std::array<uint8_t, 7> kBitWidths = {1, 2, 4, 8, 16, 32, 64};
+    const auto bitsNeeded = velox::bits::bitsRequired(maxValue);
+    for (const auto width : kBitWidths) {
+      if (width >= bitsNeeded) {
+        return width;
+      }
+    }
+    return 64;
+  }
+
+  static void prepareSliceHeaderMetadata(
+      const Header& header,
+      uint32_t firstFrame,
+      uint32_t numFrames,
+      uint32_t offset,
+      uint32_t length,
+      Header& sliceHeader,
+      Vector<uint8_t>& sourceBitWidths,
+      Vector<uint64_t>& sourceBitOffsets,
+      Vector<uint64_t>& sliceBitOffsets,
+      Buffer& buffer,
+      const Encoding::Options& options);
+
+  static uint32_t frameRowOffset(const Header& header, uint32_t frameIndex) {
+    if (frameIndex == 0) {
+      return 0;
+    }
+    return header.firstFrameRows + (frameIndex - 1) * header.frameSize;
+  }
+
+  // Uses cached lastFrameRows because sliced streams may have partial first and
+  // last frames.
+  static uint32_t frameRowCount(const Header& header, uint32_t frameIndex) {
+    if (frameIndex == header.numFrames - 1) {
+      return header.lastFrameRows;
+    }
+    if (frameIndex == 0) {
+      return header.firstFrameRows;
+    }
+    return header.frameSize;
+  }
+
+  static uint32_t frameIndex(const Header& header, uint32_t row) {
+    if (row < header.firstFrameRows) {
+      return 0;
+    }
+    const auto frameIndex =
+        1 + (row - header.firstFrameRows) / header.frameSize;
+    NIMBLE_CHECK_LT(frameIndex, header.numFrames);
+    return frameIndex;
+  }
+
+  static uint32_t rowOffsetInFrame(const Header& header, uint32_t row) {
+    if (header.firstFrameRows == header.frameSize) {
+      return row % header.frameSize;
+    }
+    return row - frameRowOffset(header, frameIndex(header, row));
+  }
+
+  uint32_t frameIndex(uint32_t row) const {
+    return frameIndex(header_, row);
+  }
+
+  uint32_t rowOffsetInFrame(uint32_t row) const {
+    return rowOffsetInFrame(header_, row);
   }
 
   void decodeRange(uint32_t startRow, uint32_t rowCount, physicalType* output)
       const;
 
   physicalType decodeValue(uint32_t row) const;
+
+  Header header_;
+  Vector<FrameInfo> frames_;
+  const char* packedData_;
+  uint32_t currentRow_;
+  velox::BufferPtr uncompressedData_;
+  Vector<physicalType> buffer_;
 };
 //
 // Implementation
@@ -133,7 +326,7 @@ ForEncoding<T>::ForEncoding(
       std::is_integral_v<physicalType>,
       "ForEncoding only supports integral types");
 
-  const char* pos = data.data() + kCompressionOffset;
+  const char* pos;
   const EncodingFactory encodingFactory(options);
   const auto nullStringBufferFactory = [](uint32_t /*size*/) -> void* {
     return nullptr;
@@ -141,56 +334,32 @@ ForEncoding<T>::ForEncoding(
   const auto& decodeStringBufferFactory =
       stringBufferFactory ? stringBufferFactory : nullStringBufferFactory;
 
-  CompressionType compressionType =
-      static_cast<CompressionType>(encoding::readChar(pos));
+  header_ = parseHeader(data, options, pos);
+  NIMBLE_CHECK_EQ(header_.rowCount, this->rowCount_);
 
-  frameSize_ = encoding::readUint32(pos);
-  numFrames_ = encoding::readUint32(pos);
-  enableBitOffsets_ = static_cast<bool>(encoding::readChar(pos));
-
-  // Read BitWidths array
-  const uint32_t bitWidthsSize = encoding::readUint32(pos);
   auto bitWidthsEncoding = encodingFactory.create(
-      *this->pool_,
-      std::string_view(pos, bitWidthsSize),
-      decodeStringBufferFactory);
-  pos += bitWidthsSize;
+      *this->pool_, header_.serializedBitWidths, decodeStringBufferFactory);
 
-  Vector<uint8_t> bitWidths(&memoryPool, numFrames_);
-  bitWidthsEncoding->materialize(numFrames_, bitWidths.data());
+  Vector<uint8_t> bitWidths(&memoryPool, header_.numFrames);
+  bitWidthsEncoding->materialize(header_.numFrames, bitWidths.data());
 
-  // Read References array
-  const uint32_t referencesSize = encoding::readUint32(pos);
   auto referencesEncoding = encodingFactory.create(
-      *this->pool_,
-      std::string_view(pos, referencesSize),
-      decodeStringBufferFactory);
-  pos += referencesSize;
+      *this->pool_, header_.serializedReferences, decodeStringBufferFactory);
 
-  Vector<physicalType> references(&memoryPool, numFrames_);
-  referencesEncoding->materialize(numFrames_, references.data());
+  Vector<physicalType> references(&memoryPool, header_.numFrames);
+  referencesEncoding->materialize(header_.numFrames, references.data());
 
-  // Read BitOffsets array if enabled
-  Vector<uint64_t> bitOffsets(&memoryPool);
-  if (enableBitOffsets_) {
-    const uint32_t bitOffsetsSize = encoding::readUint32(pos);
-    auto bitOffsetsEncoding = encodingFactory.create(
-        *this->pool_,
-        std::string_view(pos, bitOffsetsSize),
-        decodeStringBufferFactory);
-    pos += bitOffsetsSize;
+  auto bitOffsetsEncoding = encodingFactory.create(
+      *this->pool_, header_.serializedBitOffsets, decodeStringBufferFactory);
+  Vector<uint64_t> bitOffsets(&memoryPool, header_.numFrames);
+  bitOffsetsEncoding->materialize(header_.numFrames, bitOffsets.data());
 
-    bitOffsets.resize(numFrames_);
-    bitOffsetsEncoding->materialize(numFrames_, bitOffsets.data());
-  }
+  std::string_view packedDataView{pos, header_.packedDataSize};
 
-  const uint32_t packedDataSize = encoding::readUint32(pos);
-  std::string_view packedDataView{pos, packedDataSize};
-
-  if (compressionType != CompressionType::Uncompressed) {
+  if (header_.compressionType != CompressionType::Uncompressed) {
     uncompressedData_ = Compression::uncompress(
         *this->pool_,
-        compressionType,
+        header_.compressionType,
         DataType::Undefined,
         packedDataView,
         options.decompressCounter());
@@ -200,25 +369,16 @@ ForEncoding<T>::ForEncoding(
   }
 
   // Build frame metadata
-  frames_.reserve(numFrames_);
-  uint64_t cumulativeBitOffset = 0;
-
-  for (uint32_t i = 0; i < numFrames_; ++i) {
-    FrameInfo frame;
+  frames_.reserve(header_.numFrames);
+  for (uint32_t i = 0; i < header_.numFrames; ++i) {
+    FrameInfo frame{};
     frame.reference = references[i];
     frame.bitWidth = bitWidths[i];
-    frame.bitOffset = enableBitOffsets_ ? bitOffsets[i] : cumulativeBitOffset;
+    frame.bitOffset = bitOffsets[i];
 
-    uint32_t startRow = i * frameSize_;
-    uint32_t endRow = std::min(startRow + frameSize_, this->rowCount_);
-    frame.size = endRow - startRow;
+    frame.size = frameRowCount(header_, i);
 
     frames_.push_back(frame);
-
-    // Update cumulative offset for next frame
-    if (!enableBitOffsets_) {
-      cumulativeBitOffset += frame.size * frame.bitWidth;
-    }
   }
 }
 
@@ -280,12 +440,11 @@ void ForEncoding<T>::decodeRange(
   uint32_t remainingRowCount = rowCount;
 
   while (remainingRowCount > 0) {
-    const uint32_t frameIndex = getFrameIndex(currentRow);
-    const auto& frame = frames_[frameIndex];
-    const uint32_t positionInFrame = getPositionInFrame(currentRow);
-    const uint32_t rowsAvailableInFrame = frame.size - positionInFrame;
-    const uint32_t rowsToDecode =
-        std::min(remainingRowCount, rowsAvailableInFrame);
+    const uint32_t index = frameIndex(currentRow);
+    const auto& frame = frames_[index];
+    const uint32_t rowOffset = rowOffsetInFrame(currentRow);
+    const uint32_t rowsInFrame = frame.size - rowOffset;
+    const uint32_t rowsToDecode = std::min(remainingRowCount, rowsInFrame);
 
     // Per-frame reference application — captures frame by ref
     auto decodeException = [&](uint32_t i, uint64_t residual) {
@@ -307,8 +466,8 @@ void ForEncoding<T>::decodeRange(
           frame.reference);
 
     } else {
-      const uint64_t bitPosition = frame.bitOffset +
-          static_cast<uint64_t>(positionInFrame) * frame.bitWidth;
+      const uint64_t bitPosition =
+          frame.bitOffset + static_cast<uint64_t>(rowOffset) * frame.bitWidth;
       const uint8_t bitOffsetInByte = static_cast<uint8_t>(bitPosition & 7U);
       const uint8_t* byteCursor =
           reinterpret_cast<const uint8_t*>(packedData_) + (bitPosition / 8);
@@ -409,11 +568,10 @@ template <typename T>
 std::string ForEncoding<T>::debugString(int offset) const {
   std::string log = Encoding::debugString(offset);
   log += fmt::format(
-      "\n{}frameSize={}, numFrames={}, enableBitOffsets={}",
+      "\n{}frameSize={}, numFrames={}",
       std::string(offset, ' '),
-      frameSize_,
-      numFrames_,
-      enableBitOffsets_);
+      header_.frameSize,
+      header_.numFrames);
 
   std::map<uint8_t, uint32_t> bitWidthCounts;
   for (const auto& frame : frames_) {
@@ -442,24 +600,22 @@ std::string_view ForEncoding<T>::encode(
 
   const bool useVarint = options.useVarintRowCount;
   const uint32_t rowCount = values.size();
-  if (rowCount == 0) {
-    NIMBLE_UNSUPPORTED("Cannot encode empty data with ForEncoding");
-  }
+  NIMBLE_CHECK_GT(rowCount, 0, "Cannot encode empty data with ForEncoding.");
 
-  // Configuration (TODO: make configurable via policy)
-  const bool enableBitOffsets = true; // Default: enable for O(1) random access
-  const uint32_t frameSize =
-      128; // Default frame size (TODO: adaptive selection)
+  // Default frame size (TODO: adaptive selection)
+  const uint32_t frameSize = 128;
 
-  const uint32_t numFrames = (rowCount + frameSize - 1) / frameSize;
+  const auto firstFrameRows = std::min(rowCount, frameSize);
+  Header header{
+      rowCount,
+      frameSize,
+      ForEncoding<T>::numFrames(rowCount, frameSize, firstFrameRows),
+      firstFrameRows};
 
   auto* pool = &buffer.getMemoryPool();
-  Vector<uint8_t> bitWidths(pool, numFrames);
-  Vector<physicalType> references(pool, numFrames);
-  Vector<uint64_t> bitOffsets(pool);
-  if (enableBitOffsets) {
-    bitOffsets.resize(numFrames);
-  }
+  Vector<uint8_t> bitWidths(pool, header.numFrames);
+  Vector<physicalType> references(pool, header.numFrames);
+  Vector<uint64_t> bitOffsets(pool, header.numFrames);
 
   Vector<char> packedData(pool);
   uint64_t bitBuffer = 0;
@@ -492,30 +648,12 @@ std::string_view ForEncoding<T>::encode(
     }
   };
 
-  constexpr std::array<uint8_t, 7> BIT_WIDTHS = {1, 2, 4, 8, 16, 32, 64};
-
-  auto findMinBitWidth = [&](uint64_t maxValue) -> uint8_t {
-    if (maxValue == 0) {
-      return 1;
-    }
-
-    size_t bitsNeeded = 64 - __builtin_clzll(maxValue);
-
-    for (uint8_t width : BIT_WIDTHS) {
-      if (width >= bitsNeeded) {
-        return width;
-      }
-    }
-
-    return 64;
-  };
-
   uint64_t totalBits = 0;
 
-  for (uint32_t frameIdx = 0; frameIdx < numFrames; ++frameIdx) {
-    uint32_t frameStart = frameIdx * frameSize;
-    uint32_t frameEnd = std::min(frameStart + frameSize, rowCount);
-    uint32_t frameLength = frameEnd - frameStart;
+  for (uint32_t frameIdx = 0; frameIdx < header.numFrames; ++frameIdx) {
+    uint32_t frameStart = frameRowOffset(header, frameIdx);
+    uint32_t frameLength = frameRowCount(header, frameIdx);
+    uint32_t frameEnd = frameStart + frameLength;
 
     physicalType minValue = values[frameStart];
     physicalType maxValue = values[frameStart];
@@ -533,14 +671,12 @@ std::string_view ForEncoding<T>::encode(
       maxException = static_cast<uint64_t>(maxValue - minValue);
     }
 
-    uint8_t bitWidth = findMinBitWidth(maxException);
+    const uint8_t bitWidth = minBitWidth(maxException);
 
     references[frameIdx] = minValue;
     bitWidths[frameIdx] = bitWidth;
 
-    if (enableBitOffsets) {
-      bitOffsets[frameIdx] = totalBits;
-    }
+    bitOffsets[frameIdx] = totalBits;
     for (uint32_t i = frameStart; i < frameEnd; ++i) {
       uint64_t exception;
       if constexpr (std::is_signed_v<physicalType>) {
@@ -561,29 +697,30 @@ std::string_view ForEncoding<T>::encode(
 
   ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
 
-  std::string_view serializedBitWidths =
-      selection.template encodeNested<uint8_t>(
-          0, // identifier - TODO: define proper identifiers
-          {bitWidths},
-          scopedBuffer.get(),
-          options);
+  header.serializedBitWidths = selection.template encodeNested<uint8_t>(
+      EncodingIdentifiers::For::BitWidths,
+      {bitWidths},
+      scopedBuffer.get(),
+      options);
 
-  std::string_view serializedReferences =
-      selection.template encodeNested<physicalType>(
-          1, {references}, scopedBuffer.get(), options);
+  header.serializedReferences = selection.template encodeNested<physicalType>(
+      EncodingIdentifiers::For::References,
+      {references},
+      scopedBuffer.get(),
+      options);
 
-  std::string_view serializedBitOffsets;
-  if (enableBitOffsets) {
-    serializedBitOffsets = selection.template encodeNested<uint64_t>(
-        2, {bitOffsets}, scopedBuffer.get(), options);
-  }
+  header.serializedBitOffsets = selection.template encodeNested<uint64_t>(
+      EncodingIdentifiers::For::BitOffsets,
+      {bitOffsets},
+      scopedBuffer.get(),
+      options);
 
   auto dataCompressionPolicy = selection.compressionPolicy();
   CompressionEncoder<char> compressionEncoder{
       *pool,
       *dataCompressionPolicy,
       DataType::Undefined,
-      0, // bitWidth not applicable
+      /*bitWidth=*/8,
       static_cast<uint32_t>(packedData.size()),
       [&]() { return std::span<char>{packedData}; },
       [&](char*& pos) {
@@ -591,16 +728,11 @@ std::string_view ForEncoding<T>::encode(
         pos += packedData.size();
         return pos;
       }};
+  header.compressionType = compressionEncoder.compressionType();
+  header.packedDataSize = compressionEncoder.getSize();
 
-  uint32_t encodingSize = Encoding::serializePrefixSize(rowCount, useVarint) +
-      // FOR-specific fixed fields only; the standard prefix is accounted for
-      // separately above via serializePrefixSize (kPrefixSize already includes
-      // Encoding::kPrefixSize, so subtract it to avoid double-counting).
-      (ForEncoding<T>::kPrefixSize - Encoding::kPrefixSize) + 4 +
-      serializedBitWidths.size() + // BitWidths
-      4 + serializedReferences.size() + // References
-      (enableBitOffsets ? 4 + serializedBitOffsets.size() : 0) + 4 +
-      compressionEncoder.getSize();
+  uint32_t encodingSize =
+      Encoding::serializePrefixSize(rowCount, useVarint) + headerSize(header);
 
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
@@ -608,27 +740,185 @@ std::string_view ForEncoding<T>::encode(
   Encoding::serializePrefix(
       EncodingType::FOR, TypeTraits<T>::dataType, rowCount, useVarint, pos);
 
-  encoding::writeChar(
-      static_cast<char>(compressionEncoder.compressionType()), pos);
-  encoding::writeUint32(frameSize, pos);
-  encoding::writeUint32(numFrames, pos);
-  encoding::writeChar(enableBitOffsets ? 1 : 0, pos);
+  encoding::writeChar(static_cast<char>(header.compressionType), pos);
+  varint::writeVarint(header.frameSize, &pos);
+  varint::writeVarint(header.numFrames, &pos);
+  varint::writeVarint(header.firstFrameRows, &pos);
 
-  encoding::writeUint32(serializedBitWidths.size(), pos);
-  encoding::writeBytes(serializedBitWidths, pos);
+  encoding::writeVarintString(header.serializedBitWidths, pos);
+  encoding::writeVarintString(header.serializedReferences, pos);
 
-  encoding::writeUint32(serializedReferences.size(), pos);
-  encoding::writeBytes(serializedReferences, pos);
+  encoding::writeVarintString(header.serializedBitOffsets, pos);
 
-  if (enableBitOffsets) {
-    encoding::writeUint32(serializedBitOffsets.size(), pos);
-    encoding::writeBytes(serializedBitOffsets, pos);
-  }
-
-  encoding::writeUint32(compressionEncoder.getSize(), pos);
+  varint::writeVarint(header.packedDataSize, &pos);
   compressionEncoder.write(pos);
 
   NIMBLE_DCHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+void ForEncoding<T>::prepareSliceHeaderMetadata(
+    const Header& header,
+    uint32_t firstFrame,
+    uint32_t numFrames,
+    uint32_t offset,
+    uint32_t length,
+    Header& sliceHeader,
+    Vector<uint8_t>& sourceBitWidths,
+    Vector<uint64_t>& sourceBitOffsets,
+    Vector<uint64_t>& sliceBitOffsets,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto noStringBufferFactory = [](uint32_t /*size*/) -> void* {
+    return nullptr;
+  };
+  sliceHeader.serializedBitWidths = EncodingFactory::slice(
+      header.serializedBitWidths, firstFrame, numFrames, buffer, options);
+  sliceHeader.serializedReferences = EncodingFactory::slice(
+      header.serializedReferences, firstFrame, numFrames, buffer, options);
+  const auto sourceSerializedBitOffsets = EncodingFactory::slice(
+      header.serializedBitOffsets, firstFrame, numFrames, buffer, options);
+
+  // Bit widths and references are frame-local child streams, so the slice keeps
+  // the source encoding layout for the contiguous frame range. Bit offsets
+  // point into the packed payload and must be regenerated because the sliced
+  // payload starts at bit offset 0.
+  EncodingFactory encodingFactory{options};
+  auto bitWidthsEncoding = encodingFactory.create(
+      buffer.getMemoryPool(),
+      sliceHeader.serializedBitWidths,
+      noStringBufferFactory);
+  bitWidthsEncoding->materialize(numFrames, sourceBitWidths.data());
+
+  auto bitOffsetsEncoding = encodingFactory.create(
+      buffer.getMemoryPool(),
+      sourceSerializedBitOffsets,
+      noStringBufferFactory);
+  bitOffsetsEncoding->materialize(numFrames, sourceBitOffsets.data());
+
+  uint64_t totalBits{0};
+  uint32_t currentRow{offset};
+  const uint32_t endRow = offset + length;
+  for (uint32_t sliceFrame = 0; sliceFrame < numFrames; ++sliceFrame) {
+    const auto sourceFrame = firstFrame + sliceFrame;
+    const auto rowOffset = currentRow - frameRowOffset(header, sourceFrame);
+    const auto rowCount = std::min<uint32_t>(
+        endRow - currentRow, frameRowCount(header, sourceFrame) - rowOffset);
+
+    sliceBitOffsets[sliceFrame] = totalBits;
+    totalBits += static_cast<uint64_t>(rowCount) * sourceBitWidths[sliceFrame];
+    currentRow += rowCount;
+  }
+  NIMBLE_CHECK_EQ(currentRow, endRow, "FOR slice frame planning mismatch.");
+
+  sliceHeader.serializedBitOffsets =
+      EncodingFactory::encodeWithCapturedLayout<uint64_t>(
+          header.serializedBitOffsets,
+          {sliceBitOffsets.data(), sliceBitOffsets.size()},
+          buffer,
+          options,
+          "Captured FOR bit offset layout");
+  sliceHeader.packedDataSize = velox::bits::nbytes(totalBits);
+}
+
+template <typename T>
+std::string_view ForEncoding<T>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+
+  auto* pool = &buffer.getMemoryPool();
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  const char* packedDataPos{nullptr};
+  const auto header = parseHeader(encoded, options, packedDataPos);
+  NIMBLE_CHECK_EQ(header.rowCount, sourceRowCount);
+  const auto firstFrame = frameIndex(header, offset);
+  const auto lastFrame = frameIndex(header, offset + length - 1);
+  const auto numFrames = lastFrame - firstFrame + 1;
+  const auto firstFrameRows = std::min<uint32_t>(
+      length,
+      frameRowCount(header, firstFrame) - rowOffsetInFrame(header, offset));
+  Header sliceHeader{length, header.frameSize, numFrames, firstFrameRows};
+
+  ScopedVector<uint8_t> sourceBitWidths{numFrames, pool, options.bufferPool};
+  ScopedVector<uint64_t> sourceBitOffsets{numFrames, pool, options.bufferPool};
+  ScopedVector<uint64_t> sliceBitOffsets{numFrames, pool, options.bufferPool};
+  prepareSliceHeaderMetadata(
+      header,
+      firstFrame,
+      numFrames,
+      offset,
+      length,
+      sliceHeader,
+      sourceBitWidths,
+      sourceBitOffsets,
+      sliceBitOffsets,
+      scopedBuffer.get(),
+      options);
+
+  std::string_view packedData{packedDataPos, header.packedDataSize};
+  velox::BufferPtr uncompressedData;
+  if (header.compressionType != CompressionType::Uncompressed) {
+    uncompressedData = Compression::uncompress(
+        *pool,
+        header.compressionType,
+        DataType::Undefined,
+        packedData,
+        options.decompressCounter());
+    packedData = {uncompressedData->as<char>(), uncompressedData->size()};
+  }
+
+  uint32_t currentRow{offset};
+  const uint32_t endRow = offset + length;
+  const bool useVarint = options.useVarintRowCount;
+  const uint32_t encodingSize =
+      Encoding::serializePrefixSize(length, useVarint) +
+      headerSize(sliceHeader);
+
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::FOR, TypeTraits<T>::dataType, length, useVarint, pos);
+  encoding::writeChar(static_cast<char>(CompressionType::Uncompressed), pos);
+  varint::writeVarint(sliceHeader.frameSize, &pos);
+  varint::writeVarint(sliceHeader.numFrames, &pos);
+  varint::writeVarint(sliceHeader.firstFrameRows, &pos);
+  encoding::writeVarintString(sliceHeader.serializedBitWidths, pos);
+  encoding::writeVarintString(sliceHeader.serializedReferences, pos);
+  encoding::writeVarintString(sliceHeader.serializedBitOffsets, pos);
+  varint::writeVarint(sliceHeader.packedDataSize, &pos);
+
+  std::memset(pos, 0, sliceHeader.packedDataSize);
+  currentRow = offset;
+  for (uint32_t sliceFrame = 0; sliceFrame < numFrames; ++sliceFrame) {
+    const auto sourceFrame = firstFrame + sliceFrame;
+    const auto rowOffset = currentRow - frameRowOffset(header, sourceFrame);
+    const auto rowCount = std::min<uint32_t>(
+        endRow - currentRow, frameRowCount(header, sourceFrame) - rowOffset);
+    const auto bitWidth = sourceBitWidths[sliceFrame];
+    const auto bitCount = static_cast<uint64_t>(rowCount) * bitWidth;
+    if (bitCount > 0) {
+      velox::bits::copyBits(
+          reinterpret_cast<const uint64_t*>(packedData.data()),
+          sourceBitOffsets[sliceFrame] +
+              static_cast<uint64_t>(rowOffset) * bitWidth,
+          reinterpret_cast<uint64_t*>(pos),
+          sliceBitOffsets[sliceFrame],
+          bitCount);
+    }
+    currentRow += rowCount;
+  }
+  pos += sliceHeader.packedDataSize;
+
+  NIMBLE_CHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
   return {reserved, encodingSize};
 }
 

--- a/dwio/nimble/encodings/FsstEncoding.cpp
+++ b/dwio/nimble/encodings/FsstEncoding.cpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <numeric>
 
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
@@ -118,10 +119,10 @@ FsstEncoding::CompressedValues::CompressedValues(
 
 FsstEncoding::Header FsstEncoding::parseHeader(const char* pos) {
   Header header{};
-  header.symbolTableSize = encoding::readUint32(pos);
+  header.symbolTableSize = varint::readVarint32(&pos);
   header.symbolTable = pos;
   pos += header.symbolTableSize;
-  header.lengthsSize = encoding::readUint32(pos);
+  header.lengthsSize = varint::readVarint32(&pos);
   header.lengths = pos;
   header.blob = pos + header.lengthsSize;
   return header;
@@ -334,9 +335,7 @@ std::string_view FsstEncoding::decompressToStringBuffer(
       0,
       "FSST decompression failed for non-empty compressed string.");
 
-  if (pageCapacityBytes_ - pageUsedBytes_ < decompressedSize) {
-    allocatePage(std::max(kStringPageSize, decompressedSize));
-  }
+  ensurePage(decompressedSize);
 
   std::memcpy(
       currentPage_ + pageUsedBytes_,
@@ -347,9 +346,13 @@ std::string_view FsstEncoding::decompressToStringBuffer(
   return result;
 }
 
-void FsstEncoding::allocatePage(size_t minSize) {
-  currentPage_ = static_cast<char*>(stringBufferFactory_(minSize));
-  pageCapacityBytes_ = minSize;
+void FsstEncoding::ensurePage(size_t requiredBytes) {
+  if (pageCapacityBytes_ - pageUsedBytes_ >= requiredBytes) {
+    return;
+  }
+  const auto pageSize = std::max(kStringPageSize, requiredBytes);
+  currentPage_ = static_cast<char*>(stringBufferFactory_(pageSize));
+  pageCapacityBytes_ = pageSize;
   pageUsedBytes_ = 0;
 }
 
@@ -373,9 +376,10 @@ std::string_view FsstEncoding::encode(
     const auto valueCount = static_cast<uint32_t>(values.size());
     const uint32_t encodingSize =
         Encoding::serializePrefixSize(valueCount, useVarint) +
-        4 /* symbolTableSize */ + compressedValues.symbolTableSize +
-        4 /* lengthsSize */ + serializedLengths.size() +
-        compressedValues.totalCompressedSize;
+        varint::varintSize(compressedValues.symbolTableSize) +
+        compressedValues.symbolTableSize +
+        varint::varintSize(serializedLengths.size()) +
+        serializedLengths.size() + compressedValues.totalCompressedSize;
 
     if (meetsCompressionTarget(
             compressedValues.totalInputSize,
@@ -386,20 +390,16 @@ std::string_view FsstEncoding::encode(
       char* pos = reserved;
       Encoding::serializePrefix(
           EncodingType::Fsst, DataType::String, valueCount, useVarint, pos);
-      encoding::writeUint32(compressedValues.symbolTableSize, pos);
-      std::memcpy(
-          pos,
-          compressedValues.symbolTableData,
-          compressedValues.symbolTableSize);
-      pos += compressedValues.symbolTableSize;
-      encoding::writeUint32(serializedLengths.size(), pos);
-      encoding::writeBytes(serializedLengths, pos);
+      encoding::writeVarintString(
+          {reinterpret_cast<const char*>(compressedValues.symbolTableData),
+           compressedValues.symbolTableSize},
+          pos);
+      encoding::writeVarintString(serializedLengths, pos);
       for (uint32_t i = 0; i < valueCount; ++i) {
-        std::memcpy(
-            pos,
-            compressedValues.compressedPtrs[i],
-            compressedValues.compressedLengths[i]);
-        pos += compressedValues.compressedLengths[i];
+        encoding::writeBytes(
+            {reinterpret_cast<const char*>(compressedValues.compressedPtrs[i]),
+             compressedValues.compressedLengths[i]},
+            pos);
       }
 
       NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
@@ -413,6 +413,69 @@ std::string_view FsstEncoding::encode(
       encodeTrivialFallback(selection, values, trivialBuffer, options));
 }
 
+std::string_view FsstEncoding::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+
+  const auto header = parseHeader(
+      encoded.data() +
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount));
+  const std::string_view lengths{
+      header.lengths, static_cast<size_t>(header.lengthsSize)};
+
+  const auto rowEnd = offset + length;
+  Vector<uint32_t> materializedLengths{&buffer.getMemoryPool(), rowEnd};
+  EncodingFactory{}
+      .create(
+          buffer.getMemoryPool(),
+          lengths,
+          [](uint32_t /*totalLength*/) -> void* { return nullptr; },
+          options)
+      ->materialize(rowEnd, materializedLengths.data());
+
+  const auto blobOffset = std::accumulate(
+      materializedLengths.begin(),
+      materializedLengths.begin() + offset,
+      uint32_t{0});
+  const auto blobBytes = std::accumulate(
+      materializedLengths.begin() + offset,
+      materializedLengths.end(),
+      uint32_t{0});
+
+  auto* pool = &buffer.getMemoryPool();
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  const auto slicedLengths = EncodingFactory::slice(
+      lengths, offset, length, scopedBuffer.get(), options);
+
+  const uint32_t encodingSize =
+      EncodingPrefix::serializedSize(length, options.useVarintRowCount) +
+      varint::varintSize(header.symbolTableSize) + header.symbolTableSize +
+      varint::varintSize(slicedLengths.size()) + slicedLengths.size() +
+      blobBytes;
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  EncodingPrefix::serialize(
+      EncodingType::Fsst,
+      DataType::String,
+      length,
+      options.useVarintRowCount,
+      pos);
+  encoding::writeVarintString(
+      {header.symbolTable, static_cast<size_t>(header.symbolTableSize)}, pos);
+  encoding::writeVarintString(slicedLengths, pos);
+  encoding::writeBytes({header.blob + blobOffset, blobBytes}, pos);
+  NIMBLE_CHECK_EQ(pos - reserved, encodingSize, "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
 uint64_t FsstEncoding::estimateSize(
     uint64_t rowCount,
     const Statistics<std::string_view>& statistics,
@@ -424,8 +487,10 @@ uint64_t FsstEncoding::estimateSize(
   const uint64_t estimatedLengthsSize =
       FixedBitWidthEncoding<uint32_t>::estimateSize(
           rowCount, 0, estimatedMaxCompressedLength, options);
-  return kSymbolTableOverhead + estimatedBlobSize + estimatedLengthsSize +
-      EncodingPrefix::kFixedPrefixSize;
+  return Encoding::serializePrefixSize(rowCount, options.useVarintRowCount) +
+      varint::varintSize(kSymbolTableOverhead) + kSymbolTableOverhead +
+      varint::varintSize(estimatedLengthsSize) + estimatedLengthsSize +
+      estimatedBlobSize;
 }
 
 std::string FsstEncoding::debugString(int offset) const {

--- a/dwio/nimble/encodings/FsstEncoding.h
+++ b/dwio/nimble/encodings/FsstEncoding.h
@@ -69,9 +69,9 @@ namespace facebook::nimble {
 ///
 /// Binary layout:
 /// - Encoding::kPrefixSize bytes: standard Encoding prefix
-/// - 4 bytes: serialized FSST symbol table size
+/// - varint: serialized FSST symbol table size
 /// - N bytes: serialized FSST symbol table (~2KB typical)
-/// - 4 bytes: lengths encoding size
+/// - varint: lengths encoding size
 /// - M bytes: nested encoding of compressed string lengths
 /// - K bytes: compressed string blob (concatenated FSST-compressed strings)
 ///
@@ -98,6 +98,13 @@ class FsstEncoding final
   static std::string_view encode(
       EncodingSelection<physicalType>& selection,
       std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
       Buffer& buffer,
       const Encoding::Options& options = {});
 
@@ -199,9 +206,7 @@ class FsstEncoding final
       const char* compressedData,
       uint32_t compressedLength);
 
-  // Allocates a new string page of at least minSize bytes via
-  // stringBufferFactory_.
-  void allocatePage(size_t minSize);
+  void ensurePage(size_t requiredBytes);
 
   const std::function<void*(uint32_t)> stringBufferFactory_;
 

--- a/dwio/nimble/encodings/SimdForBitpackEncoding.h
+++ b/dwio/nimble/encodings/SimdForBitpackEncoding.h
@@ -107,7 +107,7 @@ class SimdForBitpackEncoding final
 
   // Parsed stream metadata shared by normal decode and native slice. The
   // packed data pointer references the first byte of the group payload.
-  struct SourceHeader {
+  struct Header {
     uint32_t rowCount{0};
     physicalType baseline{};
     uint8_t bitWidth{0};
@@ -141,17 +141,14 @@ class SimdForBitpackEncoding final
     return static_cast<uint32_t>(velox::bits::divRoundUp(rowCount, kGroupSize));
   }
 
-  static constexpr uint32_t numGroups(const SourceHeader& source) {
-    if (source.rowCount == 0) {
+  static constexpr uint32_t numGroups(const Header& header) {
+    if (header.rowCount == 0) {
       return 0;
-    }
-    if (source.rowCount <= source.firstGroupRows) {
-      return 1;
     }
     return static_cast<uint32_t>(
         1 +
         velox::bits::divRoundUp(
-            source.rowCount - source.firstGroupRows, kGroupSize));
+            header.rowCount - header.firstGroupRows, kGroupSize));
   }
 
   // Return the total packed data size in bytes.
@@ -169,46 +166,42 @@ class SimdForBitpackEncoding final
         : static_cast<uint8_t>(velox::bits::bitsRequired(fullRange));
   }
 
-  static void populateGroupCounts(SourceHeader& source) {
-    source.numGroups = numGroups(source);
-    source.lastGroupRows =
-        source.rowCount - groupRowOffset(source, source.numGroups - 1);
+  static void populateGroupCounts(Header& header) {
+    header.numGroups = numGroups(header);
+    header.lastGroupRows =
+        header.rowCount - groupRowOffset(header, header.numGroups - 1);
   }
 
-  static uint32_t groupRowOffset(
-      const SourceHeader& source,
-      uint32_t groupIndex) {
+  static uint32_t groupRowOffset(const Header& header, uint32_t groupIndex) {
     if (groupIndex == 0) {
       return 0;
     }
-    return source.firstGroupRows + (groupIndex - 1) * kGroupSize;
+    return header.firstGroupRows + (groupIndex - 1) * kGroupSize;
   }
 
-  static uint32_t groupRowCount(
-      const SourceHeader& source,
-      uint32_t groupIndex) {
+  static uint32_t groupRowCount(const Header& header, uint32_t groupIndex) {
     if (groupIndex == 0) {
-      return source.firstGroupRows;
+      return header.firstGroupRows;
     }
-    if (groupIndex == source.numGroups - 1) {
-      return source.lastGroupRows;
+    if (groupIndex == header.numGroups - 1) {
+      return header.lastGroupRows;
     }
     return kGroupSize;
   }
 
-  static GroupInfo groupInfo(const SourceHeader& source, uint32_t row) {
-    const auto groupIndex = row < source.firstGroupRows
+  static GroupInfo groupInfo(const Header& header, uint32_t row) {
+    const auto groupIndex = row < header.firstGroupRows
         ? uint32_t{0}
-        : 1 + (row - source.firstGroupRows) / kGroupSize;
-    NIMBLE_CHECK_LT(groupIndex, source.numGroups);
+        : 1 + (row - header.firstGroupRows) / kGroupSize;
+    NIMBLE_CHECK_LT(groupIndex, header.numGroups);
     return {
         .groupIndex = groupIndex,
-        .rowOffset = row - groupRowOffset(source, groupIndex),
-        .rowCount = groupRowCount(source, groupIndex),
+        .rowOffset = row - groupRowOffset(header, groupIndex),
+        .rowCount = groupRowCount(header, groupIndex),
     };
   }
 
-  static SourceHeader parseSourceHeader(
+  static Header parseHeader(
       std::string_view encoded,
       const Encoding::Options& options);
 
@@ -222,8 +215,8 @@ class SimdForBitpackEncoding final
   packGroup(const physicalType* residuals, uint8_t bitWidth, uint32_t* output);
 
   static void writeSlicedGroupsPayload(
-      const SourceHeader& source,
-      const SourceHeader& sliceSource,
+      const Header& sourceHeader,
+      const Header& sliceHeader,
       uint32_t offset,
       uint64_t packedSize,
       char*& pos);
@@ -239,7 +232,7 @@ class SimdForBitpackEncoding final
       uint32_t count,
       physicalType* output) const;
 
-  SourceHeader source_;
+  Header header_;
   uint32_t row_{0};
 
   // Avoid re-unpacking when consecutive rows hit the same group.
@@ -262,8 +255,8 @@ SimdForBitpackEncoding<T>::SimdForBitpackEncoding(
     NIMBLE_INCOMPATIBLE_ENCODING(
         "SimdForBitpack encoding only supports integral data types.");
   }
-  source_ = parseSourceHeader(data, options);
-  NIMBLE_CHECK_EQ(source_.rowCount, this->rowCount_);
+  header_ = parseHeader(data, options);
+  NIMBLE_CHECK_EQ(header_.rowCount, this->rowCount_);
   reset();
 }
 
@@ -279,34 +272,34 @@ void SimdForBitpackEncoding<T>::skip(uint32_t rowCount) {
 }
 
 template <typename T>
-typename SimdForBitpackEncoding<T>::SourceHeader
-SimdForBitpackEncoding<T>::parseSourceHeader(
+typename SimdForBitpackEncoding<T>::Header
+SimdForBitpackEncoding<T>::parseHeader(
     std::string_view encoded,
     const Encoding::Options& options) {
-  SourceHeader source;
-  source.rowCount =
+  Header header;
+  header.rowCount =
       EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
   NIMBLE_CHECK_GT(
-      source.rowCount, 0, "SimdForBitpack stream must contain rows.");
+      header.rowCount, 0, "SimdForBitpack stream must contain rows.");
   const char* pos = encoded.data() +
       EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
-  source.baseline = encoding::read<physicalType>(pos);
-  source.bitWidth = static_cast<uint8_t>(encoding::readChar(pos));
-  source.firstGroupRows = varint::readVarint32(&pos);
+  header.baseline = encoding::read<physicalType>(pos);
+  header.bitWidth = static_cast<uint8_t>(encoding::readChar(pos));
+  header.firstGroupRows = varint::readVarint32(&pos);
   NIMBLE_CHECK_GT(
-      source.firstGroupRows, 0, "First group row count must be set.");
+      header.firstGroupRows, 0, "First group row count must be set.");
   NIMBLE_CHECK_LE(
-      source.firstGroupRows,
+      header.firstGroupRows,
       kGroupSize,
       "Invalid SimdForBitpack first group row count.");
-  populateGroupCounts(source);
+  populateGroupCounts(header);
   constexpr uint8_t kMaxBits = static_cast<uint8_t>(sizeof(physicalType) * 8);
   NIMBLE_CHECK_LE(
-      source.bitWidth,
+      header.bitWidth,
       kMaxBits,
       "SimdForBitpack bit width exceeds physical type size.");
-  source.packedData = pos;
-  return source;
+  header.packedData = pos;
+  return header;
 }
 
 template <typename T>
@@ -361,8 +354,8 @@ void SimdForBitpackEncoding<T>::packGroup(
 
 template <typename T>
 void SimdForBitpackEncoding<T>::writeSlicedGroupsPayload(
-    const SourceHeader& source,
-    const SourceHeader& sliceSource,
+    const Header& sourceHeader,
+    const Header& sliceHeader,
     uint32_t offset,
     uint64_t packedSize,
     char*& pos) {
@@ -372,21 +365,21 @@ void SimdForBitpackEncoding<T>::writeSlicedGroupsPayload(
   std::array<physicalType, kGroupSize> sliceResiduals{};
 
   const auto groupBytes =
-      static_cast<uint64_t>(source.bitWidth) * sizeof(uint32_t);
+      static_cast<uint64_t>(sourceHeader.bitWidth) * sizeof(uint32_t);
   const auto getSliceGroupSource = [&](uint32_t group) {
-    return groupInfo(source, offset + groupRowOffset(sliceSource, group));
+    return groupInfo(sourceHeader, offset + groupRowOffset(sliceHeader, group));
   };
   const auto isPartialGroup = [&](uint32_t group,
                                   const GroupInfo& sourceSlice) {
     return sourceSlice.rowOffset != 0 ||
-        groupRowCount(sliceSource, group) != sourceSlice.rowCount;
+        groupRowCount(sliceHeader, group) != sourceSlice.rowCount;
   };
   const auto copyPartialGroup = [&](uint32_t group,
                                     const GroupInfo& sourceSlice) {
-    const uint32_t rowCount = groupRowCount(sliceSource, group);
+    const uint32_t rowCount = groupRowCount(sliceHeader, group);
     unpackGroup(
-        source.packedData,
-        source.bitWidth,
+        sourceHeader.packedData,
+        sourceHeader.bitWidth,
         sourceSlice.groupIndex,
         sourceResiduals.data());
     std::fill(sliceResiduals.begin(), sliceResiduals.end(), physicalType{0});
@@ -395,7 +388,7 @@ void SimdForBitpackEncoding<T>::writeSlicedGroupsPayload(
     }
     packGroup(
         sliceResiduals.data(),
-        source.bitWidth,
+        sourceHeader.bitWidth,
         reinterpret_cast<uint32_t*>(outputData + group * groupBytes));
   };
 
@@ -406,19 +399,19 @@ void SimdForBitpackEncoding<T>::writeSlicedGroupsPayload(
   }
 
   const uint32_t copyBegin = firstPartialGroup ? 1 : 0;
-  const uint32_t lastGroup = sliceSource.numGroups - 1;
+  const uint32_t lastGroup = sliceHeader.numGroups - 1;
   const auto lastSourceSlice = getSliceGroupSource(lastGroup);
   const bool lastPartialGroup =
       lastGroup != 0 && isPartialGroup(lastGroup, lastSourceSlice);
-  const uint32_t copyEnd = lastPartialGroup ? lastGroup : sliceSource.numGroups;
+  const uint32_t copyEnd = lastPartialGroup ? lastGroup : sliceHeader.numGroups;
   if (copyBegin < copyEnd) {
     const auto beginSourceSlice = getSliceGroupSource(copyBegin);
     NIMBLE_CHECK_EQ(beginSourceSlice.rowOffset, 0);
     NIMBLE_CHECK_EQ(
-        groupRowCount(sliceSource, copyBegin), beginSourceSlice.rowCount);
+        groupRowCount(sliceHeader, copyBegin), beginSourceSlice.rowCount);
     std::memcpy(
         outputData + static_cast<uint64_t>(copyBegin) * groupBytes,
-        source.packedData +
+        sourceHeader.packedData +
             static_cast<uint64_t>(beginSourceSlice.groupIndex) * groupBytes,
         static_cast<uint64_t>(copyEnd - copyBegin) * groupBytes);
   }
@@ -433,7 +426,7 @@ template <typename T>
 void SimdForBitpackEncoding<T>::unpackGroup(
     uint32_t groupIndex,
     physicalType* output) const {
-  unpackGroup(source_.packedData, source_.bitWidth, groupIndex, output);
+  unpackGroup(header_.packedData, header_.bitWidth, groupIndex, output);
 }
 
 template <typename T>
@@ -446,7 +439,7 @@ inline void SimdForBitpackEncoding<T>::materializePartialGroup(
   unpackGroup(groupIndex, temp.data());
   for (uint32_t i = 0; i < count; ++i) {
     output[i] =
-        static_cast<physicalType>(temp[offsetInGroup + i] + source_.baseline);
+        static_cast<physicalType>(temp[offsetInGroup + i] + header_.baseline);
   }
 }
 
@@ -457,9 +450,9 @@ void SimdForBitpackEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
   }
   auto* output = static_cast<physicalType*>(buffer);
 
-  if (source_.bitWidth == 0) {
+  if (header_.bitWidth == 0) {
     // All values match the baseline, so there are no residual bits to unpack.
-    std::fill(output, output + rowCount, source_.baseline);
+    std::fill(output, output + rowCount, header_.baseline);
     row_ += rowCount;
     return;
   }
@@ -468,7 +461,7 @@ void SimdForBitpackEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
   uint32_t outputIndex = 0;
 
   // Partial first group.
-  const auto firstGroup = groupInfo(source_, row_);
+  const auto firstGroup = groupInfo(header_, row_);
   if (firstGroup.rowOffset != 0) {
     const uint32_t available = firstGroup.rowCount - firstGroup.rowOffset;
     const uint32_t toCopy = std::min(available, remaining);
@@ -484,12 +477,12 @@ void SimdForBitpackEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
   // Full groups can unpack directly into the caller's output. Short groups
   // need the bounded path because FastPFor always writes 32 values.
   while (remaining > 0) {
-    const auto group = groupInfo(source_, row_ + outputIndex);
+    const auto group = groupInfo(header_, row_ + outputIndex);
     const uint32_t toCopy = std::min(remaining, group.rowCount);
     if (toCopy == kGroupSize) {
       unpackGroup(group.groupIndex, output + outputIndex);
       for (uint32_t i = 0; i < kGroupSize; ++i) {
-        output[outputIndex + i] += source_.baseline;
+        output[outputIndex + i] += header_.baseline;
       }
     } else {
       materializePartialGroup(
@@ -513,16 +506,16 @@ void SimdForBitpackEncoding<T>::readWithVisitor(
       [&](auto toSkip) { skip(toSkip); },
       [&]() {
         physicalType value;
-        if (source_.bitWidth == 0) {
-          value = source_.baseline;
+        if (header_.bitWidth == 0) {
+          value = header_.baseline;
         } else {
-          const auto group = groupInfo(source_, row_);
+          const auto group = groupInfo(header_, row_);
           if (group.groupIndex != cachedGroupIndex_) {
             unpackGroup(group.groupIndex, cachedGroup_.data());
             cachedGroupIndex_ = group.groupIndex;
           }
           value = static_cast<physicalType>(
-              cachedGroup_[group.rowOffset] + source_.baseline);
+              cachedGroup_[group.rowOffset] + header_.baseline);
         }
         ++row_;
         return value;
@@ -554,7 +547,7 @@ std::string_view SimdForBitpackEncoding<T>::encode(
   const bool useVarint = options.useVarintRowCount;
   NIMBLE_CHECK(
       !values.empty(), "SimdForBitpack encoding cannot be used with 0 rows.");
-  SourceHeader source{
+  Header header{
       .rowCount = static_cast<uint32_t>(values.size()),
       .baseline = selection.statistics().min(),
       .bitWidth =
@@ -562,12 +555,12 @@ std::string_view SimdForBitpackEncoding<T>::encode(
       .firstGroupRows =
           firstGroupRowCount(static_cast<uint32_t>(values.size())),
   };
-  populateGroupCounts(source);
-  const uint64_t packedSize = packedDataSize(source.numGroups, source.bitWidth);
+  populateGroupCounts(header);
+  const uint64_t packedSize = packedDataSize(header.numGroups, header.bitWidth);
 
   const uint32_t encodingSize =
-      Encoding::serializePrefixSize(source.rowCount, useVarint) +
-      fixedHeaderSize() + varint::varintSize(source.firstGroupRows) +
+      Encoding::serializePrefixSize(header.rowCount, useVarint) +
+      fixedHeaderSize() + varint::varintSize(header.firstGroupRows) +
       static_cast<uint32_t>(packedSize);
 
   char* reserved = buffer.reserve(encodingSize);
@@ -575,14 +568,14 @@ std::string_view SimdForBitpackEncoding<T>::encode(
   Encoding::serializePrefix(
       EncodingType::SimdForBitpack,
       TypeTraits<T>::dataType,
-      source.rowCount,
+      header.rowCount,
       useVarint,
       pos);
-  encoding::write(source.baseline, pos);
-  encoding::writeChar(static_cast<char>(source.bitWidth), pos);
-  varint::writeVarint(source.firstGroupRows, &pos);
+  encoding::write(header.baseline, pos);
+  encoding::writeChar(static_cast<char>(header.bitWidth), pos);
+  varint::writeVarint(header.firstGroupRows, &pos);
 
-  if (source.bitWidth > 0) {
+  if (header.bitWidth > 0) {
     auto* packedOut = reinterpret_cast<uint32_t*>(pos);
     std::array<physicalType, kGroupSize> residuals{};
 
@@ -592,9 +585,9 @@ std::string_view SimdForBitpackEncoding<T>::encode(
     //
     // The last group is zero-padded before packing when rowCount is not a
     // multiple of 32.
-    for (uint32_t group = 0; group < source.numGroups; ++group) {
-      const uint32_t groupStart = groupRowOffset(source, group);
-      const uint32_t groupLen = groupRowCount(source, group);
+    for (uint32_t group = 0; group < header.numGroups; ++group) {
+      const uint32_t groupStart = groupRowOffset(header, group);
+      const uint32_t groupLen = groupRowCount(header, group);
 
       // Only zero-fill the last partial group; full groups overwrite all 32.
       if (groupLen < kGroupSize) {
@@ -602,13 +595,13 @@ std::string_view SimdForBitpackEncoding<T>::encode(
       }
       for (uint32_t i = 0; i < groupLen; ++i) {
         residuals[i] =
-            static_cast<physicalType>(values[groupStart + i] - source.baseline);
+            static_cast<physicalType>(values[groupStart + i] - header.baseline);
       }
 
-      packGroup(residuals.data(), source.bitWidth, packedOut);
+      packGroup(residuals.data(), header.bitWidth, packedOut);
       // `packedOut` is a uint32_t pointer. One packed group occupies
       // `bitWidth` uint32_t words.
-      packedOut += source.bitWidth;
+      packedOut += header.bitWidth;
     }
     pos += packedSize;
   }
@@ -631,22 +624,22 @@ std::string_view SimdForBitpackEncoding<T>::slice(
   NIMBLE_CHECK_LE(offset, sourceRowCount);
   NIMBLE_CHECK_LE(length, sourceRowCount - offset);
 
-  const auto source = parseSourceHeader(encoded, options);
-  const auto firstGroup = groupInfo(source, offset);
-  SourceHeader sliceSource;
-  sliceSource.rowCount = length;
-  sliceSource.baseline = source.baseline;
-  sliceSource.bitWidth = source.bitWidth;
-  sliceSource.firstGroupRows =
+  const auto sourceHeader = parseHeader(encoded, options);
+  const auto firstGroup = groupInfo(sourceHeader, offset);
+  Header sliceHeader;
+  sliceHeader.rowCount = length;
+  sliceHeader.baseline = sourceHeader.baseline;
+  sliceHeader.bitWidth = sourceHeader.bitWidth;
+  sliceHeader.firstGroupRows =
       std::min(length, firstGroup.rowCount - firstGroup.rowOffset);
-  populateGroupCounts(sliceSource);
+  populateGroupCounts(sliceHeader);
   const uint64_t packedSize =
-      packedDataSize(sliceSource.numGroups, sliceSource.bitWidth);
+      packedDataSize(sliceHeader.numGroups, sliceHeader.bitWidth);
 
   const bool useVarint = options.useVarintRowCount;
   const uint32_t encodingSize =
       Encoding::serializePrefixSize(length, useVarint) + fixedHeaderSize() +
-      varint::varintSize(sliceSource.firstGroupRows) +
+      varint::varintSize(sliceHeader.firstGroupRows) +
       static_cast<uint32_t>(packedSize);
   char* reserved = buffer.reserve(encodingSize);
   char* pos = reserved;
@@ -656,12 +649,13 @@ std::string_view SimdForBitpackEncoding<T>::slice(
       length,
       useVarint,
       pos);
-  encoding::write(sliceSource.baseline, pos);
-  encoding::writeChar(static_cast<char>(sliceSource.bitWidth), pos);
-  varint::writeVarint(sliceSource.firstGroupRows, &pos);
+  encoding::write(sliceHeader.baseline, pos);
+  encoding::writeChar(static_cast<char>(sliceHeader.bitWidth), pos);
+  varint::writeVarint(sliceHeader.firstGroupRows, &pos);
 
-  if (sliceSource.bitWidth > 0) {
-    writeSlicedGroupsPayload(source, sliceSource, offset, packedSize, pos);
+  if (sliceHeader.bitWidth > 0) {
+    writeSlicedGroupsPayload(
+        sourceHeader, sliceHeader, offset, packedSize, pos);
   }
 
   NIMBLE_CHECK_EQ(
@@ -677,7 +671,7 @@ std::string SimdForBitpackEncoding<T>::debugString(int offset) const {
       Encoding::encodingType(),
       Encoding::dataType(),
       Encoding::rowCount(),
-      static_cast<int>(source_.bitWidth));
+      static_cast<int>(header_.bitWidth));
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
@@ -20,6 +20,7 @@
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/ForEncoding.h"
+#include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
@@ -27,6 +28,8 @@
 #include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
 #include "folly/Benchmark.h"
 #include "folly/init/Init.h"
+
+#include <limits>
 
 using namespace facebook::nimble;
 using namespace facebook::nimble::benchmarks;
@@ -117,6 +120,58 @@ Vector<uint32_t> makePforUint32(uint32_t n = kNumElements) {
     data[i] = i % 10 == 7 ? 100000 + i : 50 + (i % 64);
   }
   return data;
+}
+
+Vector<std::string_view> makeFsstStrings(uint32_t n = kNumElements) {
+  static std::vector<std::string> storage;
+  if (storage.size() != n) {
+    storage.clear();
+    storage.reserve(n);
+    for (uint32_t i = 0; i < n; ++i) {
+      storage.emplace_back(
+          "common/prefix/for/fsst/slice/benchmark/" + std::to_string(i % 257));
+    }
+  }
+
+  auto& pool = benchmarkPool();
+  Vector<std::string_view> data{pool.get()};
+  data.resize(n);
+  for (uint32_t i = 0; i < n; ++i) {
+    data[i] = storage[i];
+  }
+  return data;
+}
+
+Encoding::Options fsstOptions() {
+  Encoding::Options options;
+  options.fsstCompressionTargetRatio = std::numeric_limits<double>::max();
+  return options;
+}
+
+void materializeEncodeFsstBenchmark(
+    const std::string& encoded,
+    uint32_t iters) {
+  auto& pool = benchmarkPool();
+  while (iters--) {
+    std::vector<facebook::velox::BufferPtr> stringBuffers;
+    auto stringBufferFactory = [&](uint32_t totalLength) {
+      auto& buffer = stringBuffers.emplace_back(
+          facebook::velox::AlignedBuffer::allocate<char>(
+              totalLength, benchmarkPool().get()));
+      return buffer->asMutable<void>();
+    };
+    auto encoding =
+        EncodingFactory{}.create(*pool, encoded, stringBufferFactory);
+    encoding->skip(kSliceOffset);
+
+    Vector<std::string_view> values{pool.get(), kSliceLength};
+    encoding->materialize(kSliceLength, values.data());
+
+    const auto materialized =
+        encodeData<FsstEncoding>(EncodingType::Fsst, values, fsstOptions());
+    folly::doNotOptimizeAway(materialized.data());
+    folly::doNotOptimizeAway(materialized.size());
+  }
 }
 
 } // namespace
@@ -221,6 +276,24 @@ SLICE_BENCHMARKS(
     double,
     EncodingType::ALP,
     makeAlpDouble());
+
+BENCHMARK(Slice_FsstString, iters) {
+  std::string encoded;
+  BENCHMARK_SUSPEND {
+    const auto data = makeFsstStrings();
+    encoded = encodeData<FsstEncoding>(EncodingType::Fsst, data, fsstOptions());
+  }
+  sliceBenchmark(encoded, iters);
+}
+BENCHMARK_RELATIVE(MaterializeEncode_FsstString, iters) {
+  std::string encoded;
+  BENCHMARK_SUSPEND {
+    const auto data = makeFsstStrings();
+    encoded = encodeData<FsstEncoding>(EncodingType::Fsst, data, fsstOptions());
+  }
+  materializeEncodeFsstBenchmark(encoded, iters);
+}
+BENCHMARK_DRAW_LINE();
 
 BENCHMARK(Slice_BlockBitPackingUint32PartialBlock, iters) {
   std::string encoded;

--- a/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
+++ b/dwio/nimble/encodings/benchmarks/SliceEncodingBenchmark.cpp
@@ -19,6 +19,7 @@
 #include "dwio/nimble/encodings/ConstantEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/ForEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
@@ -208,6 +209,12 @@ SLICE_BENCHMARKS(
     uint32_t,
     EncodingType::SimdForBitpack,
     makeNarrow<uint32_t>(12));
+SLICE_BENCHMARKS(
+    FORUint32,
+    ForEncoding<uint32_t>,
+    uint32_t,
+    EncodingType::FOR,
+    makeIncreasing<uint32_t>());
 SLICE_BENCHMARKS(
     ALPDouble,
     ALPEncoding<double>,

--- a/dwio/nimble/encodings/common/Encoding.cpp
+++ b/dwio/nimble/encodings/common/Encoding.cpp
@@ -15,6 +15,8 @@
  */
 #include "dwio/nimble/encodings/common/Encoding.h"
 
+#include <algorithm>
+
 namespace facebook::nimble {
 
 Encoding::Encoding(

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -28,7 +28,6 @@
 #include "velox/dwio/common/ColumnVisitors.h"
 #include "velox/dwio/common/DecoderUtil.h"
 
-#include <algorithm>
 #include <string_view>
 #include <type_traits>
 

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -25,6 +25,7 @@
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/EncodingSliceFactory.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/ForEncoding.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
@@ -146,6 +147,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::Huffman: {
       RETURN_ENCODING_BY_INTEGER_TYPE(HuffmanEncoding, dataType);
+    }
+    case EncodingType::FOR: {
+      RETURN_ENCODING_BY_INTEGER_TYPE(ForEncoding, dataType);
     }
     default: {
       NIMBLE_UNREACHABLE(
@@ -382,6 +386,14 @@ std::string_view EncodingFactory::encode(
       }
       NIMBLE_INCOMPATIBLE_ENCODING(
           "Huffman encoding only supports integral data types, got {}.",
+          TypeTraits<T>::dataType);
+    }
+    case EncodingType::FOR: {
+      if constexpr (isIntegralType<physicalType>()) {
+        return ForEncoding<T>::encode(selection, castedValues, buffer, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "FOR encoding only supports integral data types, got {}.",
           TypeTraits<T>::dataType);
     }
     default: {

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -181,7 +181,8 @@ EncodingLayout EncodingLayoutCapture::capture(
 
   if (encodingType == EncodingType::FixedBitWidth ||
       encodingType == EncodingType::Trivial ||
-      encodingType == EncodingType::BlockBitPacking) {
+      encodingType == EncodingType::BlockBitPacking ||
+      encodingType == EncodingType::FOR) {
     compressionType =
         encoding::peek<uint8_t, CompressionType>(encoding.data() + prefixSize);
   }
@@ -195,7 +196,6 @@ EncodingLayout EncodingLayoutCapture::capture(
     case EncodingType::DeltaBlock:
     case EncodingType::SimdForBitpack:
     case EncodingType::SubIntSplit:
-    case EncodingType::FOR:
     case EncodingType::FrequencyPartition:
     case EncodingType::Huffman:
       // Non nested encodings have zero children
@@ -243,6 +243,22 @@ EncodingLayout EncodingLayoutCapture::capture(
       captureChild(children, pos, bitWidthsBytes, options);
       const auto dataOffsetsBytes = varint::readVarint32(&pos);
       captureChild(children, pos, dataOffsetsBytes, options);
+      break;
+    }
+    case EncodingType::FOR: {
+      const char* pos = encoding.data() + prefixSize;
+      encoding::readChar(pos); // compressionType
+      varint::readVarint32(&pos); // frameSize
+      varint::readVarint32(&pos); // numFrames
+      varint::readVarint32(&pos); // firstFrameRows
+
+      children.reserve(3);
+      const auto bitWidthsBytes = varint::readVarint32(&pos);
+      captureChild(children, pos, bitWidthsBytes, options);
+      const auto referencesBytes = varint::readVarint32(&pos);
+      captureChild(children, pos, referencesBytes, options);
+      const auto bitOffsetsBytes = varint::readVarint32(&pos);
+      captureChild(children, pos, bitOffsetsBytes, options);
       break;
     }
     case EncodingType::Trivial: {

--- a/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -102,6 +102,12 @@ struct EncodingIdentifiers {
     static constexpr NestedEncodingIdentifier Offsets = 2;
   };
 
+  struct For {
+    static constexpr NestedEncodingIdentifier BitWidths = 0;
+    static constexpr NestedEncodingIdentifier References = 1;
+    static constexpr NestedEncodingIdentifier BitOffsets = 2;
+  };
+
   struct Fsst {
     static constexpr NestedEncodingIdentifier Lengths = 0;
   };

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -309,6 +309,44 @@ TEST(EncodingLayoutTests, for) {
   EXPECT_TRUE(captured.child(2).has_value());
 }
 
+TEST(EncodingLayoutTests, fsst) {
+  nimble::EncodingLayout fsstLayout{
+      nimble::EncodingType::Fsst,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {
+          nimble::EncodingLayout{
+              nimble::EncodingType::Trivial,
+              {},
+              nimble::CompressionType::Uncompressed},
+      }};
+
+  testSerialization(fsstLayout);
+
+  std::vector<std::string> storage;
+  storage.reserve(500);
+  for (uint32_t i = 0; i < 500; ++i) {
+    storage.emplace_back(
+        "common/prefix/for/fsst/layout/" + std::to_string(i % 31));
+  }
+
+  std::vector<std::string_view> data;
+  data.reserve(storage.size());
+  for (const auto& value : storage) {
+    data.push_back(value);
+  }
+
+  auto captured = encodeAndCapture<std::string_view>(fsstLayout, data);
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::Fsst);
+  ASSERT_EQ(captured.childrenCount(), 1);
+  ASSERT_TRUE(
+      captured.child(nimble::EncodingIdentifiers::Fsst::Lengths).has_value());
+  EXPECT_EQ(
+      captured.child(nimble::EncodingIdentifiers::Fsst::Lengths)
+          ->encodingType(),
+      nimble::EncodingType::Trivial);
+}
+
 TEST(EncodingLayoutTests, BlockBitPacking) {
   // BlockBitPacking nests three per-block metadata sub-streams (baselines, bit
   // widths, data offsets). Capture records each present sub-stream recursively,

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -283,6 +283,32 @@ TEST(EncodingLayoutTests, Pfor) {
   EXPECT_TRUE(captured.child(1).has_value());
 }
 
+TEST(EncodingLayoutTests, for) {
+  // FOR nests three frame metadata sub-streams: bit widths, references, and
+  // bit offsets. Capture records each present sub-stream recursively so a
+  // captured layout reproduces the full FOR tree.
+  nimble::EncodingLayout forLayout{
+      nimble::EncodingType::FOR,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {std::nullopt, std::nullopt, std::nullopt}};
+
+  testSerialization(forLayout);
+
+  std::vector<uint32_t> data;
+  data.reserve(500);
+  for (uint32_t i = 0; i < 500; ++i) {
+    data.push_back((i / 128) * 1000 + (i % 37));
+  }
+
+  auto captured = encodeAndCapture<uint32_t>(forLayout, data);
+  ASSERT_EQ(captured.encodingType(), nimble::EncodingType::FOR);
+  ASSERT_EQ(captured.childrenCount(), 3);
+  EXPECT_TRUE(captured.child(0).has_value());
+  EXPECT_TRUE(captured.child(1).has_value());
+  EXPECT_TRUE(captured.child(2).has_value());
+}
+
 TEST(EncodingLayoutTests, BlockBitPacking) {
   // BlockBitPacking nests three per-block metadata sub-streams (baselines, bit
   // widths, data offsets). Capture records each present sub-stream recursively,

--- a/dwio/nimble/encodings/tests/ForEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ForEncodingTest.cpp
@@ -19,9 +19,14 @@
 #include <algorithm>
 #include <memory>
 #include <random>
+#include <string_view>
+#include <vector>
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "dwio/nimble/encodings/views/EncodingViewFactory.h"
 #include "folly/Random.h"
 #include "velox/common/memory/Memory.h"
 
@@ -44,6 +49,206 @@ class ForEncodingTest : public ::testing::Test {
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::unique_ptr<nimble::Buffer> buffer_;
 };
+
+TEST_F(ForEncodingTest, slicePartialFrames) {
+  nimble::Vector<uint32_t> data(pool_.get());
+  data.reserve(384);
+  for (uint32_t i = 0; i < 384; ++i) {
+    data.push_back(1000 + (i / 128) * 100 + (i % 17));
+  }
+
+  const auto encoded =
+      nimble::test::Encoder<nimble::ForEncoding<uint32_t>>::encode(
+          *buffer_, data);
+
+  struct Range {
+    std::string_view name;
+    uint32_t offset;
+    uint32_t length;
+  };
+
+  for (const auto range :
+       {Range{"partialFirstAndLast", /*offset=*/64, /*length=*/192},
+        Range{"misalignedMiddle", /*offset=*/65, /*length=*/130},
+        Range{"crossFrameBoundary", /*offset=*/127, /*length=*/2},
+        Range{"fullFrame", /*offset=*/128, /*length=*/128}}) {
+    SCOPED_TRACE(
+        testing::Message() << "name=" << range.name << ", offset="
+                           << range.offset << ", length=" << range.length);
+    nimble::Buffer sliceBuffer{*pool_};
+    const auto sliced = nimble::ForEncoding<uint32_t>::slice(
+        encoded,
+        range.offset,
+        range.length,
+        sliceBuffer,
+        nimble::Encoding::Options{});
+
+    nimble::ForEncoding<uint32_t> encoding{
+        *pool_, sliced, [](uint32_t /*totalLength*/) -> void* {
+          return nullptr;
+        }};
+    nimble::Vector<uint32_t> output(pool_.get(), range.length);
+    encoding.materialize(range.length, output.data());
+
+    auto view = nimble::detail::createTypedEncodingView<uint32_t>(
+        sliced, pool_.get(), nimble::Encoding::Options{});
+    ASSERT_NE(view, nullptr);
+    nimble::Vector<uint32_t> viewOutput(pool_.get(), range.length);
+    view->read(/*offset=*/0, range.length, viewOutput.data());
+
+    for (uint32_t i = 0; i < range.length; ++i) {
+      ASSERT_EQ(output[i], data[range.offset + i]) << "encoding row " << i;
+      ASSERT_EQ(viewOutput[i], data[range.offset + i]) << "view row " << i;
+    }
+  }
+}
+
+TEST_F(ForEncodingTest, sliceRandomRanges) {
+  constexpr uint32_t kIterations{64};
+  std::mt19937 rng{0x5eed};
+
+  for (uint32_t iteration = 0; iteration < kIterations; ++iteration) {
+    const auto rowCount = std::uniform_int_distribution<uint32_t>{1, 512}(rng);
+    nimble::Vector<uint32_t> data(pool_.get());
+    data.reserve(rowCount);
+    for (uint32_t row = 0; row < rowCount; ++row) {
+      data.push_back(
+          (row / 128) * 1000 +
+          std::uniform_int_distribution<uint32_t>{0, 127}(rng));
+    }
+
+    const auto offset =
+        std::uniform_int_distribution<uint32_t>{0, rowCount - 1}(rng);
+    const auto length =
+        std::uniform_int_distribution<uint32_t>{1, rowCount - offset}(rng);
+    SCOPED_TRACE(
+        testing::Message() << "iteration=" << iteration
+                           << ", rowCount=" << rowCount << ", offset=" << offset
+                           << ", length=" << length);
+
+    const auto encoded =
+        nimble::test::Encoder<nimble::ForEncoding<uint32_t>>::encode(
+            *buffer_, data);
+    nimble::Buffer sliceBuffer{*pool_};
+    const auto sliced = nimble::ForEncoding<uint32_t>::slice(
+        encoded, offset, length, sliceBuffer, nimble::Encoding::Options{});
+
+    nimble::ForEncoding<uint32_t> encoding{
+        *pool_, sliced, [](uint32_t /*totalLength*/) -> void* {
+          return nullptr;
+        }};
+    nimble::Vector<uint32_t> output(pool_.get(), length);
+    encoding.materialize(length, output.data());
+
+    auto view = nimble::detail::createTypedEncodingView<uint32_t>(
+        sliced, pool_.get(), nimble::Encoding::Options{});
+    ASSERT_NE(view, nullptr);
+    nimble::Vector<uint32_t> viewOutput(pool_.get(), length);
+    view->read(/*offset=*/0, length, viewOutput.data());
+
+    const std::vector<uint32_t> expected(
+        data.begin() + offset, data.begin() + offset + length);
+    EXPECT_EQ(std::vector<uint32_t>(output.begin(), output.end()), expected);
+    EXPECT_EQ(
+        std::vector<uint32_t>(viewOutput.begin(), viewOutput.end()), expected);
+  }
+}
+
+TEST_F(ForEncodingTest, slicePreservesMetadataLayout) {
+  nimble::Vector<uint32_t> data(pool_.get());
+  data.reserve(4096);
+  for (uint32_t i = 0; i < 4096; ++i) {
+    data.push_back(1000 + (i % 3));
+  }
+
+  struct SourceCompression {
+    nimble::CompressionType type;
+    std::string_view name;
+  };
+
+  for (const auto sourceCompression :
+       {SourceCompression{
+            nimble::CompressionType::Uncompressed, "uncompressed"},
+        SourceCompression{nimble::CompressionType::Zstd, "zstd"}}) {
+    SCOPED_TRACE(
+        testing::Message() << "sourceCompression=" << sourceCompression.name);
+    const auto encoded =
+        nimble::test::Encoder<nimble::ForEncoding<uint32_t>>::encode(
+            *buffer_, data, sourceCompression.type);
+    const auto sourceLayout = nimble::EncodingLayoutCapture::capture(
+        encoded, nimble::Encoding::Options{});
+    ASSERT_EQ(sourceLayout.encodingType(), nimble::EncodingType::FOR);
+    ASSERT_EQ(sourceLayout.compressionType(), sourceCompression.type);
+
+    constexpr uint32_t offset{129};
+    constexpr uint32_t length{257};
+    nimble::Buffer sliceBuffer{*pool_};
+    const auto sliced = nimble::ForEncoding<uint32_t>::slice(
+        encoded, offset, length, sliceBuffer, nimble::Encoding::Options{});
+    const auto sliceLayout = nimble::EncodingLayoutCapture::capture(
+        sliced, nimble::Encoding::Options{});
+    ASSERT_EQ(sliceLayout.encodingType(), nimble::EncodingType::FOR);
+    EXPECT_EQ(
+        sliceLayout.compressionType(), nimble::CompressionType::Uncompressed);
+    ASSERT_EQ(sourceLayout.childrenCount(), 3);
+    ASSERT_EQ(sliceLayout.childrenCount(), 3);
+    for (uint32_t child = 0; child < 3; ++child) {
+      SCOPED_TRACE(testing::Message() << "child=" << child);
+      ASSERT_TRUE(sourceLayout.child(child).has_value());
+      ASSERT_TRUE(sliceLayout.child(child).has_value());
+      EXPECT_EQ(
+          sliceLayout.child(child)->encodingType(),
+          sourceLayout.child(child)->encodingType());
+    }
+
+    nimble::ForEncoding<uint32_t> encoding{
+        *pool_, sliced, [](uint32_t /*totalLength*/) -> void* {
+          return nullptr;
+        }};
+    nimble::Vector<uint32_t> output(pool_.get(), length);
+    encoding.materialize(length, output.data());
+
+    auto view = nimble::detail::createTypedEncodingView<uint32_t>(
+        sliced, pool_.get(), nimble::Encoding::Options{});
+    ASSERT_NE(view, nullptr);
+    nimble::Vector<uint32_t> viewOutput(pool_.get(), length);
+    view->read(/*offset=*/0, length, viewOutput.data());
+
+    const std::vector<uint32_t> expected{
+        data.begin() + offset, data.begin() + offset + length};
+    EXPECT_EQ(std::vector<uint32_t>(output.begin(), output.end()), expected);
+    EXPECT_EQ(
+        std::vector<uint32_t>(viewOutput.begin(), viewOutput.end()), expected);
+  }
+}
+
+TEST_F(ForEncodingTest, sliceRejectsInvalidRange) {
+  nimble::Vector<uint32_t> data(pool_.get());
+  for (uint32_t i = 0; i < 16; ++i) {
+    data.push_back(i);
+  }
+  const auto encoded =
+      nimble::test::Encoder<nimble::ForEncoding<uint32_t>>::encode(
+          *buffer_, data);
+
+  nimble::Buffer sliceBuffer{*pool_};
+  NIMBLE_ASSERT_THROW(
+      nimble::ForEncoding<uint32_t>::slice(
+          encoded,
+          /*offset=*/0,
+          /*length=*/0,
+          sliceBuffer,
+          nimble::Encoding::Options{}),
+      "Cannot slice zero rows.");
+  NIMBLE_ASSERT_THROW(
+      nimble::ForEncoding<uint32_t>::slice(
+          encoded,
+          /*offset=*/data.size(),
+          /*length=*/1,
+          sliceBuffer,
+          nimble::Encoding::Options{}),
+      "");
+}
 
 TEST_F(ForEncodingTest, BasicEncodeDecode) {
   nimble::Vector<int32_t> data(pool_.get());

--- a/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/FsstEncodingTest.cpp
@@ -18,8 +18,11 @@
 #include <fmt/core.h>
 #include <gtest/gtest.h>
 #include <limits>
+#include <random>
 
 #include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrefix.h"
@@ -34,7 +37,9 @@ namespace {
 class FsstEncodingTest : public ::testing::Test {
  protected:
   static void SetUpTestCase() {
-    velox::memory::MemoryManager::initialize({});
+    if (!velox::memory::MemoryManager::testInstance()) {
+      velox::memory::MemoryManager::initialize({});
+    }
   }
 
   void SetUp() override {
@@ -245,6 +250,170 @@ TEST_F(FsstEncodingTest, roundTripStrings) {
 
   for (const auto& testCase : testCases) {
     roundTrip(testCase.values, testCase.name, testCase.expectedEncodingType);
+  }
+}
+
+TEST_F(FsstEncodingTest, slice) {
+  const std::vector<std::string> storage{
+      "common/prefix/value/0000",
+      "common/prefix/value/0001",
+      "common/prefix/value/0002",
+      "common/prefix/value/0003",
+      "common/prefix/value/0004",
+      "common/prefix/value/0005",
+  };
+  std::vector<std::string_view> values;
+  values.reserve(storage.size());
+  for (const auto& value : storage) {
+    values.push_back(value);
+  }
+
+  Buffer buffer{*pool_};
+  const auto encoded = encodeFsst(values, buffer);
+  ASSERT_EQ(EncodingPrefix::encodingType(encoded), EncodingType::Fsst);
+
+  Buffer sliceBuffer{*pool_};
+  const auto sliced = EncodingFactory::slice(
+      encoded,
+      /*offset=*/2,
+      /*length=*/3,
+      sliceBuffer,
+      {.fsstCompressionTargetRatio = std::numeric_limits<double>::max()});
+
+  auto encoding =
+      EncodingFactory({}).create(*pool_, sliced, createStringBufferFactory());
+  ASSERT_EQ(encoding->encodingType(), EncodingType::Fsst);
+  ASSERT_EQ(encoding->dataType(), DataType::String);
+  ASSERT_EQ(encoding->rowCount(), 3);
+
+  std::vector<std::string_view> decoded(3);
+  encoding->materialize(decoded.size(), decoded.data());
+
+  const std::vector<std::string_view> expected{values[2], values[3], values[4]};
+  EXPECT_EQ(decoded, expected);
+}
+
+TEST_F(FsstEncodingTest, capturesLengthsLayoutWithVarintHeaderSizes) {
+  std::vector<std::string> storage;
+  storage.reserve(512);
+  for (uint32_t i = 0; i < 512; ++i) {
+    storage.emplace_back(
+        fmt::format("common/prefix/for/fsst/layout/{:04}", i % 97));
+  }
+
+  std::vector<std::string_view> values;
+  values.reserve(storage.size());
+  for (const auto& value : storage) {
+    values.push_back(value);
+  }
+
+  Buffer buffer{*pool_};
+  const auto encoded = encodeFsst(values, buffer);
+  ASSERT_EQ(EncodingPrefix::encodingType(encoded), EncodingType::Fsst);
+
+  const char* pos =
+      encoded.data() + EncodingPrefix::prefixSize(encoded, /*useVarint=*/false);
+  const auto symbolTableSize = varint::readVarint32(&pos);
+  ASSERT_GT(symbolTableSize, 0);
+  pos += symbolTableSize;
+  const auto lengthsSize = varint::readVarint32(&pos);
+  ASSERT_GT(lengthsSize, 0);
+
+  const auto lengths = FsstEncoding::lengthsEncoding(encoded);
+  EXPECT_EQ(lengths.data(), pos);
+  EXPECT_EQ(lengths.size(), lengthsSize);
+
+  const auto captured = EncodingLayoutCapture::capture(encoded, {});
+  ASSERT_EQ(captured.encodingType(), EncodingType::Fsst);
+  ASSERT_EQ(captured.childrenCount(), 1);
+  ASSERT_TRUE(captured.child(EncodingIdentifiers::Fsst::Lengths).has_value());
+  EXPECT_EQ(
+      captured.child(EncodingIdentifiers::Fsst::Lengths)->encodingType(),
+      EncodingType::Trivial);
+}
+
+TEST_F(FsstEncodingTest, invalidSliceRange) {
+  const std::vector<std::string> storage{
+      "common/prefix/value/0000",
+      "common/prefix/value/0001",
+      "common/prefix/value/0002",
+      "common/prefix/value/0003",
+  };
+  std::vector<std::string_view> values;
+  values.reserve(storage.size());
+  for (const auto& value : storage) {
+    values.push_back(value);
+  }
+
+  Buffer buffer{*pool_};
+  const auto encoded = encodeFsst(values, buffer);
+
+  Buffer sliceBuffer{*pool_};
+  NIMBLE_ASSERT_THROW(
+      FsstEncoding::slice(
+          encoded,
+          /*offset=*/0,
+          /*length=*/0,
+          sliceBuffer,
+          Encoding::Options{}),
+      "Cannot slice zero rows.");
+  NIMBLE_ASSERT_THROW(
+      FsstEncoding::slice(
+          encoded,
+          /*offset=*/values.size(),
+          /*length=*/1,
+          sliceBuffer,
+          Encoding::Options{}),
+      "");
+}
+
+TEST_F(FsstEncodingTest, sliceRandomRanges) {
+  std::vector<std::string> storage;
+  storage.reserve(256);
+  for (uint32_t i = 0; i < 256; ++i) {
+    storage.emplace_back(
+        fmt::format("common/prefix/for/random/fsst/range/{:04}", i % 37));
+  }
+  std::vector<std::string_view> values;
+  values.reserve(storage.size());
+  for (const auto& value : storage) {
+    values.push_back(value);
+  }
+
+  Buffer buffer{*pool_};
+  const auto encoded = encodeFsst(values, buffer);
+  ASSERT_EQ(EncodingPrefix::encodingType(encoded), EncodingType::Fsst);
+
+  std::mt19937 rng{0x5eed};
+  const auto rowCount = static_cast<uint32_t>(values.size());
+  for (uint32_t iteration = 0; iteration < 64; ++iteration) {
+    const auto offset =
+        std::uniform_int_distribution<uint32_t>{0, rowCount - 1}(rng);
+    const auto length =
+        std::uniform_int_distribution<uint32_t>{1, rowCount - offset}(rng);
+    SCOPED_TRACE(
+        testing::Message() << "iteration=" << iteration << ", offset=" << offset
+                           << ", length=" << length);
+
+    Buffer sliceBuffer{*pool_};
+    const auto sliced = EncodingFactory::slice(
+        encoded,
+        offset,
+        length,
+        sliceBuffer,
+        {.fsstCompressionTargetRatio = std::numeric_limits<double>::max()});
+
+    stringBuffers_.clear();
+    auto encoding =
+        EncodingFactory({}).create(*pool_, sliced, createStringBufferFactory());
+    ASSERT_EQ(encoding->encodingType(), EncodingType::Fsst);
+    ASSERT_EQ(encoding->rowCount(), length);
+
+    std::vector<std::string_view> decoded(length);
+    encoding->materialize(length, decoded.data());
+    for (uint32_t i = 0; i < length; ++i) {
+      ASSERT_EQ(decoded[i], values[offset + i]) << "row " << i;
+    }
   }
 }
 

--- a/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -33,6 +33,7 @@
 #include "dwio/nimble/encodings/DeltaEncoding.h"
 #include "dwio/nimble/encodings/DictionaryEncoding.h"
 #include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/ForEncoding.h"
 #include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/MainlyConstantEncoding.h"
 #include "dwio/nimble/encodings/NullableEncoding.h"
@@ -332,6 +333,7 @@ using SliceEncodingTypes = ::testing::Types<
     SliceEncodingConfig<nimble::PFOREncoding<uint32_t>>,
     SliceEncodingConfig<nimble::SimdForBitpackEncoding<uint32_t>>,
     SliceEncodingConfig<nimble::HuffmanEncoding<uint32_t>>,
+    SliceEncodingConfig<nimble::ForEncoding<uint32_t>>,
     SliceEncodingConfig<nimble::ALPEncoding<double>>>;
 
 template <typename Config>

--- a/dwio/nimble/encodings/views/BlockBitPackingEncodingView.h
+++ b/dwio/nimble/encodings/views/BlockBitPackingEncodingView.h
@@ -45,8 +45,7 @@ class BlockBitPackingEncodingView final : public TypedEncodingView<T> {
         blocks_{this->template getVectorBuffer<BlockMeta>()},
         blockRowOffsets_{this->template getVectorBuffer<uint32_t>()} {
     NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::BlockBitPacking);
-    const auto source =
-        BlockBitPackingEncoding<T>::parseSourceHeader(data, options);
+    const auto source = BlockBitPackingEncoding<T>::parseHeader(data, options);
     NIMBLE_CHECK_EQ(
         source.compressionType,
         CompressionType::Uncompressed,

--- a/dwio/nimble/encodings/views/FOREncodingView.h
+++ b/dwio/nimble/encodings/views/FOREncodingView.h
@@ -19,6 +19,7 @@
 #include <cstring>
 #include <type_traits>
 
+#include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/views/EncodingViewFactory.h"
 #include "velox/common/base/BitUtil.h"
@@ -50,14 +51,21 @@ class FOREncodingView final : public TypedEncodingView<T> {
         compressionType,
         CompressionType::Uncompressed,
         "EncodingView does not support compressed FOR streams.");
-    frameSize_ = encoding::readUint32(pos);
-    numFrames_ = encoding::readUint32(pos);
-    enableBitOffsets_ = static_cast<bool>(encoding::readChar(pos));
+    frameSize_ = varint::readVarint32(&pos);
+    numFrames_ = varint::readVarint32(&pos);
+    firstFrameRows_ = varint::readVarint32(&pos);
     NIMBLE_CHECK_GT(frameSize_, 0);
+    NIMBLE_CHECK_GT(firstFrameRows_, 0);
+    NIMBLE_CHECK_LE(firstFrameRows_, frameSize_);
     NIMBLE_CHECK_EQ(
-        numFrames_, (this->rowCount_ + frameSize_ - 1) / frameSize_);
+        numFrames_,
+        this->rowCount_ <= firstFrameRows_ ? 1
+                                           : 1 +
+                velox::bits::divRoundUp(this->rowCount_ - firstFrameRows_,
+                                        frameSize_));
+    lastFrameRows_ = this->rowCount_ - frameRowOffset(numFrames_ - 1);
 
-    const auto bitWidthsSize = encoding::readUint32(pos);
+    const auto bitWidthsSize = varint::readVarint32(&pos);
     auto bitWidths = detail::createTypedEncodingView<uint8_t>(
         {pos, bitWidthsSize}, pool, options);
     NIMBLE_CHECK_NOT_NULL(bitWidths);
@@ -68,7 +76,7 @@ class FOREncodingView final : public TypedEncodingView<T> {
     }
     pos += bitWidthsSize;
 
-    const auto referencesSize = encoding::readUint32(pos);
+    const auto referencesSize = varint::readVarint32(&pos);
     auto references = detail::createTypedEncodingView<physicalType>(
         {pos, referencesSize}, pool, options);
     NIMBLE_CHECK_NOT_NULL(references);
@@ -80,25 +88,17 @@ class FOREncodingView final : public TypedEncodingView<T> {
     pos += referencesSize;
 
     bitOffsets_.resize(numFrames_);
-    if (enableBitOffsets_) {
-      const auto bitOffsetsSize = encoding::readUint32(pos);
-      auto bitOffsets = detail::createTypedEncodingView<uint64_t>(
-          {pos, bitOffsetsSize}, pool, options);
-      NIMBLE_CHECK_NOT_NULL(bitOffsets);
-      NIMBLE_CHECK_EQ(bitOffsets->rowCount(), numFrames_);
-      for (uint32_t frame = 0; frame < numFrames_; ++frame) {
-        bitOffsets_[frame] = bitOffsets->readAt(frame);
-      }
-      pos += bitOffsetsSize;
-    } else {
-      uint64_t cumulativeBitOffset{0};
-      for (uint32_t frame = 0; frame < numFrames_; ++frame) {
-        bitOffsets_[frame] = cumulativeBitOffset;
-        cumulativeBitOffset += frameRowCount(frame) * bitWidths_[frame];
-      }
+    const auto bitOffsetsSize = varint::readVarint32(&pos);
+    auto bitOffsets = detail::createTypedEncodingView<uint64_t>(
+        {pos, bitOffsetsSize}, pool, options);
+    NIMBLE_CHECK_NOT_NULL(bitOffsets);
+    NIMBLE_CHECK_EQ(bitOffsets->rowCount(), numFrames_);
+    for (uint32_t frame = 0; frame < numFrames_; ++frame) {
+      bitOffsets_[frame] = bitOffsets->readAt(frame);
     }
+    pos += bitOffsetsSize;
 
-    const auto packedDataSize = encoding::readUint32(pos);
+    const auto packedDataSize = varint::readVarint32(&pos);
     packedData_ = pos;
     pos += packedDataSize;
     NIMBLE_CHECK_EQ(pos, data.end(), "Unexpected FOR view end.");
@@ -112,8 +112,29 @@ class FOREncodingView final : public TypedEncodingView<T> {
 
  private:
   uint32_t frameRowCount(uint32_t frame) const {
-    const auto startRow = frame * frameSize_;
-    return std::min(frameSize_, this->rowCount_ - startRow);
+    if (frame == numFrames_ - 1) {
+      return lastFrameRows_;
+    }
+    if (frame == 0) {
+      return firstFrameRows_;
+    }
+    return frameSize_;
+  }
+
+  uint32_t frameRowOffset(uint32_t frame) const {
+    if (frame == 0) {
+      return 0;
+    }
+    return firstFrameRows_ + (frame - 1) * frameSize_;
+  }
+
+  uint32_t frameIndex(uint32_t row) const {
+    if (row < firstFrameRows_) {
+      return 0;
+    }
+    const auto frame = 1 + (row - firstFrameRows_) / frameSize_;
+    NIMBLE_CHECK_LT(frame, numFrames_);
+    return frame;
   }
 
   uint64_t bitOffset(uint32_t frame) const {
@@ -183,8 +204,8 @@ class FOREncodingView final : public TypedEncodingView<T> {
 
   T readTypedAt(uint32_t index) const final {
     NIMBLE_CHECK_LT(index, this->rowCount_);
-    const auto frame = index / frameSize_;
-    const auto positionInFrame = index % frameSize_;
+    const auto frame = frameIndex(index);
+    const auto positionInFrame = index - frameRowOffset(frame);
     const auto bitWidth = bitWidths_[frame];
     NIMBLE_CHECK_LE(bitWidth, sizeof(physicalType) * 8);
     const auto residual =
@@ -198,10 +219,10 @@ class FOREncodingView final : public TypedEncodingView<T> {
     this->checkReadRange(offset, length);
     uint32_t outputOffset{0};
     while (outputOffset < length) {
-      const auto frame = offset / frameSize_;
-      const auto positionInFrame = offset % frameSize_;
+      const auto frame = frameIndex(offset);
+      const auto positionInFrame = offset - frameRowOffset(frame);
       const auto count = std::min<uint32_t>(
-          length - outputOffset, frameSize_ - positionInFrame);
+          length - outputOffset, frameRowCount(frame) - positionInFrame);
       readFrameRange(frame, positionInFrame, count, output + outputOffset);
       outputOffset += count;
       offset += count;
@@ -225,7 +246,8 @@ class FOREncodingView final : public TypedEncodingView<T> {
 
   uint32_t frameSize_{0};
   uint32_t numFrames_{0};
-  bool enableBitOffsets_{false};
+  uint32_t firstFrameRows_{0};
+  uint32_t lastFrameRows_{0};
   Vector<uint8_t> bitWidths_;
   Vector<physicalType> references_;
   Vector<uint64_t> bitOffsets_;

--- a/dwio/nimble/encodings/views/SimdForBitpackEncodingView.h
+++ b/dwio/nimble/encodings/views/SimdForBitpackEncodingView.h
@@ -36,43 +36,43 @@ class SimdForBitpackEncodingView final : public TypedEncodingView<T> {
       const Encoding::Options& options)
       : TypedEncodingView<T>{data, pool, options} {
     NIMBLE_CHECK_EQ(this->encodingType_, EncodingType::SimdForBitpack);
-    source_ = SimdForBitpackEncoding<T>::parseSourceHeader(data, options);
-    NIMBLE_CHECK_EQ(source_.rowCount, this->rowCount_);
+    header_ = SimdForBitpackEncoding<T>::parseHeader(data, options);
+    NIMBLE_CHECK_EQ(header_.rowCount, this->rowCount_);
   }
 
  private:
   T readTypedAt(uint32_t index) const final {
     NIMBLE_CHECK_LT(index, this->rowCount_);
-    if (source_.bitWidth == 0) {
-      return detail::castFromPhysicalType<T>(source_.baseline);
+    if (header_.bitWidth == 0) {
+      return detail::castFromPhysicalType<T>(header_.baseline);
     }
 
-    const auto position = SimdForBitpackEncoding<T>::groupInfo(source_, index);
+    const auto position = SimdForBitpackEncoding<T>::groupInfo(header_, index);
     std::array<physicalType, kGroupSize> residuals{};
     unpackGroup(position.groupIndex, residuals.data());
     return detail::castFromPhysicalType<T>(static_cast<physicalType>(
-        residuals[position.rowOffset] + source_.baseline));
+        residuals[position.rowOffset] + header_.baseline));
   }
 
   void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
       const final {
     this->checkReadRange(offset, length);
-    if (source_.bitWidth == 0) {
-      std::fill(output, output + length, source_.baseline);
+    if (header_.bitWidth == 0) {
+      std::fill(output, output + length, header_.baseline);
       return;
     }
 
     uint32_t outputOffset{0};
     while (outputOffset < length) {
       const auto position =
-          SimdForBitpackEncoding<T>::groupInfo(source_, offset);
+          SimdForBitpackEncoding<T>::groupInfo(header_, offset);
       const auto count = std::min<uint32_t>(
           length - outputOffset, position.rowCount - position.rowOffset);
       std::array<physicalType, kGroupSize> residuals{};
       unpackGroup(position.groupIndex, residuals.data());
       for (uint32_t i = 0; i < count; ++i) {
         output[outputOffset + i] = static_cast<physicalType>(
-            residuals[position.rowOffset + i] + source_.baseline);
+            residuals[position.rowOffset + i] + header_.baseline);
       }
       outputOffset += count;
       offset += count;
@@ -89,25 +89,25 @@ class SimdForBitpackEncodingView final : public TypedEncodingView<T> {
             isEightByteIntegralType<physicalType>(),
         "Unexpected SimdForBitpack physical type width.");
     const auto* groupStart =
-        reinterpret_cast<const uint32_t*>(source_.packedData) +
-        static_cast<uint64_t>(groupIndex) * source_.bitWidth;
+        reinterpret_cast<const uint32_t*>(header_.packedData) +
+        static_cast<uint64_t>(groupIndex) * header_.bitWidth;
     if constexpr (isEightByteIntegralType<physicalType>()) {
       facebook::velox::fastpforlib::fastunpack(
-          groupStart, reinterpret_cast<uint64_t*>(output), source_.bitWidth);
+          groupStart, reinterpret_cast<uint64_t*>(output), header_.bitWidth);
     } else if constexpr (isFourByteIntegralType<physicalType>()) {
       facebook::velox::fastpforlib::fastunpack(
-          groupStart, reinterpret_cast<uint32_t*>(output), source_.bitWidth);
+          groupStart, reinterpret_cast<uint32_t*>(output), header_.bitWidth);
     } else {
       std::array<uint32_t, kGroupSize> temp{};
       facebook::velox::fastpforlib::fastunpack(
-          groupStart, temp.data(), source_.bitWidth);
+          groupStart, temp.data(), header_.bitWidth);
       for (uint32_t i = 0; i < kGroupSize; ++i) {
         output[i] = static_cast<physicalType>(temp[i]);
       }
     }
   }
 
-  typename SimdForBitpackEncoding<T>::SourceHeader source_;
+  typename SimdForBitpackEncoding<T>::Header header_;
 };
 
 } // namespace facebook::nimble


### PR DESCRIPTION
Summary:

Adds native encoded slice support for FSST streams. The slice path reuses the source symbol table, slices the nested compressed-lengths stream with captured layout, and copies the compressed blob range without decompressing string data.

FSST header child sizes are now varint-encoded, and layout capture reads the same varint framing for the nested lengths stream.

Reviewed By: HuamengJiang, tanjialiang

Differential Revision: D113728373


