### PR TITLE
fix(nimble): Add opt-in encoding scratch buffer cache (#1051)

### DIFF
--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -372,6 +372,7 @@ std::string_view encode(
     std::optional<EncodingLayout> encodingLayout,
     detail::WriterContext& context,
     Buffer& buffer,
+    velox::BufferPool* encodingScratchBufferPool,
     EncodingBufferPool* encodingBufferPool,
     const StreamData& streamData) {
   NIMBLE_DCHECK_EQ(
@@ -408,6 +409,7 @@ std::string_view encode(
   }
 
   auto encodingOptions = context.options().buildEncodingOptions();
+  encodingOptions.bufferPool = encodingScratchBufferPool;
   encodingOptions.encodingBufferPool = encodingBufferPool;
   velox::common::testutil::TestValue::adjust(
       "facebook::nimble::VeloxWriter::encode", &encodingOptions);
@@ -433,6 +435,7 @@ std::string_view encodeWithFallback(
     const EncodingLayout* encodingLayout,
     detail::WriterContext& context,
     Buffer& buffer,
+    velox::BufferPool* encodingScratchBufferPool,
     EncodingBufferPool* encodingBufferPool,
     const StreamData& streamData) {
   NIMBLE_CHECK_NOT_NULL(
@@ -440,13 +443,23 @@ std::string_view encodeWithFallback(
       "encodeWithFallback requires a saved encoding layout to replay.");
   try {
     return encode<T>(
-        *encodingLayout, context, buffer, encodingBufferPool, streamData);
+        *encodingLayout,
+        context,
+        buffer,
+        encodingScratchBufferPool,
+        encodingBufferPool,
+        streamData);
   } catch (const std::exception&) {
     // A saved layout can fail to apply to this chunk's data in ways beyond a
     // clean IncompatibleEncoding, so retry on any error rather than keying off
     // a specific (unreliable) error code.
     return encode<T>(
-        std::nullopt, context, buffer, encodingBufferPool, streamData);
+        std::nullopt,
+        context,
+        buffer,
+        encodingScratchBufferPool,
+        encodingBufferPool,
+        streamData);
   }
 }
 
@@ -454,6 +467,7 @@ template <typename T>
 std::string_view encodeStreamTyped(
     detail::WriterContext& context,
     Buffer& buffer,
+    velox::BufferPool* encodingScratchBufferPool,
     EncodingBufferPool* encodingBufferPool,
     const StreamData& streamData) {
   const auto* writerStreamContext =
@@ -468,13 +482,19 @@ std::string_view encodeStreamTyped(
         writerStreamContext->encoding(),
         context,
         buffer,
+        encodingScratchBufferPool,
         encodingBufferPool,
         streamData);
   }
 
   // No layout to replay: run a fresh selection.
-  auto encoded =
-      encode<T>(std::nullopt, context, buffer, encodingBufferPool, streamData);
+  auto encoded = encode<T>(
+      std::nullopt,
+      context,
+      buffer,
+      encodingScratchBufferPool,
+      encodingBufferPool,
+      streamData);
 
   // Cache the data layout from this first encode so later chunks/stripes replay
   // it, skipping the full selection cascade. EncodingLayoutCapture::capture()
@@ -493,41 +513,82 @@ std::string_view encodeStreamTyped(
 std::string_view encodeStreamData(
     detail::WriterContext& context,
     Buffer& buffer,
+    velox::BufferPool* encodingScratchBufferPool,
     EncodingBufferPool* encodingBufferPool,
     const StreamData& streamData) {
   auto scalarKind = streamData.descriptor().scalarKind();
   switch (scalarKind) {
     case ScalarKind::Bool:
       return encodeStreamTyped<bool>(
-          context, buffer, encodingBufferPool, streamData);
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamData);
     case ScalarKind::Int8:
       return encodeStreamTyped<int8_t>(
-          context, buffer, encodingBufferPool, streamData);
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamData);
     case ScalarKind::Int16:
       return encodeStreamTyped<int16_t>(
-          context, buffer, encodingBufferPool, streamData);
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamData);
     case ScalarKind::UInt16:
       return encodeStreamTyped<uint16_t>(
-          context, buffer, encodingBufferPool, streamData);
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamData);
     case ScalarKind::Int32:
       return encodeStreamTyped<int32_t>(
-          context, buffer, encodingBufferPool, streamData);
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamData);
     case ScalarKind::UInt32:
       return encodeStreamTyped<uint32_t>(
-          context, buffer, encodingBufferPool, streamData);
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamData);
     case ScalarKind::Int64:
       return encodeStreamTyped<int64_t>(
-          context, buffer, encodingBufferPool, streamData);
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamData);
     case ScalarKind::Float:
       return encodeStreamTyped<float>(
-          context, buffer, encodingBufferPool, streamData);
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamData);
     case ScalarKind::Double:
       return encodeStreamTyped<double>(
-          context, buffer, encodingBufferPool, streamData);
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamData);
     case ScalarKind::String:
     case ScalarKind::Binary:
       return encodeStreamTyped<std::string_view>(
-          context, buffer, encodingBufferPool, streamData);
+          context,
+          buffer,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamData);
     default:
       NIMBLE_UNREACHABLE("Unsupported scalar kind {}", toString(scalarKind));
   }
