### PR TITLE
refactor(nimble): Drop redundant enableChunkIndex guard on per-chunk null count (#1052)

### DIFF
--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -1514,9 +1514,7 @@ uint32_t VeloxWriter::encodeChunk(
   uint32_t chunkBytes{0};
   chunk.rowCount = chunkView.rowCount();
   // Per-chunk null count, precomputed by the chunker.
-  if (context_->options().enableChunkIndex) {
-    chunk.nullCount = static_cast<uint32_t>(chunkView.numNulls());
-  }
+  chunk.nullCount = static_cast<uint32_t>(chunkView.numNulls());
   ChunkedStreamWriter chunkWriter{
       *encodingBuffer_, context_->options().chunkCompression};
   for (auto& buffer : chunkWriter.encode(encoded)) {

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -2808,6 +2808,34 @@ TEST_F(VeloxWriterTest, chunkNullCountsForStructNullStream) {
   EXPECT_EQ(6, totalChunkNullCount);
 }
 
+TEST_F(VeloxWriterTest, chunkStatsAbsentWhenChunkIndexDisabled) {
+  // encodeChunk sets chunk.nullCount unconditionally; the chunk stats section
+  // (and its null counts) must still be written only when the chunk index is
+  // enabled. With the index off, no section should be produced.
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto vec = vectorMaker.rowVector(
+      {"c1"}, {vectorMaker.flatVector<int32_t>({1, 2, 3})});
+  vec->setNull(1, /*isNull=*/true);
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriter writer(
+      vec->type(),
+      std::move(writeFile),
+      *rootPool_,
+      {.enableChunkIndex = false});
+  writer.write(vec);
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = nimble::TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+  ASSERT_EQ(1, tablet->stripeCount());
+  auto stripeIdentifier = tablet->stripeIdentifier(0);
+  EXPECT_EQ(stripeIdentifier.chunkStats(), nullptr)
+      << "no chunk stats section should be written when the index is disabled";
+}
+
 TEST_F(VeloxWriterTest, chunkedStreamsRowNoNullsNoChunks) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
 


### PR DESCRIPTION
Summary:

The null count is precomputed by the chunker (the StreamDataView carries it, so
numNulls() is O(1)) and is consumed only by ChunkStatsWriter, which exists only
when the chunk index is enabled. So the enableChunkIndex guard around
chunk.nullCount in VeloxWriter::encodeChunk saved nothing -- the count is
computed in the chunker regardless -- and only made nullCount look conditional
while chunk.rowCount right above it is unconditional. Drop it for consistency.

No behavior change: the null count is still written only when the index is on.

Reviewed By: xiaoxmeng

Differential Revision: D114275215


