### PR TITLE
feat(fuzzer): Add ALP, BlockBitPacking, and FSST to table evolution fuzzer encoding candidates

### DIFF
--- a/dwio/nimble/encodings/legacy/CMakeLists.txt
+++ b/dwio/nimble/encodings/legacy/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
 
 target_link_libraries(
   nimble_encodings_legacy
+  fsst
   velox_common_base
   Folly::folly
   absl::flat_hash_map

--- a/dwio/nimble/encodings/legacy/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/legacy/EncodingFactory.cpp
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
 #include "dwio/nimble/encodings/DeltaBlockEncoding.h"
+#include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
@@ -321,6 +323,28 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     case EncodingType::Huffman: {
       RETURN_ENCODING_BY_INTEGRAL_TYPE(
           ::facebook::nimble::HuffmanEncoding, dataType);
+    }
+    case EncodingType::ALP: {
+      switch (dataType) {
+        case DataType::Float:
+          return std::make_unique<::facebook::nimble::ALPEncoding<float>>(
+              memoryPool, data, stringBufferFactory);
+        case DataType::Double:
+          return std::make_unique<::facebook::nimble::ALPEncoding<double>>(
+              memoryPool, data, stringBufferFactory);
+        default:
+          NIMBLE_INCOMPATIBLE_ENCODING(
+              "ALP encoding only supports float and double data types, got {}.",
+              dataType);
+      }
+    }
+    case EncodingType::Fsst: {
+      NIMBLE_CHECK_EQ(
+          dataType,
+          DataType::String,
+          "Trying to deserialize a FsstEncoding with a non-string data type.");
+      return std::make_unique<::facebook::nimble::FsstEncoding>(
+          memoryPool, data, stringBufferFactory);
     }
     default: {
       NIMBLE_UNREACHABLE(

--- a/dwio/nimble/encodings/legacy/EncodingUtils.h
+++ b/dwio/nimble/encodings/legacy/EncodingUtils.h
@@ -15,7 +15,9 @@
  */
 #pragma once
 
+#include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/DeltaBlockEncoding.h"
+#include "dwio/nimble/encodings/FsstEncoding.h"
 #include "dwio/nimble/encodings/HuffmanEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
@@ -68,6 +70,8 @@ auto encodingTypeDispatchString(Encoding& encoding, F f) {
     case EncodingType::MainlyConstant:
       return f(
           static_cast<MainlyConstantEncoding<std::string_view>&>(encoding));
+    case EncodingType::Fsst:
+      return f(static_cast<::facebook::nimble::FsstEncoding&>(encoding));
     default:
       NIMBLE_UNSUPPORTED(toString(encoding.encodingType()));
   }
@@ -150,6 +154,14 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
             static_cast<::facebook::nimble::HuffmanEncoding<T>&>(encoding));
       } else {
         NIMBLE_UNREACHABLE("{}", encoding.dataType());
+      }
+    case EncodingType::ALP:
+      if constexpr (std::is_same_v<T, float> || std::is_same_v<T, double>) {
+        return f(static_cast<::facebook::nimble::ALPEncoding<T>&>(encoding));
+      } else {
+        NIMBLE_UNREACHABLE(
+            "ALP encoding only supports float and double data types, got {}.",
+            encoding.dataType());
       }
     // SubIntSplit integration commented out (disabled):
     /*

--- a/dwio/nimble/encodings/selection/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/selection/tests/CMakeLists.txt
@@ -19,5 +19,6 @@ add_library(
 target_link_libraries(
   nimble_random_encoding_selection_policy
   nimble_encodings
+  fsst
   Folly::folly
 )

--- a/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.cpp
+++ b/dwio/nimble/encodings/selection/tests/RandomEncodingSelectionPolicy.cpp
@@ -73,6 +73,9 @@ RandomEncodingSelectionPolicyFactory::defaultEncodingChoices() {
       EncodingType::Dictionary,
       EncodingType::RLE,
       EncodingType::Varint,
+      EncodingType::ALP,
+      EncodingType::BlockBitPacking,
+      EncodingType::Fsst,
   };
 }
 

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(
   TestUtils.cpp
   ../selection/tests/RandomEncodingSelectionPolicy.cpp
 )
-target_link_libraries(nimble_encodings_tests_utils nimble_encodings)
+target_link_libraries(nimble_encodings_tests_utils nimble_encodings fsst)
 
 add_library(nimble_encoding_layout_test_helper EncodingLayoutTestHelper.cpp)
 target_link_libraries(nimble_encoding_layout_test_helper nimble_encodings)


### PR DESCRIPTION
Summary:
- Add ALP, BlockBitPacking, and FSST to `RandomEncodingSelectionPolicyFactory::defaultEncodingChoices()` so they are automatically included in random encoding selection
- Fix legacy `EncodingFactory` to deserialize ALP and FSST encodings (missing cases caused "invalid EncodingType" on read)
- Fix legacy `EncodingUtils` dispatch to handle ALP (float/double) and FSST (string) encoding types
- Add `fsst` CMake dependency to legacy and test targets for `FsstEncoding.h` include

Reviewed By: HuamengJiang

Differential Revision: D114295784


