### PR TITLE
feat: Add file features for omitted cluster key storage (#1057)

### DIFF
--- a/dwio/nimble/tablet/CMakeLists.txt
+++ b/dwio/nimble/tablet/CMakeLists.txt
@@ -97,6 +97,22 @@ target_include_directories(
 add_dependencies(nimble_bloom_filter_fb nimble_bloom_filter_schema_fb)
 
 build_flatbuffers(
+  "${CMAKE_CURRENT_SOURCE_DIR}/Features.fbs"
+  ""
+  nimble_features_schema_fb
+  ""
+  "${CMAKE_CURRENT_BINARY_DIR}"
+  ""
+  ""
+)
+add_library(nimble_features_fb INTERFACE)
+target_include_directories(
+  nimble_features_fb
+  INTERFACE ${PROJECT_BINARY_DIR} ${FLATBUFFERS_INCLUDE_DIR}
+)
+add_dependencies(nimble_features_fb nimble_features_schema_fb)
+
+build_flatbuffers(
   "${CMAKE_CURRENT_SOURCE_DIR}/HashIndex.fbs"
   "${CMAKE_CURRENT_SOURCE_DIR}"
   nimble_hash_index_schema_fb
@@ -131,12 +147,14 @@ add_dependencies(nimble_sorted_index_fb nimble_sorted_index_schema_fb)
 add_library(
   nimble_tablet_common
   Compression.cpp
+  FileFeatures.cpp
   MetadataBuffer.cpp
   MetadataInput.cpp
   Postscript.cpp
 )
 target_link_libraries(
   nimble_tablet_common
+  nimble_features_fb
   nimble_footer_fb
   nimble_common
   velox_caching

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -36,5 +36,6 @@ constexpr std::string_view kVectorizedStatsSection =
     "columnar.vectorized_stats";
 constexpr std::string_view kIndexSection = "columnar.indexes";
 constexpr std::string_view kChunkStatsSection = "columnar.chunk.stats";
+constexpr std::string_view kFeaturesSection = "columnar.features";
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tablet/Features.fbs
+++ b/dwio/nimble/tablet/Features.fbs
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace facebook.nimble.serialization;
+
+/// Experimental compact encoding format switches. Missing table means all
+/// compact encoding switches are disabled.
+table CompactEncoding {
+  /// Whether encoded stream row counts use compact varint encoding.
+  row_count:bool = false;
+}
+
+/// File-level feature state needed by readers before feature-specific optional
+/// metadata is loaded.
+table Features {
+  /// Whether cluster index key columns were omitted from normal data storage.
+  cluster_index_key_column_storage_omitted:bool = false;
+
+  /// Cluster index key columns whose normal data streams are absent.
+  cluster_index_key_columns_with_omitted_storage:[string];
+
+  /// Experimental compact encoding state.
+  compact_encoding:CompactEncoding;
+}
+
+root_type Features;

--- a/dwio/nimble/tablet/FileFeatures.cpp
+++ b/dwio/nimble/tablet/FileFeatures.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/tablet/FileFeatures.h"
+
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/tablet/FeaturesGenerated.h"
+
+#include "flatbuffers/flatbuffers.h"
+
+#include <utility>
+
+namespace facebook::nimble {
+
+FileFeatures::FileFeatures(
+    bool compactRowCountEncoding,
+    bool clusterIndexKeyColumnStorageOmitted,
+    std::vector<std::string> clusterIndexKeyColumnsWithOmittedStorage)
+    : compactRowCountEncoding_{compactRowCountEncoding},
+      clusterIndexKeyColumnStorageOmitted_{clusterIndexKeyColumnStorageOmitted},
+      clusterIndexKeyColumnsWithOmittedStorage_{
+          std::move(clusterIndexKeyColumnsWithOmittedStorage)} {
+  NIMBLE_CHECK_EQ(
+      clusterIndexKeyColumnStorageOmitted_,
+      !clusterIndexKeyColumnsWithOmittedStorage_.empty(),
+      "clusterIndexKeyColumnStorageOmitted must match clusterIndexKeyColumnsWithOmittedStorage presence");
+}
+
+std::string FileFeatures::serialize() const {
+  flatbuffers::FlatBufferBuilder builder;
+
+  flatbuffers::Offset<serialization::CompactEncoding> compactEncodingOffset;
+  if (compactRowCountEncoding_) {
+    compactEncodingOffset =
+        serialization::CreateCompactEncoding(builder, compactRowCountEncoding_);
+  }
+
+  auto clusterIndexKeyColumnsWithOmittedStorage =
+      builder.CreateVector<flatbuffers::Offset<flatbuffers::String>>(
+          clusterIndexKeyColumnsWithOmittedStorage_.size(),
+          [this, &builder](size_t i) {
+            return builder.CreateString(
+                clusterIndexKeyColumnsWithOmittedStorage_[i]);
+          });
+
+  builder.Finish(
+      serialization::CreateFeatures(
+          builder,
+          clusterIndexKeyColumnStorageOmitted_,
+          clusterIndexKeyColumnsWithOmittedStorage,
+          compactEncodingOffset));
+
+  return std::string{
+      reinterpret_cast<const char*>(builder.GetBufferPointer()),
+      builder.GetSize()};
+}
+
+FileFeatures FileFeatures::deserialize(std::string_view data) {
+  const auto* serialized = flatbuffers::GetRoot<serialization::Features>(
+      reinterpret_cast<const uint8_t*>(data.data()));
+
+  bool compactRowCountEncoding{false};
+  if (const auto* serializedCompactEncoding = serialized->compact_encoding()) {
+    compactRowCountEncoding = serializedCompactEncoding->row_count();
+  }
+
+  std::vector<std::string> clusterIndexKeyColumnsWithOmittedStorage;
+  if (const auto* columns =
+          serialized->cluster_index_key_columns_with_omitted_storage()) {
+    clusterIndexKeyColumnsWithOmittedStorage.reserve(columns->size());
+    for (const auto* column : *columns) {
+      clusterIndexKeyColumnsWithOmittedStorage.push_back(column->str());
+    }
+  }
+  NIMBLE_CHECK_EQ(
+      serialized->cluster_index_key_column_storage_omitted(),
+      !clusterIndexKeyColumnsWithOmittedStorage.empty(),
+      "cluster_index_key_column_storage_omitted must match cluster_index_key_columns_with_omitted_storage presence");
+  return FileFeatures{
+      compactRowCountEncoding,
+      serialized->cluster_index_key_column_storage_omitted(),
+      std::move(clusterIndexKeyColumnsWithOmittedStorage)};
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/FileFeatures.h
+++ b/dwio/nimble/tablet/FileFeatures.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace facebook::nimble {
+
+/// File-level feature state that readers need before loading feature-specific
+/// optional metadata.
+class FileFeatures {
+ public:
+  FileFeatures(
+      bool compactRowCountEncoding,
+      bool clusterIndexKeyColumnStorageOmitted,
+      std::vector<std::string> clusterIndexKeyColumnsWithOmittedStorage);
+
+  /// Returns whether encoded stream row counts use compact varint encoding.
+  bool compactRowCountEncoding() const {
+    return compactRowCountEncoding_;
+  }
+
+  /// Returns whether cluster index key columns were omitted from data storage.
+  bool clusterIndexKeyColumnStorageOmitted() const {
+    return clusterIndexKeyColumnStorageOmitted_;
+  }
+
+  /// Returns cluster index key columns whose normal data streams are absent.
+  const std::vector<std::string>& clusterIndexKeyColumnsWithOmittedStorage()
+      const {
+    return clusterIndexKeyColumnsWithOmittedStorage_;
+  }
+
+  /// Serializes file features into the `columnar.features` optional section.
+  std::string serialize() const;
+
+  /// Deserializes the `columnar.features` optional section.
+  static FileFeatures deserialize(std::string_view data);
+
+ private:
+  bool compactRowCountEncoding_{false};
+  bool clusterIndexKeyColumnStorageOmitted_{false};
+  std::vector<std::string> clusterIndexKeyColumnsWithOmittedStorage_;
+};
+
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -280,6 +280,7 @@ void TabletReader::init(const Options& options) {
   loadSections(sections);
 
   initStripes(footerView, footerOffset);
+  initFeatures();
   initIndexDescriptors();
   initClusterIndex();
   initChunkStats(footerView, footerOffset);
@@ -405,6 +406,7 @@ bool TabletReader::initFromCache(const Options& options) {
   loadSections(sections);
 
   initStripes();
+  initFeatures();
   initIndexDescriptors();
   initClusterIndex();
   initChunkStats();
@@ -459,6 +461,11 @@ void TabletReader::cacheMetadata(
   if (auto* stripeGroups = footer->stripe_groups();
       stripeGroups != nullptr && stripeGroups->size() > 0) {
     cacheSection(toMetadataSection(stripeGroups->Get(0)));
+  }
+
+  if (auto featuresIt = optionalSections_.find(std::string{kFeaturesSection});
+      featuresIt != optionalSections_.end()) {
+    cacheSection(featuresIt->second);
   }
 
   if (clusterIndex_ != nullptr || denseIndexRegistry_ != nullptr) {
@@ -676,10 +683,20 @@ void TabletReader::initOptionalSections() {
   }
 }
 
+void TabletReader::initFeatures() {
+  auto section =
+      loadOptionalSection(std::string{kFeaturesSection}, /*keepCache=*/true);
+  if (!section.has_value()) {
+    return;
+  }
+
+  features_ = FileFeatures::deserialize(section->content());
+}
+
 std::vector<std::string> TabletReader::preloadSectionNames(
     const Options& options) const {
   std::vector<std::string> names;
-  names.reserve(options.preloadOptionalSections.size() + 1);
+  names.reserve(options.preloadOptionalSections.size() + 2);
   auto addName = [&names](std::string name) {
     if (std::find(names.begin(), names.end(), name) == names.end()) {
       names.emplace_back(std::move(name));
@@ -691,6 +708,7 @@ std::vector<std::string> TabletReader::preloadSectionNames(
   if (options.loadClusterIndex || options.loadDenseIndexes) {
     addName(std::string{kIndexSection});
   }
+  addName(std::string{kFeaturesSection});
   return names;
 }
 

--- a/dwio/nimble/tablet/TabletReader.h
+++ b/dwio/nimble/tablet/TabletReader.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 #include <span>
+#include <string>
 #include <vector>
 
 #include "dwio/nimble/common/Types.h"
@@ -32,6 +33,7 @@
 #include "dwio/nimble/index/IndexConstants.h"
 #include "dwio/nimble/index/IndexLookup.h"
 #include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/tablet/FileFeatures.h"
 #include "dwio/nimble/tablet/FileLayout.h"
 #include "dwio/nimble/tablet/MetadataBuffer.h"
 #include "dwio/nimble/tablet/MetadataCache.h"
@@ -256,6 +258,11 @@ class TabletReader {
   // Returns the cluster index if available, nullptr otherwise.
   const ClusterIndex* clusterIndex() const {
     return clusterIndex_.get();
+  }
+
+  /// Returns file-level feature state. Missing section means default features.
+  const FileFeatures& features() const {
+    return features_;
   }
 
   /// Finds the dense index matching the given columns, or nullptr if none.
@@ -487,6 +494,8 @@ class TabletReader {
   // Parses optional sections metadata from footer into optionalSections_ map.
   void initOptionalSections();
 
+  void initFeatures();
+
   // Returns the list of optional section names to preload: the user-specified
   // sections plus the index section if present.
   std::vector<std::string> preloadSectionNames(const Options& options) const;
@@ -553,6 +562,7 @@ class TabletReader {
   // Index related fields.
   std::vector<index::IndexDescriptor> indexDescriptors_;
   std::unique_ptr<ClusterIndex> clusterIndex_;
+  FileFeatures features_{false, false, {}};
 
   std::unique_ptr<index::DenseIndexRegistry> denseIndexRegistry_;
 

--- a/dwio/nimble/tablet/tests/CMakeLists.txt
+++ b/dwio/nimble/tablet/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 add_executable(
   nimble_tablet_tests
   CompressionTest.cpp
+  FileFeaturesTest.cpp
   FileLayoutTest.cpp
   MetadataBufferTest.cpp
   TabletTest.cpp

--- a/dwio/nimble/tablet/tests/FileFeaturesTest.cpp
+++ b/dwio/nimble/tablet/tests/FileFeaturesTest.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/tablet/FileFeatures.h"
+
+#include <gtest/gtest.h>
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
+#include "dwio/nimble/tablet/FeaturesGenerated.h"
+
+#include "flatbuffers/flatbuffers.h"
+
+#include <vector>
+
+namespace facebook::nimble {
+namespace {
+
+TEST(FileFeaturesTest, basic) {
+  FileFeatures features{/*compactRowCountEncoding=*/false,
+                        /*clusterIndexKeyColumnStorageOmitted=*/false,
+                        /*clusterIndexKeyColumnsWithOmittedStorage=*/{}};
+
+  const auto decoded = FileFeatures::deserialize(features.serialize());
+  EXPECT_FALSE(decoded.compactRowCountEncoding());
+  EXPECT_FALSE(decoded.clusterIndexKeyColumnStorageOmitted());
+  EXPECT_TRUE(decoded.clusterIndexKeyColumnsWithOmittedStorage().empty());
+}
+
+TEST(FileFeaturesTest, roundTripKeyColumnsWithOmittedStorage) {
+  FileFeatures features{
+      /*compactRowCountEncoding=*/false,
+      /*clusterIndexKeyColumnStorageOmitted=*/true,
+      /*clusterIndexKeyColumnsWithOmittedStorage=*/{"key0", "key1"}};
+
+  const auto decoded = FileFeatures::deserialize(features.serialize());
+  EXPECT_FALSE(decoded.compactRowCountEncoding());
+  EXPECT_TRUE(decoded.clusterIndexKeyColumnStorageOmitted());
+  EXPECT_EQ(
+      decoded.clusterIndexKeyColumnsWithOmittedStorage(),
+      (std::vector<std::string>{"key0", "key1"}));
+}
+
+TEST(FileFeaturesTest, roundTripCompactRowCountEncoding) {
+  FileFeatures enabled{/*compactRowCountEncoding=*/true,
+                       /*clusterIndexKeyColumnStorageOmitted=*/false,
+                       /*clusterIndexKeyColumnsWithOmittedStorage=*/{}};
+
+  auto decoded = FileFeatures::deserialize(enabled.serialize());
+  EXPECT_TRUE(decoded.compactRowCountEncoding());
+
+  FileFeatures disabled{/*compactRowCountEncoding=*/false,
+                        /*clusterIndexKeyColumnStorageOmitted=*/false,
+                        /*clusterIndexKeyColumnsWithOmittedStorage=*/{}};
+
+  decoded = FileFeatures::deserialize(disabled.serialize());
+  EXPECT_FALSE(decoded.compactRowCountEncoding());
+}
+
+TEST(FileFeaturesTest, rejectsConstructedOmittedStorageWithoutColumns) {
+  NIMBLE_ASSERT_THROW(
+      FileFeatures(
+          /*compactRowCountEncoding=*/false,
+          /*clusterIndexKeyColumnStorageOmitted=*/true,
+          /*clusterIndexKeyColumnsWithOmittedStorage=*/{}),
+      "clusterIndexKeyColumnStorageOmitted must match clusterIndexKeyColumnsWithOmittedStorage presence");
+
+  NIMBLE_ASSERT_THROW(
+      FileFeatures(
+          /*compactRowCountEncoding=*/false,
+          /*clusterIndexKeyColumnStorageOmitted=*/false,
+          /*clusterIndexKeyColumnsWithOmittedStorage=*/{"key0"}),
+      "clusterIndexKeyColumnStorageOmitted must match clusterIndexKeyColumnsWithOmittedStorage presence");
+}
+
+TEST(FileFeaturesTest, rejectsOmittedStorageWithoutColumns) {
+  auto serialized =
+      [](bool clusterIndexKeyColumnStorageOmitted,
+         std::vector<std::string> clusterIndexKeyColumnsWithOmittedStorage) {
+        flatbuffers::FlatBufferBuilder builder;
+        auto columns =
+            builder.CreateVector<flatbuffers::Offset<flatbuffers::String>>(
+                clusterIndexKeyColumnsWithOmittedStorage.size(),
+                [&builder,
+                 &clusterIndexKeyColumnsWithOmittedStorage](size_t i) {
+                  return builder.CreateString(
+                      clusterIndexKeyColumnsWithOmittedStorage[i]);
+                });
+        builder.Finish(
+            serialization::CreateFeatures(
+                builder,
+                clusterIndexKeyColumnStorageOmitted,
+                columns,
+                /*compact_encoding=*/0));
+
+        return std::string{
+            reinterpret_cast<const char*>(builder.GetBufferPointer()),
+            builder.GetSize()};
+      };
+
+  struct Case {
+    bool clusterIndexKeyColumnStorageOmitted;
+    std::vector<std::string> clusterIndexKeyColumnsWithOmittedStorage;
+  };
+  const std::vector<Case> cases{{true, {}}, {false, {"key0"}}};
+  for (const auto& testCase : cases) {
+    SCOPED_TRACE(
+        testing::Message() << "clusterIndexKeyColumnStorageOmitted="
+                           << testCase.clusterIndexKeyColumnStorageOmitted);
+    NIMBLE_ASSERT_THROW(
+        FileFeatures::deserialize(serialized(
+            testCase.clusterIndexKeyColumnStorageOmitted,
+            testCase.clusterIndexKeyColumnsWithOmittedStorage)),
+        "cluster_index_key_column_storage_omitted must match cluster_index_key_columns_with_omitted_storage presence");
+  }
+}
+
+} // namespace
+} // namespace facebook::nimble

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -31,6 +31,7 @@
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/TestUtils.h"
 #include "dwio/nimble/index/ChunkStatsGroup.h"
+#include "dwio/nimble/index/ClusterIndexConfig.h"
 #include "dwio/nimble/index/HashIndexConfig.h"
 #include "dwio/nimble/index/IndexLookup.h"
 #include "dwio/nimble/index/SortedIndexConfig.h"
@@ -4207,6 +4208,49 @@ TEST_P(TabletWithIndexTest, loadDenseIndexes) {
       EXPECT_EQ(indexIoStats->rawBytesRead(), 0);
     }
   }
+}
+
+TEST_P(TabletTest, features) {
+  auto type =
+      velox::ROW({{"id", velox::INTEGER()}, {"value", velox::INTEGER()}});
+  auto ids = velox::BaseVector::create(velox::INTEGER(), 3, pool_.get());
+  auto values = velox::BaseVector::create(velox::INTEGER(), 3, pool_.get());
+  auto* flatIds = ids->asFlatVector<int32_t>();
+  auto* flatValues = values->asFlatVector<int32_t>();
+  for (int i = 0; i < 3; ++i) {
+    flatIds->set(i, i);
+    flatValues->set(i, i * 10);
+  }
+  auto batch = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      type,
+      nullptr,
+      3,
+      std::vector<velox::VectorPtr>{ids, values});
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  nimble::VeloxWriterOptions writerOptions;
+  writerOptions.experimentalCompactRowCountEncoding = true;
+  writerOptions.clusterIndexConfig =
+      nimble::index::ClusterIndexConfigBuilder{}
+          .withKeyColumns({"id"})
+          .withSortOrders({SortOrder{.ascending = true}})
+          .withEnforceKeyOrder(true)
+          .build();
+  writerOptions.experimentalOmitClusterIndexKeyColumnStorage = true;
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *pool_, std::move(writerOptions));
+  writer.write(batch);
+  writer.close();
+
+  auto tablet = createTabletReader(file);
+
+  EXPECT_TRUE(tablet->features().compactRowCountEncoding());
+  EXPECT_TRUE(tablet->features().clusterIndexKeyColumnStorageOmitted());
+  EXPECT_EQ(
+      tablet->features().clusterIndexKeyColumnsWithOmittedStorage(),
+      (std::vector<std::string>{"id"}));
 }
 
 TEST_P(TabletWithIndexTest, loadDenseIndexesMissingIoStats) {

--- a/dwio/nimble/velox/NimbleConfig.cpp
+++ b/dwio/nimble/velox/NimbleConfig.cpp
@@ -362,6 +362,10 @@ std::map<uint64_t, float> parseGrowthConfigMap(const std::string& str) {
     "nimble.index.max_rows_per_key_chunk",
     10'000);
 
+/* static */ Config::Entry<bool> Config::INDEX_OMIT_KEY_COLUMN_STORAGE(
+    "nimble.index.omit_key_column_storage",
+    false);
+
 // EXPERIMENTAL: BlockBitPacking encoding is not production-ready. Do not
 // enable for production tables without consulting the Nimble team
 // (oncall: dwios).

--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -129,6 +129,13 @@ class Config : public velox::config::ConfigBase {
   /// chunk per partition), which can hang on large tables. Default: 10000.
   static Entry<uint64_t> INDEX_MAX_ROWS_PER_KEY_CHUNK;
 
+  /// Whether cluster index key columns are omitted from normal data storage.
+  /// The columns must still be present in write input batches.
+  /// EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
+  /// production tables without consulting the Nimble team (oncall: dwios).
+  // @lint-ignore CLANGTIDY facebook-hte-NonPodStaticDeclaration
+  static Entry<bool> INDEX_OMIT_KEY_COLUMN_STORAGE;
+
   // EXPERIMENTAL: BlockBitPacking encoding is not production-ready. Do not
   // enable for production tables without consulting the Nimble team
   // (oncall: dwios).

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -19,17 +19,20 @@
 #include <memory>
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/index/ClusterIndexConfig.h"
 #include "dwio/nimble/index/ClusterIndexFactory.h"
 #include "dwio/nimble/index/DenseIndexFactory.h"
 #include "dwio/nimble/index/HashIndexWriter.h"
 #include "dwio/nimble/index/IndexSerialization.h"
 #include "dwio/nimble/index/SortedIndexWriter.h"
 #include "dwio/nimble/tablet/Constants.h"
+#include "dwio/nimble/tablet/FileFeatures.h"
 #include "dwio/nimble/tablet/IndexGenerated.h"
 #include "dwio/nimble/velox/BufferGrowthPolicy.h"
 #include "dwio/nimble/velox/ChunkedStreamWriter.h"
@@ -45,6 +48,7 @@
 #include "dwio/nimble/velox/StatsGenerated.h"
 #include "dwio/nimble/velox/StreamChunker.h"
 #include "dwio/nimble/velox/stats/VectorizedStatistics.h"
+#include "folly/container/F14Map.h"
 #include "velox/common/memory/MemoryArbitrator.h"
 #include "velox/common/testutil/TestValue.h"
 #include "velox/common/time/CpuWallTimer.h"
@@ -231,10 +235,184 @@ class WriterContext : public FieldWriterContext {
 
 namespace {
 
+using SchemaAttributeValues = std::vector<std::pair<std::string, std::string>>;
+using SchemaAttributes = folly::F14FastMap<uint32_t, SchemaAttributeValues>;
+
 std::string_view asView(const flatbuffers::FlatBufferBuilder& builder) {
   return {
       reinterpret_cast<const char*>(builder.GetBufferPointer()),
       builder.GetSize()};
+}
+
+const index::ClusterIndexConfig& clusterIndexConfig(
+    const VeloxWriterOptions& options) {
+  NIMBLE_USER_CHECK_NOT_NULL(
+      options.clusterIndexConfig,
+      "Cluster index key column storage can only be omitted when cluster index is enabled");
+  return index::checkedIndexConfig<index::ClusterIndexConfig>(
+      *options.clusterIndexConfig);
+}
+
+bool omitClusterIndexKeyColumnStorage(const VeloxWriterOptions& options) {
+  if (!options.experimentalOmitClusterIndexKeyColumnStorage) {
+    return false;
+  }
+  NIMBLE_USER_CHECK_NOT_NULL(
+      options.clusterIndexConfig,
+      "Cluster index key column storage can only be omitted when cluster index is enabled");
+  return true;
+}
+
+std::vector<velox::column_index_t> storedInputColumnIndices(
+    const velox::TypePtr& type,
+    const VeloxWriterOptions& options) {
+  NIMBLE_USER_CHECK(
+      omitClusterIndexKeyColumnStorage(options),
+      "storedInputColumnIndices is only used when cluster index key column storage is omitted");
+
+  const auto rowType = velox::asRowType(type);
+  std::vector<velox::column_index_t> indices;
+  indices.reserve(rowType->size());
+
+  const auto& indexOptions = clusterIndexConfig(options);
+  std::unordered_set<std::string> keyColumns;
+  keyColumns.reserve(indexOptions.columns.size());
+  for (const auto& column : indexOptions.columns) {
+    NIMBLE_USER_CHECK(
+        rowType->containsChild(column),
+        "Cluster index key column '{}' not found in input schema: {}",
+        column,
+        rowType->toString());
+    keyColumns.insert(column);
+  }
+
+  for (auto i = 0; i < rowType->size(); ++i) {
+    if (keyColumns.find(rowType->nameOf(i)) == keyColumns.end()) {
+      indices.push_back(i);
+    }
+  }
+  return indices;
+}
+
+velox::RowTypePtr storedDataType(
+    const velox::TypePtr& type,
+    const VeloxWriterOptions& options) {
+  if (!omitClusterIndexKeyColumnStorage(options)) {
+    return velox::asRowType(type);
+  }
+
+  const auto rowType = velox::asRowType(type);
+  const auto indices = storedInputColumnIndices(type, options);
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+  names.reserve(indices.size());
+  types.reserve(indices.size());
+  for (auto index : indices) {
+    names.push_back(rowType->nameOf(index));
+    types.push_back(rowType->childAt(index));
+  }
+  return velox::ROW(std::move(names), std::move(types));
+}
+
+void mapSchemaAttributeNode(
+    const velox::dwio::common::TypeWithId& inputNode,
+    const velox::dwio::common::TypeWithId& storedNode,
+    const SchemaAttributes& inputAttributes,
+    SchemaAttributes& remappedAttributes) {
+  // schemaAttributes is sparse; nodes without caller-provided attributes are
+  // intentionally skipped.
+  auto it = inputAttributes.find(inputNode.id());
+  if (it != inputAttributes.end()) {
+    remappedAttributes[storedNode.id()] = it->second;
+  }
+
+  NIMBLE_CHECK_EQ(
+      inputNode.size(),
+      storedNode.size(),
+      "Stored schema subtree must match input schema subtree");
+  for (auto i = 0; i < inputNode.size(); ++i) {
+    mapSchemaAttributeNode(
+        *inputNode.childAt(i),
+        *storedNode.childAt(i),
+        inputAttributes,
+        remappedAttributes);
+  }
+}
+
+SchemaAttributes remapSchemaAttributes(
+    const velox::TypePtr& inputType,
+    const velox::TypePtr& storedType,
+    const std::vector<velox::column_index_t>& storedInputColumnIndices,
+    const SchemaAttributes& inputAttributes) {
+  const auto input = velox::dwio::common::TypeWithId::create(inputType);
+  const auto stored = velox::dwio::common::TypeWithId::create(storedType);
+  SchemaAttributes remappedAttributes;
+
+  auto rootAttributes = inputAttributes.find(input->id());
+  if (rootAttributes != inputAttributes.end()) {
+    remappedAttributes[stored->id()] = rootAttributes->second;
+  }
+  for (auto storedIndex = 0; storedIndex < storedInputColumnIndices.size();
+       ++storedIndex) {
+    mapSchemaAttributeNode(
+        *input->childAt(storedInputColumnIndices[storedIndex]),
+        *stored->childAt(storedIndex),
+        inputAttributes,
+        remappedAttributes);
+  }
+  return remappedAttributes;
+}
+
+VeloxWriterOptions storedWriterOptions(
+    const velox::TypePtr& inputType,
+    const velox::TypePtr& storedType,
+    const std::vector<velox::column_index_t>& storedInputColumnIndices,
+    VeloxWriterOptions options) {
+  if (!omitClusterIndexKeyColumnStorage(options)) {
+    return options;
+  }
+
+  if (!options.schemaAttributes.empty()) {
+    // schemaAttributes is keyed by input TypeWithId ids, while field writers
+    // are built from storedDataType(). When key columns are omitted, stored
+    // TypeWithId ids can differ from input ids, so attributes such as Iceberg
+    // field ids must be translated to the matching stored schema nodes.
+    options.schemaAttributes = remapSchemaAttributes(
+        inputType,
+        storedType,
+        storedInputColumnIndices,
+        options.schemaAttributes);
+  }
+
+  if (!options.featureReordering.has_value()) {
+    return options;
+  }
+
+  // Field writers and the layout planner are built from storedDataType().
+  // When key columns are omitted, stored column ordinals can differ from input
+  // ordinals, so feature reordering must be translated to stored ordinals
+  // before it reaches the layout planner.
+  folly::F14FastMap<velox::column_index_t, size_t> storedIndexByInputIndex;
+  storedIndexByInputIndex.reserve(storedInputColumnIndices.size());
+  for (auto storedIndex = 0; storedIndex < storedInputColumnIndices.size();
+       ++storedIndex) {
+    storedIndexByInputIndex.emplace(
+        storedInputColumnIndices[storedIndex], storedIndex);
+  }
+
+  std::vector<std::tuple<size_t, std::vector<int64_t>>> remapped;
+  remapped.reserve(options.featureReordering->size());
+  for (auto& [originalIndex, keys] : *options.featureReordering) {
+    auto it = storedIndexByInputIndex.find(originalIndex);
+    NIMBLE_USER_CHECK(
+        it != storedIndexByInputIndex.end(),
+        "Feature reordering cannot target hidden cluster index key column at index {}",
+        originalIndex);
+    remapped.emplace_back(it->second, std::move(keys));
+  }
+  options.featureReordering = std::move(remapped);
+
+  return options;
 }
 
 void writeIndexSection(
@@ -919,8 +1097,13 @@ VeloxWriter::VeloxWriter(
     std::unique_ptr<velox::WriteFile> file,
     velox::memory::MemoryPool& pool,
     VeloxWriterOptions options)
-    : schema_{velox::dwio::common::TypeWithId::create(type)},
-      writerMemoryPool_{MemoryPoolHolder::create(
+    : storedDataType_{storedDataType(type, options)},
+      storedInputColumnIndices_{
+          omitClusterIndexKeyColumnStorage(options)
+              ? storedInputColumnIndices(type, options)
+              : std::vector<velox::column_index_t>{}},
+      schema_{velox::dwio::common::TypeWithId::create(storedDataType_)},
+      pool_{MemoryPoolHolder::create(
           pool,
           [&](auto& pool) {
             return pool.addAggregateChild(
@@ -928,14 +1111,18 @@ VeloxWriter::VeloxWriter(
                 options.reclaimerFactory());
           })},
       encodingMemoryPool_{MemoryPoolHolder::create(
-          *writerMemoryPool_,
+          *pool_,
           [&](auto& pool) {
             return pool.addLeafChild(
                 "encoding", true, options.reclaimerFactory());
           })},
       context_{std::make_unique<detail::WriterContext>(
-          *writerMemoryPool_,
-          std::move(options))},
+          *pool_,
+          storedWriterOptions(
+              type,
+              storedDataType_,
+              storedInputColumnIndices_,
+              std::move(options)))},
       file_{std::move(file)},
       clusterIndexWriter_{createClusterIndexWriter(
           context_->options(),
@@ -986,6 +1173,7 @@ VeloxWriter::VeloxWriter(
                    const WriteDataFn& writeDataFn,
                    const CreateMetadataSectionFn& createMetadataFn,
                    const WriteOptionalSectionFn& writeMetadataFn) {
+                 writeFeatures(writeMetadataFn);
                  writeIndexes(writeDataFn, createMetadataFn, writeMetadataFn);
                }})},
       bufferPolicy_{
@@ -1088,6 +1276,7 @@ bool VeloxWriter::flushInputBuffers(bool finalize) {
 
 void VeloxWriter::writeBatch(const velox::VectorPtr& input) {
   const auto numRows = input->size();
+  const auto storedData = storedDataInput(input);
   // When enableStatsConsistencyCheck is true, compute raw size using
   // RawSizeUtils to verify consistency with column statistics.
   // Otherwise, skip this computation as column statistics will provide
@@ -1100,7 +1289,7 @@ void VeloxWriter::writeBatch(const velox::VectorPtr& input) {
     // passthrough flatmaps.
     RawSizeContext context;
     const auto rawSize = nimble::getRawSizeFromVector(
-        input,
+        storedData,
         velox::common::Ranges::of(0, numRows),
         context,
         schema_.get(),
@@ -1112,7 +1301,7 @@ void VeloxWriter::writeBatch(const velox::VectorPtr& input) {
 
   {
     velox::CpuWallTimer ingestionTimer{context_->ingestionTiming()};
-    rootWriter_->write(input, OrderedRanges::of(0, numRows));
+    rootWriter_->write(storedData, OrderedRanges::of(0, numRows));
   }
   addIndexKey(input);
 
@@ -1125,6 +1314,28 @@ void VeloxWriter::writeBatch(const velox::VectorPtr& input) {
   context_->updateRowsInFile(numRows);
   context_->updateRowsInStripe(numRows);
   context_->setBytesWritten(file_->size());
+}
+
+velox::VectorPtr VeloxWriter::storedDataInput(
+    const velox::VectorPtr& input) const {
+  if (!omitClusterIndexKeyColumnStorage(context_->options())) {
+    return input;
+  }
+
+  auto loaded = velox::BaseVector::loadedVectorShared(input);
+  auto rowInput = velox::checkedPointerCast<const velox::RowVector>(loaded);
+
+  std::vector<velox::VectorPtr> children;
+  children.reserve(storedInputColumnIndices_.size());
+  for (auto index : storedInputColumnIndices_) {
+    children.push_back(rowInput->childAt(index));
+  }
+  return std::make_shared<velox::RowVector>(
+      pool_.get(),
+      velox::asRowType(storedDataType_),
+      loaded->nulls(),
+      loaded->size(),
+      std::move(children));
 }
 
 void VeloxWriter::writeMetadata() {
@@ -1193,6 +1404,30 @@ void VeloxWriter::addIndexKey(const velox::VectorPtr& input) {
   for (const auto& denseIndex : denseIndexWriters_) {
     denseIndex.writer->write(input);
   }
+}
+
+void VeloxWriter::writeFeatures(const WriteOptionalSectionFn& writeMetadataFn) {
+  const bool compactRowCountEncoding =
+      context_->options().experimentalCompactRowCountEncoding;
+  bool clusterIndexKeyColumnStorageOmitted{false};
+  std::vector<std::string> clusterIndexKeyColumnsWithOmittedStorage;
+  if (omitClusterIndexKeyColumnStorage(context_->options())) {
+    const auto& indexOptions = clusterIndexConfig(context_->options());
+    clusterIndexKeyColumnStorageOmitted = true;
+    clusterIndexKeyColumnsWithOmittedStorage = indexOptions.columns;
+  }
+
+  if (!compactRowCountEncoding && !clusterIndexKeyColumnStorageOmitted) {
+    return;
+  }
+
+  const auto serialized =
+      FileFeatures{
+          compactRowCountEncoding,
+          clusterIndexKeyColumnStorageOmitted,
+          std::move(clusterIndexKeyColumnsWithOmittedStorage)}
+          .serialize();
+  writeMetadataFn(std::string(kFeaturesSection), serialized);
 }
 
 void VeloxWriter::writeIndexes(

--- a/dwio/nimble/velox/VeloxWriter.h
+++ b/dwio/nimble/velox/VeloxWriter.h
@@ -116,6 +116,14 @@ class VeloxWriter {
   // Adds index keys to all configured index writers.
   void addIndexKey(const velox::VectorPtr& input);
 
+  void writeFeatures(const WriteOptionalSectionFn& writeMetadataFn);
+
+  // Returns the vector written to data streams. When cluster index key column
+  // storage is omitted, this is a top-level row projection excluding key
+  // columns; index writers still consume the original input. In that mode,
+  // write input must load to a top-level RowVector.
+  velox::VectorPtr storedDataInput(const velox::VectorPtr& input) const;
+
   bool shouldFlush(FlushPolicy* policy) const;
 
   bool shouldChunk(FlushPolicy* policy) const;
@@ -229,8 +237,15 @@ class VeloxWriter {
   void ensureWriteStreams();
   void resetFieldWriter();
 
+  // Schema used to build normal data stream writers. Usually the input schema;
+  // when cluster index key column storage is omitted, excludes the key columns
+  // so no normal data streams are created for them.
+  const velox::TypePtr storedDataType_;
+  // Input column indices retained in storedDataType_. Empty unless key column
+  // storage is omitted.
+  const std::vector<velox::column_index_t> storedInputColumnIndices_;
   const std::shared_ptr<const velox::dwio::common::TypeWithId> schema_;
-  MemoryPoolHolder writerMemoryPool_;
+  MemoryPoolHolder pool_;
   MemoryPoolHolder encodingMemoryPool_;
   const std::unique_ptr<detail::WriterContext> context_;
   std::unique_ptr<velox::WriteFile> file_;

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -46,6 +46,7 @@ struct VeloxWriterOptions {
   /// Builds Encoding::Options from VeloxWriterOptions fields.
   Encoding::Options buildEncodingOptions() const {
     return {
+        .useVarintRowCount = experimentalCompactRowCountEncoding,
         .blockBitPackingBlockSize = blockBitPackingBlockSize,
         .fixedBitWidthUseExactBits = fixedBitWidthUseExactBits,
         .allowNestedAlpSelection = allowNestedAlpSelection,
@@ -101,6 +102,20 @@ struct VeloxWriterOptions {
   /// EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
   /// production tables without consulting the Nimble team (oncall: dwios).
   std::shared_ptr<const index::IndexConfig> clusterIndexConfig;
+
+  /// Whether to omit cluster index key columns from normal data storage. The
+  /// key columns must still be present in write input batches.
+  /// EXPERIMENTAL: Cluster index is not production-ready. Do not enable for
+  /// production tables without consulting the Nimble team (oncall: dwios).
+  bool experimentalOmitClusterIndexKeyColumnStorage{false};
+
+  /// Enables compact varint row-count encoding for encoded data streams. The
+  /// value is persisted in file features so readers can select the matching
+  /// decoding behavior.
+  /// EXPERIMENTAL: Compact row-count encoding is not production-ready. Do not
+  /// enable for production tables without consulting the Nimble team (oncall:
+  /// dwios).
+  bool experimentalCompactRowCountEncoding{false};
 
   /// Dense index configurations, grouped by factory name. Each factory creates
   /// one writer that may produce multiple logical indexes.

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.cpp
@@ -21,7 +21,6 @@
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/legacy/EncodingFactory.h"
 #include "dwio/nimble/index/ClusterIndex.h"
-#include "dwio/nimble/velox/SchemaUtils.h"
 #include "dwio/nimble/velox/selective/ColumnReader.h"
 #include "dwio/nimble/velox/selective/ReaderBase.h"
 #include "dwio/nimble/velox/selective/RowSizeTracker.h"
@@ -35,25 +34,10 @@ using RuntimeCounter = velox::RuntimeCounter;
 
 namespace {
 
-// Converts index column names from nimble schema (internal file names) to
-// file schema (user-facing names).
-std::vector<std::string> convertIndexColumnsToFileSchema(
-    const std::vector<std::string>& nimbleIndexColumns,
-    const std::shared_ptr<const Type>& nimbleSchema,
-    const RowTypePtr& fileSchema) {
-  const auto nimbleRowType = asRowType(convertToVeloxType(*nimbleSchema));
-  std::vector<std::string> convertedIndexColumns;
-  convertedIndexColumns.reserve(nimbleIndexColumns.size());
-  for (const auto& nimbleColName : nimbleIndexColumns) {
-    const auto colIndex = nimbleRowType->getChildIdxIfExists(nimbleColName);
-    NIMBLE_CHECK(
-        colIndex.has_value(),
-        "Index column '{}' not found in nimble schema: {}",
-        nimbleColName,
-        nimbleRowType->toString());
-    convertedIndexColumns.push_back(fileSchema->nameOf(colIndex.value()));
-  }
-  return convertedIndexColumns;
+Encoding::Options encodingOptions(const TabletReader& tablet) {
+  Encoding::Options options;
+  options.useVarintRowCount = tablet.features().compactRowCountEncoding();
+  return options;
 }
 
 // Converts nimble SortOrders to velox::core::SortOrders.
@@ -150,8 +134,10 @@ SelectiveNimbleIndexReader::SelectiveNimbleIndexReader(
       options_(options),
       encodingFactory_(
           options.stringDecoderZeroCopy()
-              ? std::make_unique<const EncodingFactory>()
-              : std::make_unique<const legacy::EncodingFactory>()),
+              ? std::make_unique<const EncodingFactory>(
+                    encodingOptions(readerBase_->tablet()))
+              : std::make_unique<const legacy::EncodingFactory>(
+                    encodingOptions(readerBase_->tablet()))),
       rowSizeTracker_(
           std::make_unique<RowSizeTracker>(readerBase_->fileSchemaWithId())),
       hasFilters_(options.scanSpec()->hasFilter()),
@@ -163,10 +149,6 @@ SelectiveNimbleIndexReader::SelectiveNimbleIndexReader(
           readerBase_->fileSchema(),
           *options.scanSpec())),
       clusterIndex_{readerBase_->tablet().clusterIndex()},
-      indexColumns_{convertIndexColumnsToFileSchema(
-          clusterIndex_->indexColumns(),
-          readerBase_->nimbleSchema(),
-          readerBase_->fileSchema())},
       streams_{readerBase_},
       numStripes_{static_cast<int32_t>(readerBase_->tablet().stripeCount())},
       stats_{

--- a/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
+++ b/dwio/nimble/velox/selective/SelectiveNimbleIndexReader.h
@@ -282,7 +282,6 @@ class SelectiveNimbleIndexReader : public velox::dwio::common::IndexReader {
   const velox::RowTypePtr fileOutputType_;
 
   const ClusterIndex* const clusterIndex_;
-  const std::vector<std::string> indexColumns_;
 
   StripeStreams streams_;
   int32_t numStripes_{0};

--- a/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
+++ b/dwio/nimble/velox/selective/SelectiveNimbleReader.cpp
@@ -44,6 +44,12 @@ using namespace facebook::velox;
 
 namespace {
 
+Encoding::Options encodingOptions(const TabletReader& tablet) {
+  Encoding::Options options;
+  options.useVarintRowCount = tablet.features().compactRowCountEncoding();
+  return options;
+}
+
 // Converts index column names from nimble schema (internal file names) to
 // file schema (user-facing names). The nimble schema and file schema have
 // the same structure but potentially different column names due to the
@@ -124,8 +130,10 @@ class SelectiveNimbleRowReader : public dwio::common::RowReader {
         options_{options},
         encodingFactory_(
             options.stringDecoderZeroCopy()
-                ? std::make_unique<const EncodingFactory>()
-                : std::make_unique<const legacy::EncodingFactory>()),
+                ? std::make_unique<const EncodingFactory>(
+                      encodingOptions(readerBase_->tablet()))
+                : std::make_unique<const legacy::EncodingFactory>(
+                      encodingOptions(readerBase_->tablet()))),
         streams_(readerBase_),
         rowSizeTracker_{
             std::make_unique<RowSizeTracker>(readerBase->fileSchemaWithId())} {
@@ -685,6 +693,9 @@ class SelectiveNimbleReader : public dwio::common::Reader {
       const dwio::common::RowReaderOptions& options) const override;
 
  private:
+  void validateOmittedKeyColumnStorageAccess(
+      const dwio::common::RowReaderOptions& options) const;
+
   const std::shared_ptr<ReaderBase> readerBase_;
   const dwio::common::ReaderOptions options_;
 };
@@ -715,18 +726,46 @@ SelectiveNimbleReader::typeWithId() const {
 
 std::unique_ptr<dwio::common::RowReader> SelectiveNimbleReader::createRowReader(
     const dwio::common::RowReaderOptions& options) const {
+  validateOmittedKeyColumnStorageAccess(options);
   return std::make_unique<SelectiveNimbleRowReader>(readerBase_, options);
 }
 
 std::unique_ptr<dwio::common::IndexReader>
 SelectiveNimbleReader::createIndexReader(
     const dwio::common::RowReaderOptions& options) const {
+  validateOmittedKeyColumnStorageAccess(options);
   // Empty files (no stripes) have no cluster index even when index config
   // is set. Return nullptr so the caller handles it as no-index.
   if (readerBase_->tablet().clusterIndex() == nullptr) {
     return nullptr;
   }
   return std::make_unique<SelectiveNimbleIndexReader>(readerBase_, options);
+}
+
+void SelectiveNimbleReader::validateOmittedKeyColumnStorageAccess(
+    const dwio::common::RowReaderOptions& options) const {
+  const auto& features = readerBase_->tablet().features();
+  if (!features.clusterIndexKeyColumnStorageOmitted()) {
+    return;
+  }
+
+  const auto outputType = options.requestedType() ? options.requestedType()
+                                                  : readerBase_->fileSchema();
+  const auto* scanSpec = options.scanSpec().get();
+  for (const auto& column :
+       features.clusterIndexKeyColumnsWithOmittedStorage()) {
+    NIMBLE_USER_CHECK(
+        !outputType->containsChild(column),
+        "Cluster index key column '{}' cannot be projected because this file stores it only in the cluster index key stream",
+        column);
+    if (scanSpec != nullptr) {
+      const auto* childSpec = scanSpec->childByName(column);
+      NIMBLE_USER_CHECK(
+          childSpec == nullptr || !childSpec->hasFilter(),
+          "Cluster index key column '{}' cannot be used as a remaining scan filter because this file stores it only in the cluster index key stream",
+          column);
+    }
+  }
 }
 
 } // namespace

--- a/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
+++ b/dwio/nimble/velox/selective/tests/E2EIndexTest.cpp
@@ -19,6 +19,7 @@
 
 #include <folly/executors/CPUThreadPoolExecutor.h>
 
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/index/ClusterIndexConfig.h"
 #include "dwio/nimble/velox/VeloxWriter.h"
@@ -3646,6 +3647,99 @@ TEST_F(E2EIndexTestBase, CreateIndexReaderWithoutClusterIndex) {
 
     // Files without cluster index return nullptr instead of throwing.
     EXPECT_EQ(reader->createIndexReader(rowReaderOpts), nullptr);
+  }
+}
+
+TEST_F(E2EIndexTestBase, createIndexReaderRejectsHiddenKeyReadAccess) {
+  auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+  auto storedType = ROW({"value"}, {INTEGER()});
+  auto batch = vectorMaker_->rowVector(
+      {"key", "value"},
+      {vectorMaker_->flatVector<int64_t>({1, 2, 3}),
+       vectorMaker_->flatVector<int32_t>({10, 20, 30})});
+
+  sinkData_.clear();
+  auto writeFile = std::make_unique<InMemoryWriteFile>(&sinkData_);
+  VeloxWriterOptions options;
+  options.clusterIndexConfig =
+      ClusterIndexConfigBuilder{}
+          .withKeyColumns({"key"})
+          .withSortOrders({SortOrder{.ascending = true}})
+          .withEnforceKeyOrder(true)
+          .build();
+  options.experimentalOmitClusterIndexKeyColumnStorage = true;
+
+  VeloxWriter writer(
+      rowType, std::move(writeFile), *rootPool_, std::move(options));
+  writer.write(batch);
+  writer.close();
+
+  // Hidden key columns are still usable for cluster index bounds.
+  {
+    auto reader = createReader();
+    RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setRequestedType(storedType);
+    rowReaderOpts.setScanSpec(createScanSpec(storedType, {}));
+    auto indexReader = reader->createIndexReader(rowReaderOpts);
+    ASSERT_NE(indexReader, nullptr);
+
+    auto bound = vectorMaker_->rowVector(
+        {"key"}, {vectorMaker_->flatVector<int64_t>({2})});
+    serializer::IndexBounds bounds;
+    bounds.indexColumns = {"key"};
+    bounds.set(
+        serializer::IndexBound{bound, /*inclusive=*/true},
+        serializer::IndexBound{bound, /*inclusive=*/true});
+    indexReader->startLookup(bounds, {});
+
+    ASSERT_TRUE(indexReader->hasNext());
+    auto result = indexReader->next(10);
+    ASSERT_NE(result, nullptr);
+    ASSERT_EQ(result->output->size(), 1);
+    EXPECT_EQ(
+        result->output->childAt(0)->asFlatVector<int32_t>()->valueAt(0), 20);
+    EXPECT_FALSE(indexReader->hasNext());
+  }
+
+  struct Scenario {
+    std::string name;
+    RowTypePtr requestedType;
+    bool remainingFilter;
+    std::string expectedMessage;
+  };
+  const std::vector<Scenario> scenarios{
+      {
+          // Hidden key columns cannot be read from normal data streams.
+          .name = "projection",
+          .requestedType = rowType,
+          .remainingFilter = false,
+          .expectedMessage =
+              "Cluster index key column 'key' cannot be projected",
+      },
+      {
+          // Remaining filters require normal data streams; index bounds are
+          // the supported hidden-key filter path.
+          .name = "remainingFilter",
+          .requestedType = storedType,
+          .remainingFilter = true,
+          .expectedMessage =
+              "Cluster index key column 'key' cannot be used as a remaining scan filter",
+      },
+  };
+
+  for (const auto& scenario : scenarios) {
+    SCOPED_TRACE(fmt::format("scenario={}", scenario.name));
+    auto reader = createReader();
+    RowReaderOptions rowReaderOpts;
+    rowReaderOpts.setRequestedType(scenario.requestedType);
+    std::unordered_map<std::string, std::unique_ptr<Filter>> filters;
+    if (scenario.remainingFilter) {
+      filters["key"] = std::make_unique<BigintRange>(1, 3, false);
+    }
+    rowReaderOpts.setScanSpec(createScanSpec(rowType, filters));
+
+    NIMBLE_ASSERT_THROW(
+        reader->createIndexReader(rowReaderOpts), scenario.expectedMessage);
   }
 }
 

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -1356,6 +1356,88 @@ TEST_F(VeloxWriterTest, featureReorderingStreamCollocation) {
   }
 }
 
+TEST_F(
+    VeloxWriterTest,
+    featureReorderingUsesInputOrdinalWithOmittedClusterIndexKey) {
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+
+  const std::vector<int64_t> reorderedKeys = {4, 2, 0};
+  constexpr int kNumRows = 1'000;
+  auto vector = vectorMaker.rowVector(
+      {"key", "flatmap"},
+      {
+          vectorMaker.flatVector<int64_t>(
+              kNumRows, [](auto row) { return static_cast<int64_t>(row); }),
+          vectorMaker.mapVector<int32_t, int32_t>(
+              kNumRows,
+              [](auto) { return 5; },
+              [](auto, auto mapIndex) { return mapIndex; },
+              [](auto row, auto mapIndex) { return row * 10 + mapIndex; },
+              [](auto) { return false; }),
+      });
+
+  std::string file;
+  {
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    nimble::VeloxWriterOptions options;
+    options.flatMapColumns = {{"flatmap", {}}};
+    options.clusterIndexConfig =
+        nimble::index::ClusterIndexConfigBuilder{}
+            .withKeyColumns({"key"})
+            .withSortOrders({nimble::SortOrder{.ascending = true}})
+            .withEnforceKeyOrder(true)
+            .build();
+    options.experimentalOmitClusterIndexKeyColumnStorage = true;
+    // The option is expressed against the input schema where key=0 and
+    // flatmap=1. The stored schema omits key, so the writer must remap this to
+    // stored ordinal 0 before handing it to the layout planner.
+    options.featureReordering =
+        std::vector<std::tuple<size_t, std::vector<int64_t>>>{
+            {1, reorderedKeys}};
+
+    nimble::VeloxWriter writer(
+        vector->type(), std::move(writeFile), *rootPool_, std::move(options));
+    writer.write(vector);
+    writer.close();
+  }
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = nimble::TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+  ASSERT_GE(tablet->stripeCount(), 1);
+  ASSERT_NE(tablet->clusterIndex(), nullptr);
+
+  auto stripeId = tablet->stripeIdentifier(0);
+  const auto streamCount = tablet->streamCount(stripeId);
+  std::vector<uint32_t> offsets(streamCount);
+  std::vector<uint32_t> sizes(streamCount);
+  tablet->streamOffsets(stripeId, offsets);
+  tablet->streamSizes(stripeId, sizes);
+
+  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  const auto& rowSchema = reader.schema()->asRow();
+  ASSERT_EQ(1, rowSchema.childrenCount());
+  EXPECT_EQ("flatmap", rowSchema.nameAt(0));
+  const auto& flatMap = rowSchema.childAt(0)->asFlatMap();
+
+  std::unordered_map<std::string, uint32_t> keyToValueStreamId;
+  for (size_t i = 0; i < flatMap.childrenCount(); ++i) {
+    keyToValueStreamId[flatMap.nameAt(i)] =
+        flatMap.childAt(i)->asScalar().scalarDescriptor().offset();
+  }
+
+  for (size_t i = 1; i < reorderedKeys.size(); ++i) {
+    const auto prevKey = folly::to<std::string>(reorderedKeys[i - 1]);
+    const auto currKey = folly::to<std::string>(reorderedKeys[i]);
+    const auto prevStreamId = keyToValueStreamId.at(prevKey);
+    const auto currStreamId = keyToValueStreamId.at(currKey);
+    EXPECT_EQ(
+        offsets[prevStreamId] + sizes[prevStreamId], offsets[currStreamId])
+        << "Key " << prevKey << " value stream should be adjacent to key "
+        << currKey;
+  }
+}
+
 TEST_F(VeloxWriterTest, duplicateFlatmapKey) {
   velox::test::VectorMaker vectorMaker{leafPool_.get()};
   // Vector with constant but duplicate key set. Potentially omitting in map
@@ -5933,6 +6015,173 @@ TEST_P(VeloxWriterIndexTest, multipleGroups) {
 
   // Verify value index maps each key to correct row position
   verifyValueIndex(*tablet, readFile.get(), type, batches, {"key_col"});
+}
+
+TEST_F(VeloxWriterTest, compactRowCountEncodingIsPersistedAsFileFeature) {
+  auto type = velox::ROW({{"c0", velox::BIGINT()}});
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto batch = vectorMaker.rowVector(
+      {"c0"}, {vectorMaker.flatVector<int64_t>({1, 2, 3, 4})});
+
+  auto writeWithCompactRowCountEncoding = [&](bool enabled) {
+    std::string file;
+    auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+    nimble::VeloxWriterOptions options;
+    options.experimentalCompactRowCountEncoding = enabled;
+
+    nimble::VeloxWriter writer(
+        type, std::move(writeFile), *rootPool_, std::move(options));
+    writer.write(batch);
+    writer.close();
+    return file;
+  };
+
+  for (const bool enabled : {false, true}) {
+    SCOPED_TRACE(
+        testing::Message() << "experimentalCompactRowCountEncoding="
+                           << enabled);
+    auto readFile = std::make_shared<velox::InMemoryReadFile>(
+        writeWithCompactRowCountEncoding(enabled));
+    auto tablet = nimble::TabletReader::create(
+        readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+    EXPECT_EQ(tablet->features().compactRowCountEncoding(), enabled);
+  }
+}
+
+TEST_P(VeloxWriterIndexTest, omitClusterIndexKeyColumnStorage) {
+  auto type = velox::ROW({
+      {"key_col", velox::BIGINT()},
+      {"value_col", velox::INTEGER()},
+      {"payload", velox::VARCHAR()},
+  });
+  auto storedType = velox::ROW({
+      {"value_col", velox::INTEGER()},
+      {"payload", velox::VARCHAR()},
+  });
+
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto batch = vectorMaker.rowVector(
+      {"key_col", "value_col", "payload"},
+      {
+          vectorMaker.flatVector<int64_t>({10, 20, 30, 40}),
+          vectorMaker.flatVector<int32_t>({1, 2, 3, 4}),
+          vectorMaker.flatVector<std::string>(
+              {"first", "second", "third", "fourth"}),
+      });
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  auto options = createWriterOptions(createIndexConfig({"key_col"}));
+  options.experimentalOmitClusterIndexKeyColumnStorage = true;
+
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *rootPool_, std::move(options));
+  writer.write(batch);
+  writer.close();
+
+  auto readFile = std::make_shared<velox::InMemoryReadFile>(file);
+  auto tablet = nimble::TabletReader::create(
+      readFile, leafPool_.get(), makeTestTabletOptions(leafPool_.get()));
+  ASSERT_NE(tablet->clusterIndex(), nullptr);
+  EXPECT_EQ(
+      tablet->clusterIndex()->indexColumns(),
+      (std::vector<std::string>{"key_col"}));
+  EXPECT_TRUE(tablet->features().clusterIndexKeyColumnStorageOmitted());
+  EXPECT_EQ(
+      tablet->features().clusterIndexKeyColumnsWithOmittedStorage(),
+      (std::vector<std::string>{"key_col"}));
+
+  auto tabletOptions = makeTestTabletOptions(leafPool_.get());
+  tabletOptions.loadClusterIndex = false;
+  auto tabletWithoutIndex =
+      nimble::TabletReader::create(readFile, leafPool_.get(), tabletOptions);
+  EXPECT_EQ(tabletWithoutIndex->clusterIndex(), nullptr);
+  EXPECT_TRUE(
+      tabletWithoutIndex->features().clusterIndexKeyColumnStorageOmitted());
+  EXPECT_EQ(
+      tabletWithoutIndex->features().clusterIndexKeyColumnsWithOmittedStorage(),
+      (std::vector<std::string>{"key_col"}));
+
+  nimble::VeloxReader reader(readFile.get(), *leafPool_);
+  auto actualStoredType = nimble::convertToVeloxType(*reader.schema());
+  EXPECT_EQ(*storedType, *actualStoredType);
+
+  velox::VectorPtr result;
+  ASSERT_TRUE(reader.next(10, result));
+  ASSERT_EQ(result->size(), batch->size());
+  auto expected = vectorMaker.rowVector(
+      {"value_col", "payload"},
+      {
+          batch->childAt(1),
+          batch->childAt(2),
+      });
+  for (velox::vector_size_t i = 0; i < result->size(); ++i) {
+    EXPECT_TRUE(result->equalValueAt(expected.get(), i, i));
+  }
+  EXPECT_FALSE(reader.next(10, result));
+
+  verifyValueIndex(*tablet, readFile.get(), type, {batch}, {"key_col"});
+}
+
+TEST_P(
+    VeloxWriterIndexTest,
+    omittedClusterIndexKeyColumnStorageRemapsSchemaAttributes) {
+  auto nestedType = velox::ROW({{"score", velox::INTEGER()}});
+  auto type = velox::ROW({
+      {"key_col", velox::BIGINT()},
+      {"value_col", velox::VARCHAR()},
+      {"nested_col", nestedType},
+  });
+
+  velox::test::VectorMaker vectorMaker{leafPool_.get()};
+  auto batch = vectorMaker.rowVector(
+      {"key_col", "value_col", "nested_col"},
+      {
+          vectorMaker.flatVector<int64_t>({10, 20}),
+          vectorMaker.flatVector<std::string>({"first", "second"}),
+          vectorMaker.rowVector(
+              {"score"}, {vectorMaker.flatVector<int32_t>({1, 2})}),
+      });
+
+  std::string file;
+  auto writeFile = std::make_unique<velox::InMemoryWriteFile>(&file);
+  auto options = createWriterOptions(createIndexConfig({"key_col"}));
+  options.experimentalOmitClusterIndexKeyColumnStorage = true;
+  // Input TypeWithId ids: key_col=1, value_col=2, nested_col=3, score=4.
+  // key_col is omitted from the stored schema; remaining ids must be remapped
+  // onto the stored TypeWithId tree while preserving the field-id values.
+  options.schemaAttributes[1] = {{"iceberg.id", "101"}};
+  options.schemaAttributes[2] = {{"iceberg.id", "102"}};
+  options.schemaAttributes[3] = {{"iceberg.id", "103"}};
+  options.schemaAttributes[4] = {{"iceberg.id", "104"}};
+
+  nimble::VeloxWriter writer(
+      type, std::move(writeFile), *rootPool_, std::move(options));
+  writer.write(batch);
+  writer.close();
+
+  velox::InMemoryReadFile readFile(file);
+  nimble::VeloxReader reader(&readFile, *leafPool_);
+  const auto& rowSchema = reader.schema()->asRow();
+  ASSERT_EQ(2, rowSchema.childrenCount());
+  EXPECT_EQ("value_col", rowSchema.nameAt(0));
+  EXPECT_EQ("nested_col", rowSchema.nameAt(1));
+
+  EXPECT_EQ(
+      rowSchema.childAt(0)->attributes(),
+      (std::vector<std::pair<std::string, std::string>>{
+          {"iceberg.id", "102"}}));
+
+  const auto& nestedSchema = rowSchema.childAt(1);
+  ASSERT_EQ(nimble::Kind::Row, nestedSchema->kind());
+  EXPECT_EQ(
+      nestedSchema->attributes(),
+      (std::vector<std::pair<std::string, std::string>>{
+          {"iceberg.id", "103"}}));
+  EXPECT_EQ(
+      nestedSchema->asRow().childAt(0)->attributes(),
+      (std::vector<std::pair<std::string, std::string>>{
+          {"iceberg.id", "104"}}));
 }
 
 TEST_P(VeloxWriterIndexTest, multipleIndexColumns) {


### PR DESCRIPTION
Summary:

Add an opt-in `nimble.index.skip_key_column_storage` writer mode for cluster indexes. When enabled, the writer consumes key columns from input batches for index encoding but omits those columns from the persisted data schema and normal data streams. Record file-level features in `columnar.features` so readers can detect omitted key-column storage before loading feature-specific metadata.

Add file features for compact encoding so readers can select varint row-count decoding when needed. Remap feature-reordering ordinals onto the stored schema so reordering metadata stays attached to the intended persisted columns.

Relax selective index reading so cluster index key columns no longer need normal data streams, while rejecting attempts to project hidden keys or use them as remaining scan filters.

Reviewed By: zacw7

Differential Revision: D114460268