@@ -1272,13 +1333,19 @@ void VeloxWriter::ensureEncodingBuffer() {
   }
 }
 
+std::unique_ptr<velox::BufferPool> VeloxWriter::makeEncodingScratchBufferPool()
+    const {
+  const auto maxCachedBuffers =
+      context_->options().maxCachedEncodingScratchBuffers;
+  NIMBLE_CHECK_GT(maxCachedBuffers, 0);
+  return std::make_unique<velox::BufferPool>(maxCachedBuffers);
+}
+
 std::unique_ptr<EncodingBufferPool> VeloxWriter::makeEncodingBufferPool()
     const {
   const auto maxCachedBuffers =
       context_->options().maxCachedNestedEncodingBuffers;
-  if (maxCachedBuffers == 0) {
-    return nullptr;
-  }
+  NIMBLE_CHECK_GT(maxCachedBuffers, 0);
   return std::make_unique<EncodingBufferPool>(
       encodingMemoryPool_.get(), maxCachedBuffers);
 }
@@ -1294,6 +1361,18 @@ uint32_t VeloxWriter::encodingConcurrency(uint32_t taskCount) const {
   return std::min(taskCount, options.maxEncodeParallelism);
 }
 
+void VeloxWriter::ensureEncodingScratchBufferPools(uint32_t poolCount) {
+  if (context_->options().maxCachedEncodingScratchBuffers == 0) {
+    NIMBLE_CHECK(
+        encodingScratchBufferPools_.empty(),
+        "Encoding scratch buffer pools should not be created when caching is disabled.");
+    return;
+  }
+  while (encodingScratchBufferPools_.size() < poolCount) {
+    encodingScratchBufferPools_.emplace_back(makeEncodingScratchBufferPool());
+  }
+}
+
 void VeloxWriter::ensureEncodingBufferPools(uint32_t poolCount) {
   if (context_->options().maxCachedNestedEncodingBuffers == 0) {
     NIMBLE_CHECK(
@@ -1304,6 +1383,15 @@ void VeloxWriter::ensureEncodingBufferPools(uint32_t poolCount) {
   while (encodingBufferPools_.size() < poolCount) {
     encodingBufferPools_.emplace_back(makeEncodingBufferPool());
   }
+}
+
+velox::BufferPool* VeloxWriter::encodingScratchBufferPool(uint32_t index) {
+  if (context_->options().maxCachedEncodingScratchBuffers == 0) {
+    return nullptr;
+  }
+  ensureEncodingScratchBufferPools(index + 1);
+  NIMBLE_CHECK_LT(index, encodingScratchBufferPools_.size());
+  return encodingScratchBufferPools_[index].get();
 }
 
 EncodingBufferPool* VeloxWriter::encodingBufferPool(uint32_t index) {
@@ -1321,6 +1409,7 @@ void VeloxWriter::clearEncodingBuffer() {
   }
   if (velox::memory::underMemoryArbitration()) {
     // Under memory arbitration, free the buffer and pools.
+    encodingScratchBufferPools_.clear();
     encodingBufferPools_.clear();
     encodingBuffer_.reset();
   } else {
@@ -1352,6 +1441,7 @@ void VeloxWriter::writeStreams() {
     const auto& streams = context_->streams();
     const auto streamCount = static_cast<uint32_t>(streams.size());
     const auto concurrency = encodingConcurrency(streamCount);
+    ensureEncodingScratchBufferPools(concurrency);
     ensureEncodingBufferPools(concurrency);
 
     if (concurrency > 1) {
@@ -1364,15 +1454,22 @@ void VeloxWriter::writeStreams() {
         const auto batchSize = std::min(concurrency, streamCount - start);
         for (uint32_t index = 0; index < batchSize; ++index) {
           auto& [nodeId, streamData] = streams[start + index];
+          auto* encodingScratchBufferPool =
+              this->encodingScratchBufferPool(index);
           auto* encodingBufferPool = this->encodingBufferPool(index);
           barrier.add([&,
                        statsCollector = context_->getStatsCollector(nodeId),
                        _streamData = streamData.get(),
+                       encodingScratchBufferPool,
                        encodingBufferPool]() {
             uint64_t startCpuNs = velox::process::threadCpuNanos();
             uint64_t streamSize{0};
             processStream(
-                *_streamData, encodingBufferPool, streamSize, chunkSize);
+                *_streamData,
+                encodingScratchBufferPool,
+                encodingBufferPool,
+                streamSize,
+                chunkSize);
             if (statsCollector) {
               statsCollector->addPhysicalSize(streamSize);
             }
@@ -1384,12 +1481,18 @@ void VeloxWriter::writeStreams() {
         barrier.waitAll();
       }
     } else {
+      auto* encodingScratchBufferPool = this->encodingScratchBufferPool();
       auto* encodingBufferPool = this->encodingBufferPool();
       for (auto& [nodeId, streamData] : streams) {
         auto statsCollector = context_->getStatsCollector(nodeId);
         uint64_t startCpuNs = velox::process::threadCpuNanos();
         uint64_t streamSize{0};
-        processStream(*streamData, encodingBufferPool, streamSize, chunkSize);
+        processStream(
+            *streamData,
+            encodingScratchBufferPool,
+            encodingBufferPool,
+            streamSize,
+            chunkSize);
         if (statsCollector) {
           statsCollector->addPhysicalSize(streamSize);
         }
@@ -1412,6 +1515,7 @@ void VeloxWriter::writeStreams() {
 
 void VeloxWriter::encodeStream(
     StreamData& streamData,
+    velox::BufferPool* encodingScratchBufferPool,
     EncodingBufferPool* encodingBufferPool,
     uint64_t& streamSize,
     std::atomic_uint64_t& chunkSize) {
@@ -1423,7 +1527,8 @@ void VeloxWriter::encodeStream(
   // used in non-chunked mode.
   NIMBLE_CHECK(encodedStream.chunks.empty());
   auto& chunk = encodedStream.chunks.emplace_back();
-  const auto chunkBytes = encodeChunk(streamData, chunk, encodingBufferPool);
+  const auto chunkBytes = encodeChunk(
+      streamData, chunk, encodingScratchBufferPool, encodingBufferPool);
   streamSize += chunkBytes;
   chunkSize += chunkBytes;
   streamData.reset();
@@ -1431,6 +1536,7 @@ void VeloxWriter::encodeStream(
 
 void VeloxWriter::processStream(
     StreamData& streamData,
+    velox::BufferPool* encodingScratchBufferPool,
     EncodingBufferPool* encodingBufferPool,
     uint64_t& streamSize,
     std::atomic_uint64_t& chunkSize) {
@@ -1442,7 +1548,12 @@ void VeloxWriter::processStream(
     // boolean data.
     if (streamData.hasNullValues()) {
       NullsAsDataStreamData nullsStreamData{streamData};
-      encodeStream(nullsStreamData, encodingBufferPool, streamSize, chunkSize);
+      encodeStream(
+          nullsStreamData,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamSize,
+          chunkSize);
     }
   } else if (
       (context != nullptr) && context->isInMapStream() &&
@@ -1456,12 +1567,22 @@ void VeloxWriter::processStream(
     // skipConstantFlatMapInMapStreams to remain false.
     streamData.materialize();
     if (!isConstantBoolStream(streamData.data())) {
-      encodeStream(streamData, encodingBufferPool, streamSize, chunkSize);
+      encodeStream(
+          streamData,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamSize,
+          chunkSize);
     }
   } else {
     streamData.materialize();
     if (!streamData.data().empty()) {
-      encodeStream(streamData, encodingBufferPool, streamSize, chunkSize);
+      encodeStream(
+          streamData,
+          encodingScratchBufferPool,
+          encodingBufferPool,
+          streamSize,
+          chunkSize);
     }
   }
 }
@@ -1472,6 +1593,7 @@ bool VeloxWriter::encodeStreamChunk(
     uint64_t maxChunkSize,
     bool ensureFullChunks,
     Stream& encodedStream,
+    velox::BufferPool* encodingScratchBufferPool,
     EncodingBufferPool* encodingBufferPool,
     uint64_t& streamBytes,
     std::atomic_uint64_t& chunkBytes,
@@ -1489,8 +1611,8 @@ bool VeloxWriter::encodeStreamChunk(
   uint64_t encodedChunkBytes{0};
   while (auto chunkView = chunker->next()) {
     auto& streamChunk = streamChunks.emplace_back();
-    encodedChunkBytes +=
-        encodeChunk(*chunkView, streamChunk, encodingBufferPool);
+    encodedChunkBytes += encodeChunk(
+        *chunkView, streamChunk, encodingScratchBufferPool, encodingBufferPool);
     writtenChunk = true;
   }
   streamBytes += encodedChunkBytes;
@@ -1504,9 +1626,14 @@ bool VeloxWriter::encodeStreamChunk(
 uint32_t VeloxWriter::encodeChunk(
     const StreamData& chunkView,
     Chunk& chunk,
+    velox::BufferPool* encodingScratchBufferPool,
     EncodingBufferPool* encodingBufferPool) {
   std::string_view encoded = encodeStreamData(
-      *context_, *encodingBuffer_, encodingBufferPool, chunkView);
+      *context_,
+      *encodingBuffer_,
+      encodingScratchBufferPool,
+      encodingBufferPool,
+      chunkView);
   NIMBLE_DCHECK(!encoded.empty());
   if (encoded.empty()) {
     return 0;
@@ -1549,6 +1676,7 @@ bool VeloxWriter::writeChunks(
     const auto& streams = context_->streams();
     const auto streamCount = static_cast<uint32_t>(streamIndices.size());
     const auto concurrency = encodingConcurrency(streamCount);
+    ensureEncodingScratchBufferPools(concurrency);
     ensureEncodingBufferPools(concurrency);
 
     if (concurrency > 1) {
@@ -1564,10 +1692,13 @@ bool VeloxWriter::writeChunks(
           auto& [nodeId, streamData] = streams[streamIndex];
           const auto offset = streamData->descriptor().offset();
           auto* encodedStream = &encodedStreams_[offset];
+          auto* encodingScratchBufferPool =
+              this->encodingScratchBufferPool(index);
           auto* encodingBufferPool = this->encodingBufferPool(index);
           barrier.add([&,
                        streamData = streamData.get(),
                        encodedStream,
+                       encodingScratchBufferPool,
                        encodingBufferPool,
                        statsCollector = context_->getStatsCollector(nodeId)] {
             uint64_t startCpuNs = velox::process::threadCpuNanos();
@@ -1578,6 +1709,7 @@ bool VeloxWriter::writeChunks(
                     maxChunkSize,
                     ensureFullChunks,
                     *encodedStream,
+                    encodingScratchBufferPool,
                     encodingBufferPool,
                     streamSize,
                     chunkBytes,
@@ -1595,6 +1727,7 @@ bool VeloxWriter::writeChunks(
         barrier.waitAll();
       }
     } else {
+      auto* encodingScratchBufferPool = this->encodingScratchBufferPool();
       auto* encodingBufferPool = this->encodingBufferPool();
       for (auto streamIndex : streamIndices) {
         auto& [nodeId, streamData] = streams[streamIndex];
@@ -1608,6 +1741,7 @@ bool VeloxWriter::writeChunks(
                 maxChunkSize,
                 ensureFullChunks,
                 encodedStreams_[offset],
+                encodingScratchBufferPool,
                 encodingBufferPool,
                 streamSize,
                 chunkBytes,

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -21,6 +21,7 @@
 #include "dwio/nimble/velox/BufferPolicy.h"
 #include "dwio/nimble/velox/FieldWriter.h"
 #include "dwio/nimble/velox/VeloxWriterOptions.h"
+#include "velox/buffer/BufferPool.h"
 #include "velox/common/base/RuntimeMetrics.h"
 #include "velox/common/file/File.h"
 #include "velox/dwio/common/TypeWithId.h"
@@ -130,6 +131,7 @@ class VeloxWriter {
       uint64_t maxChunkSize,
       bool ensureFullChunks,
       Stream& stream,
+      velox::BufferPool* encodingScratchBufferPool,
       EncodingBufferPool* encodingBufferPool,
       uint64_t& streamBytes,
       std::atomic_uint64_t& chunkBytes,
@@ -140,16 +142,19 @@ class VeloxWriter {
   uint32_t encodeChunk(
       const StreamData& chunkView,
       Chunk& chunk,
+      velox::BufferPool* encodingScratchBufferPool,
       EncodingBufferPool* encodingBufferPool);
 
   void encodeStream(
       StreamData& streamData,
+      velox::BufferPool* encodingScratchBufferPool,
       EncodingBufferPool* encodingBufferPool,
       uint64_t& streamSize,
       std::atomic_uint64_t& chunkSize);
 
   void processStream(
       StreamData& streamData,
+      velox::BufferPool* encodingScratchBufferPool,
       EncodingBufferPool* encodingBufferPool,
       uint64_t& streamSize,
       std::atomic_uint64_t& chunkSize);
@@ -206,12 +211,19 @@ class VeloxWriter {
   void ensureEncodingBuffer();
   void clearEncodingBuffer();
 
-  // Nested encoding scratch pools. Pool 0 is used by sequential writes;
-  // parallel writes use one pool per concurrent encode task because the pool is
+  // Scratch vector buffer pools. Pool 0 is used by sequential writes; parallel
+  // writes use one pool per concurrent encode task because velox::BufferPool is
   // not thread-safe.
+  std::unique_ptr<velox::BufferPool> makeEncodingScratchBufferPool() const;
+
+  // Nested encoding buffer pools used by ScopedEncodingBuffer. Pool 0 is used
+  // by sequential writes; parallel writes use one pool per concurrent encode
+  // task because EncodingBufferPool is not thread-safe.
   std::unique_ptr<EncodingBufferPool> makeEncodingBufferPool() const;
   uint32_t encodingConcurrency(uint32_t taskCount) const;
+  void ensureEncodingScratchBufferPools(uint32_t poolCount);
   void ensureEncodingBufferPools(uint32_t poolCount);
+  velox::BufferPool* encodingScratchBufferPool(uint32_t index = 0);
   EncodingBufferPool* encodingBufferPool(uint32_t index = 0);
 
   void ensureWriteStreams();
@@ -231,6 +243,15 @@ class VeloxWriter {
 
   std::unique_ptr<FieldWriter> rootWriter_;
   std::unique_ptr<Buffer> encodingBuffer_;
+
+  // Per-encode-task scratch vector buffer caches. They are retained across
+  // flushes for reuse, cleared under memory arbitration, and released when the
+  // writer is destroyed.
+  std::vector<std::unique_ptr<velox::BufferPool>> encodingScratchBufferPools_;
+
+  // Per-encode-task temporary encoded-buffer caches used by
+  // ScopedEncodingBuffer. They follow the same lifetime as the scratch vector
+  // buffer caches above.
   std::vector<std::unique_ptr<EncodingBufferPool>> encodingBufferPools_;
   std::vector<Stream> encodedStreams_;
   std::exception_ptr lastException_;

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -207,6 +207,13 @@ struct VeloxWriterOptions {
   /// ALP is production-ready.
   bool allowNestedAlpSelection{false};
 
+  /// Maximum number of scratch vector buffers retained by each per-encode-task
+  /// scratch pool. 0 disables scratch vector buffer caching. Disabled by
+  /// default; benchmark callers can set a non-zero value to opt in. Memory is
+  /// bounded by cached buffer count, not bytes, and cached buffers are dropped
+  /// under memory arbitration.
+  uint32_t maxCachedEncodingScratchBuffers{0};
+
   /// Maximum number of scratch buffers retained by each nested encoding buffer
   /// pool. 0 disables nested encoding buffer caching. Disabled by default;
   /// callers can set a non-zero value to opt in.

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -564,7 +564,7 @@ TEST_F(VeloxWriterTest, mainlyConstantRoundTrip) {
   ASSERT_FALSE(reader.next(1, result));
 }
 
-DEBUG_ONLY_TEST_F(VeloxWriterTest, encodingBufferPoolPassedToEncodeOptions) {
+DEBUG_ONLY_TEST_F(VeloxWriterTest, encodingPoolsPassedToEncodeOptions) {
   velox::common::testutil::TestValue::enable();
 
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
@@ -583,65 +583,122 @@ DEBUG_ONLY_TEST_F(VeloxWriterTest, encodingBufferPoolPassedToEncodeOptions) {
 
   struct TestCase {
     const char* name;
+    uint32_t maxCachedEncodingScratchBuffers;
     bool setMaxCachedNestedEncodingBuffers;
     uint32_t maxCachedNestedEncodingBuffers;
     uint32_t maxEncodeParallelism;
+    bool expectEncodingScratchBufferPool;
     bool expectEncodingBufferPool;
-    size_t expectedPoolCount;
+    size_t expectedScratchPoolCount;
+    size_t expectedEncodingPoolCount;
   };
 
   for (const auto& testCase : std::vector<TestCase>{
            {
                .name = "default",
+               .maxCachedEncodingScratchBuffers = 0,
                .setMaxCachedNestedEncodingBuffers = false,
                .maxCachedNestedEncodingBuffers = 0,
                .maxEncodeParallelism = 0,
+               .expectEncodingScratchBufferPool = false,
                .expectEncodingBufferPool = false,
-               .expectedPoolCount = 0,
+               .expectedScratchPoolCount = 0,
+               .expectedEncodingPoolCount = 0,
            },
            {
-               .name = "cache disabled",
+               .name = "nested cache disabled",
+               .maxCachedEncodingScratchBuffers = 0,
                .setMaxCachedNestedEncodingBuffers = true,
                .maxCachedNestedEncodingBuffers = 0,
                .maxEncodeParallelism = 0,
+               .expectEncodingScratchBufferPool = false,
                .expectEncodingBufferPool = false,
-               .expectedPoolCount = 0,
+               .expectedScratchPoolCount = 0,
+               .expectedEncodingPoolCount = 0,
            },
            {
-               .name = "cache enabled",
+               .name = "encoding scratch cache enabled",
+               .maxCachedEncodingScratchBuffers = 1,
+               .setMaxCachedNestedEncodingBuffers = false,
+               .maxCachedNestedEncodingBuffers = 0,
+               .maxEncodeParallelism = 0,
+               .expectEncodingScratchBufferPool = true,
+               .expectEncodingBufferPool = false,
+               .expectedScratchPoolCount = 1,
+               .expectedEncodingPoolCount = 0,
+           },
+           {
+               .name = "nested cache enabled",
+               .maxCachedEncodingScratchBuffers = 0,
                .setMaxCachedNestedEncodingBuffers = true,
                .maxCachedNestedEncodingBuffers = 1,
                .maxEncodeParallelism = 0,
+               .expectEncodingScratchBufferPool = false,
                .expectEncodingBufferPool = true,
-               .expectedPoolCount = 1,
+               .expectedScratchPoolCount = 0,
+               .expectedEncodingPoolCount = 1,
            },
            {
-               .name = "parallel cache enabled",
+               .name = "parallel encoding scratch cache enabled",
+               .maxCachedEncodingScratchBuffers = 1,
+               .setMaxCachedNestedEncodingBuffers = false,
+               .maxCachedNestedEncodingBuffers = 0,
+               .maxEncodeParallelism = 2,
+               .expectEncodingScratchBufferPool = true,
+               .expectEncodingBufferPool = false,
+               .expectedScratchPoolCount = 2,
+               .expectedEncodingPoolCount = 0,
+           },
+           {
+               .name = "parallel nested cache enabled",
+               .maxCachedEncodingScratchBuffers = 0,
                .setMaxCachedNestedEncodingBuffers = true,
                .maxCachedNestedEncodingBuffers = 1,
                .maxEncodeParallelism = 2,
+               .expectEncodingScratchBufferPool = false,
                .expectEncodingBufferPool = true,
-               .expectedPoolCount = 2,
+               .expectedScratchPoolCount = 0,
+               .expectedEncodingPoolCount = 2,
+           },
+           {
+               .name = "parallel caches enabled",
+               .maxCachedEncodingScratchBuffers = 1,
+               .setMaxCachedNestedEncodingBuffers = true,
+               .maxCachedNestedEncodingBuffers = 1,
+               .maxEncodeParallelism = 2,
+               .expectEncodingScratchBufferPool = true,
+               .expectEncodingBufferPool = true,
+               .expectedScratchPoolCount = 2,
+               .expectedEncodingPoolCount = 2,
            },
        }) {
     SCOPED_TRACE(testCase.name);
 
     uint32_t encodeCount{0};
-    uint32_t pooledEncodeCount{0};
-    std::set<const void*> observedPools;
+    uint32_t pooledScratchEncodeCount{0};
+    uint32_t pooledEncodingBufferCount{0};
+    std::set<const void*> observedScratchPools;
+    std::set<const void*> observedEncodingBufferPools;
     SCOPED_TESTVALUE_SET(
         "facebook::nimble::VeloxWriter::encode",
         std::function<void(nimble::Encoding::Options*)>(
             [&](nimble::Encoding::Options* encodingOptions) {
               ++encodeCount;
+              if (encodingOptions->bufferPool != nullptr) {
+                ++pooledScratchEncodeCount;
+                observedScratchPools.insert(encodingOptions->bufferPool);
+              }
               if (encodingOptions->encodingBufferPool != nullptr) {
-                ++pooledEncodeCount;
-                observedPools.insert(encodingOptions->encodingBufferPool);
+                ++pooledEncodingBufferCount;
+                observedEncodingBufferPools.insert(
+                    encodingOptions->encodingBufferPool);
               }
             }));
 
     std::shared_ptr<folly::CPUThreadPoolExecutor> executor;
     nimble::VeloxWriterOptions options;
+    options.maxCachedEncodingScratchBuffers =
+        testCase.maxCachedEncodingScratchBuffers;
     if (testCase.setMaxCachedNestedEncodingBuffers) {
       options.maxCachedNestedEncodingBuffers =
           testCase.maxCachedNestedEncodingBuffers;
@@ -662,8 +719,14 @@ DEBUG_ONLY_TEST_F(VeloxWriterTest, encodingBufferPoolPassedToEncodeOptions) {
 
     EXPECT_GT(encodeCount, 0);
     EXPECT_EQ(
-        pooledEncodeCount, testCase.expectEncodingBufferPool ? encodeCount : 0);
-    EXPECT_EQ(observedPools.size(), testCase.expectedPoolCount);
+        pooledScratchEncodeCount,
+        testCase.expectEncodingScratchBufferPool ? encodeCount : 0);
+    EXPECT_EQ(
+        pooledEncodingBufferCount,
+        testCase.expectEncodingBufferPool ? encodeCount : 0);
+    EXPECT_EQ(observedScratchPools.size(), testCase.expectedScratchPoolCount);
+    EXPECT_EQ(
+        observedEncodingBufferPools.size(), testCase.expectedEncodingPoolCount);
   }
 }
 


### PR DESCRIPTION
Summary:

Add an op -in writer side scratch buffer cache for temporary vectors used during Nimble encoding.

Reviewed By: xiaoxmeng

Differential Revision: D114231357


