### PR TITLE
feat(nimble): Update encoding-selection cache on replay fallback

### DIFF
--- a/dwio/nimble/velox/NimbleConfig.h
+++ b/dwio/nimble/velox/NimbleConfig.h
@@ -140,8 +140,9 @@ class Config : public velox::config::ConfigBase {
   /// Enable vectorized column statistics for row size estimation.
   static Entry<bool> ENABLE_VECTORIZED_STATS;
 
-  /// Enable the encoding selection cache: capture the encoding layout from the
-  /// first encoding of each stream and replay it on subsequent chunks/stripes.
+  /// Enable the encoding selection cache: capture the last successfully
+  /// selected encoding layout for each stream and replay it on subsequent
+  /// chunks/stripes.
   static Entry<bool> ENABLE_ENCODING_SELECTION_CACHE;
 
   static constexpr const char* kNimbleWriteTargetRawStripeSize =

--- a/dwio/nimble/velox/VeloxWriter.cpp
+++ b/dwio/nimble/velox/VeloxWriter.cpp
@@ -336,22 +336,34 @@ class WriterStreamContext : public StreamContext {
     isInMapStream_ = value;
   }
 
-  // The layout to replay for this stream: overlaid from the EncodingLayoutTree
-  // at setup, or captured from this stream's first encode when
-  // encoding-selection caching is enabled. Empty until one of those populates
-  // it.
-  const EncodingLayout* encoding() const {
-    return encoding_.has_value() ? &*encoding_ : nullptr;
+  const EncodingLayout* encodingLayoutOverride() const {
+    return encodingLayoutOverride_.has_value() ? &*encodingLayoutOverride_
+                                               : nullptr;
   }
 
-  void setEncoding(EncodingLayout value) {
-    encoding_.emplace(std::move(value));
+  void setEncodingLayoutOverride(EncodingLayout value) {
+    encodingLayoutOverride_.emplace(std::move(value));
+  }
+
+  const EncodingLayout* cachedEncoding() const {
+    return cachedEncoding_.has_value() ? &*cachedEncoding_ : nullptr;
+  }
+
+  void setCachedEncoding(EncodingLayout value) {
+    cachedEncoding_.emplace(std::move(value));
   }
 
  private:
   bool isNullStream_{false};
   bool isInMapStream_{false};
-  std::optional<EncodingLayout> encoding_;
+
+  // The layout overlaid from an explicit EncodingLayoutTree at setup. This
+  // takes precedence over runtime cache learning.
+  std::optional<EncodingLayout> encodingLayoutOverride_;
+
+  // The layout captured from this stream's latest successful fresh encode when
+  // encoding-selection caching is enabled.
+  std::optional<EncodingLayout> cachedEncoding_;
 };
 
 class FlatmapEncodingLayoutContext : public TypeBuilderContext {
@@ -424,14 +436,17 @@ std::string_view encode(
   }
 }
 
-// Encodes streamData by replaying a saved layout -- either an external
-// EncodingLayoutTree layout or one cached from this stream's first encode. Only
-// entered once the stream has a saved layout to replay (checked below). Replay
-// is best-effort: if it throws for any reason (e.g. the layout no longer fits
-// this chunk's data), retry once with a fresh selection, letting any failure of
-// that retry propagate.
+struct EncodeWithFallbackResult {
+  std::string_view encoded;
+  bool usedFreshSelection;
+};
+
+// Encodes streamData by replaying a saved layout. Replay is best-effort: if it
+// throws for any reason (e.g. the layout no longer fits this chunk's data),
+// retry once with a fresh selection, letting any failure of that retry
+// propagate.
 template <typename T>
-std::string_view encodeWithFallback(
+EncodeWithFallbackResult encodeWithFallback(
     const EncodingLayout* encodingLayout,
     detail::WriterContext& context,
     Buffer& buffer,
@@ -442,24 +457,28 @@ std::string_view encodeWithFallback(
       encodingLayout,
       "encodeWithFallback requires a saved encoding layout to replay.");
   try {
-    return encode<T>(
-        *encodingLayout,
-        context,
-        buffer,
-        encodingScratchBufferPool,
-        encodingBufferPool,
-        streamData);
+    return {
+        encode<T>(
+            *encodingLayout,
+            context,
+            buffer,
+            encodingScratchBufferPool,
+            encodingBufferPool,
+            streamData),
+        false};
   } catch (const std::exception&) {
     // A saved layout can fail to apply to this chunk's data in ways beyond a
     // clean IncompatibleEncoding, so retry on any error rather than keying off
     // a specific (unreliable) error code.
-    return encode<T>(
-        std::nullopt,
-        context,
-        buffer,
-        encodingScratchBufferPool,
-        encodingBufferPool,
-        streamData);
+    return {
+        encode<T>(
+            std::nullopt,
+            context,
+            buffer,
+            encodingScratchBufferPool,
+            encodingBufferPool,
+            streamData),
+        true};
   }
 }
 
@@ -470,21 +489,41 @@ std::string_view encodeStreamTyped(
     velox::BufferPool* encodingScratchBufferPool,
     EncodingBufferPool* encodingBufferPool,
     const StreamData& streamData) {
-  const auto* writerStreamContext =
+  auto* writerStreamContext =
       streamData.descriptor().context<WriterStreamContext>();
 
-  // Replay an externally provided (EncodingLayoutTree) or previously captured
-  // layout, falling back to a fresh selection if it no longer fits the data.
+  // Replay an explicitly provided EncodingLayoutTree layout, falling back to a
+  // fresh selection if it no longer fits the data. Overrides are not replaced
+  // by runtime cache learning.
   // TODO: Replace the exception-based best-effort replay in encodeWithFallback
   // with a non-throwing compatibility check before the replay attempt.
-  if (writerStreamContext && writerStreamContext->encoding()) {
+  if (writerStreamContext && writerStreamContext->encodingLayoutOverride()) {
     return encodeWithFallback<T>(
-        writerStreamContext->encoding(),
+               writerStreamContext->encodingLayoutOverride(),
+               context,
+               buffer,
+               encodingScratchBufferPool,
+               encodingBufferPool,
+               streamData)
+        .encoded;
+  }
+
+  // Replay the last successfully captured layout. If the layout no longer fits
+  // this chunk, the fallback fresh selection becomes the new cached layout.
+  if (writerStreamContext && writerStreamContext->cachedEncoding()) {
+    auto result = encodeWithFallback<T>(
+        writerStreamContext->cachedEncoding(),
         context,
         buffer,
         encodingScratchBufferPool,
         encodingBufferPool,
         streamData);
+    if (result.usedFreshSelection) {
+      writerStreamContext->setCachedEncoding(
+          EncodingLayoutCapture::capture(
+              result.encoded, context.options().buildEncodingOptions()));
+    }
+    return result.encoded;
   }
 
   // No layout to replay: run a fresh selection.
@@ -496,14 +535,14 @@ std::string_view encodeStreamTyped(
       encodingBufferPool,
       streamData);
 
-  // Cache the data layout from this first encode so later chunks/stripes replay
-  // it, skipping the full selection cascade. EncodingLayoutCapture::capture()
-  // already strips any Nullable/Sentinel wrapper, so the cached layout is the
-  // data encoding alone — Nimble re-applies per-chunk nullability at encode
-  // time, so it stays valid regardless of a later chunk's nulls.
+  // Cache the data layout from this fresh encode so later chunks/stripes can
+  // replay it, skipping the full selection cascade. EncodingLayoutCapture::
+  // capture() already strips any Nullable/Sentinel wrapper, so the cached
+  // layout is the data encoding alone — Nimble re-applies per-chunk nullability
+  // at encode time, so it stays valid regardless of a later chunk's nulls.
   if (context.options().enableEncodingSelectionCache) {
     streamContext(streamData.descriptor())
-        .setEncoding(
+        .setCachedEncoding(
             EncodingLayoutCapture::capture(
                 encoded, context.options().buildEncodingOptions()));
   }
@@ -683,10 +722,11 @@ void initializeEncodingLayouts(
     const TypeBuilder& typeBuilder,
     const EncodingLayoutTree& encodingLayoutTree) {
   {
-#define SET_STREAM_CONTEXT(builder, descriptor, identifier)           \
-  if (auto* encodingLayout = encodingLayoutTree.encodingLayout(       \
-          EncodingLayoutTree::StreamIdentifiers::identifier)) {       \
-    streamContext(builder.descriptor()).setEncoding(*encodingLayout); \
+#define SET_STREAM_CONTEXT(builder, descriptor, identifier)     \
+  if (auto* encodingLayout = encodingLayoutTree.encodingLayout( \
+          EncodingLayoutTree::StreamIdentifiers::identifier)) { \
+    streamContext(builder.descriptor())                         \
+        .setEncodingLayoutOverride(*encodingLayout);            \
   }
 
     if (typeBuilder.kind() == Kind::FlatMap) {

--- a/dwio/nimble/velox/VeloxWriterOptions.h
+++ b/dwio/nimble/velox/VeloxWriterOptions.h
@@ -359,9 +359,9 @@ struct VeloxWriterOptions {
   /// with column statistics for non-deduplicated columns.
   bool enableStatsConsistencyCheck{true};
 
-  // Cache the encoding layout from the first encoding of each stream and
+  // Cache the last successfully selected encoding layout for each stream and
   // replay it on subsequent chunks/stripes, skipping the full encoding
-  // selection cascade.
+  // selection cascade while the layout remains compatible.
   bool enableEncodingSelectionCache{false};
 };
 

--- a/dwio/nimble/velox/tests/VeloxWriterTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxWriterTest.cpp
@@ -4675,24 +4675,23 @@ TEST_F(VeloxWriterTest, cachedEncodingLayoutFuzz) {
     ASSERT_EQ(controlLayouts.size(), static_cast<size_t>(kChunkCount));
     ASSERT_EQ(cachedLayouts.size(), static_cast<size_t>(kChunkCount));
 
-    // The encoding selection cache is best-effort: each chunk either
-    // successfully replays chunk 0's cached encoding, or the cached encoding
-    // was incompatible with the chunk's data, raising IncompatibleEncoding
-    // which the writer catches and falls back to a fresh selection — the same
-    // encoding the uncached writer chose for that chunk (see
-    // encodeWithFallback).
+    // The encoding selection cache is best-effort: each chunk either replays a
+    // previously selected compatible layout, or the cached layout is
+    // incompatible and the writer falls back to a fresh selection. Fallback
+    // refreshes the cache, so a later chunk may replay any earlier fresh
+    // layout.
     for (int chunk = 0; chunk < kChunkCount; ++chunk) {
-      EXPECT_TRUE(
-          cachedLayouts[chunk].encodingType() ==
-              cachedLayouts.front().encodingType() ||
-          cachedLayouts[chunk].encodingType() ==
-              controlLayouts[chunk].encodingType())
-          << "seed=" << seed << " chunk=" << chunk
-          << " cached=" << static_cast<int>(cachedLayouts[chunk].encodingType())
-          << " cached0="
-          << static_cast<int>(cachedLayouts.front().encodingType())
-          << " control="
-          << static_cast<int>(controlLayouts[chunk].encodingType());
+      bool matchedEarlierFreshLayout = false;
+      for (int previous = 0; previous <= chunk; ++previous) {
+        if (cachedLayouts[chunk].encodingType() ==
+            controlLayouts[previous].encodingType()) {
+          matchedEarlierFreshLayout = true;
+          break;
+        }
+      }
+      EXPECT_TRUE(matchedEarlierFreshLayout)
+          << "seed=" << seed << " chunk=" << chunk << " cached="
+          << static_cast<int>(cachedLayouts[chunk].encodingType());
     }
   };
 
@@ -4711,9 +4710,7 @@ TEST_F(VeloxWriterTest, cachedEncodingLayoutIncompatibleFallback) {
   // constant); replaying the cached Constant onto it raises
   // IncompatibleEncoding (ConstantEncoding requires constant data), which the
   // writer catches and falls back to a fresh selection for that chunk. The
-  // fallback does not re-cache (it only caches when no layout is cached yet),
-  // so chunks 2-4 are fully constant again and still replay the original cached
-  // Constant.
+  // fallback refreshes the cache, so chunks 2-4 replay chunk 1's fresh layout.
   constexpr int kRowsPerChunk = 1000;
   constexpr int64_t kDominantValue = 7;
   constexpr uint32_t kSeed = 0xC0FFEE;
@@ -4777,14 +4774,11 @@ TEST_F(VeloxWriterTest, cachedEncodingLayoutIncompatibleFallback) {
       cachedLayouts[1].encodingType(), cachedLayouts.front().encodingType());
   EXPECT_EQ(cachedLayouts[1].encodingType(), controlLayouts[1].encodingType());
 
-  // The incompatible chunk does not disrupt the cache: the fully-constant
-  // chunks all replay the first chunk's cached encoding.
-  EXPECT_EQ(
-      cachedLayouts.front().encodingType(), cachedLayouts[2].encodingType());
-  EXPECT_EQ(
-      cachedLayouts.front().encodingType(), cachedLayouts[3].encodingType());
-  EXPECT_EQ(
-      cachedLayouts.front().encodingType(), cachedLayouts[4].encodingType());
+  // The incompatible chunk refreshes the cache: the later fully-constant chunks
+  // replay chunk 1's fresh fallback layout.
+  EXPECT_EQ(cachedLayouts[1].encodingType(), cachedLayouts[2].encodingType());
+  EXPECT_EQ(cachedLayouts[1].encodingType(), cachedLayouts[3].encodingType());
+  EXPECT_EQ(cachedLayouts[1].encodingType(), cachedLayouts[4].encodingType());
 }
 
 TEST_F(
@@ -4799,8 +4793,9 @@ TEST_F(
   // catchable IncompatibleEncoding (this is the exact shape that used to
   // DCHECK-abort the process before the empty-Dictionary replay was made
   // catchable). The writer catches it and falls back to a fresh selection for
-  // that chunk. Chunks 2-4 repeat chunk 0's data and replay the cached
-  // MainlyConstant successfully.
+  // that chunk. The fallback refreshes the cache to Constant; chunk 2 then
+  // falls back to MainlyConstant and refreshes the cache again, so chunks 3-4
+  // replay chunk 2's layout.
   constexpr int kRowsPerChunk = 1000;
   constexpr int64_t kDominantValue = 7;
   constexpr uint32_t kSeed = 0xC0FFEE;
@@ -4878,14 +4873,13 @@ TEST_F(
       cachedLayouts[1].encodingType(), cachedLayouts.front().encodingType());
   EXPECT_EQ(cachedLayouts[1].encodingType(), controlLayouts[1].encodingType());
 
-  // The incompatible chunk does not disrupt the cache: the mainly-constant
-  // chunks all replay the first chunk's cached MainlyConstant.
-  EXPECT_EQ(
-      cachedLayouts.front().encodingType(), cachedLayouts[2].encodingType());
-  EXPECT_EQ(
-      cachedLayouts.front().encodingType(), cachedLayouts[3].encodingType());
-  EXPECT_EQ(
-      cachedLayouts.front().encodingType(), cachedLayouts[4].encodingType());
+  // The fully-constant fallback refreshes the cache, so chunk 2 must fall back
+  // to a fresh MainlyConstant layout. Later mainly-constant chunks replay that
+  // refreshed layout.
+  EXPECT_EQ(cachedLayouts[2].encodingType(), controlLayouts[2].encodingType());
+  EXPECT_NE(cachedLayouts[2].encodingType(), cachedLayouts[1].encodingType());
+  EXPECT_EQ(cachedLayouts[2].encodingType(), cachedLayouts[3].encodingType());
+  EXPECT_EQ(cachedLayouts[2].encodingType(), cachedLayouts[4].encodingType());
 }
 
 TEST_F(VeloxWriterTest, cachedEncodingLayoutNestedDictionaryReplay) {
@@ -5126,6 +5120,67 @@ DEBUG_ONLY_TEST_F(VeloxWriterTest, cachedEncodingLayoutReplayRetry) {
     EXPECT_EQ(
         fullSelectionCount, 2); // chunk 0 seed (ok) + chunk 1 retry (threw)
   }
+}
+
+DEBUG_ONLY_TEST_F(
+    VeloxWriterTest,
+    cachedEncodingLayoutRefreshesAfterReplayFallback) {
+  velox::common::testutil::TestValue::enable();
+
+  constexpr int kChunkCount = 3;
+  constexpr int kRowsPerChunk = 1000;
+  auto chunkData =
+      makeDivergentInt64Chunks(kChunkCount, kRowsPerChunk, /*seed=*/0xC0FFEE);
+
+  auto makeOptions = [](bool enableEncodingSelectionCache) {
+    nimble::VeloxWriterOptions options;
+    options.enableEncodingSelectionCache = enableEncodingSelectionCache;
+    options.enableChunking = true;
+    options.minStreamChunkRawSize = 0;
+    options.flushPolicyFactory = [] {
+      return std::make_unique<nimble::LambdaFlushPolicy>(
+          /*flushLambda=*/[](auto&) { return false; },
+          /*chunkLambda=*/[](auto&) { return true; });
+    };
+    return options;
+  };
+
+  const auto uncached = writeAndCaptureChunkLayouts(
+      chunkData,
+      makeOptions(/*enableEncodingSelectionCache=*/false),
+      /*expectedStripeCount=*/1);
+  ASSERT_EQ(uncached.size(), static_cast<size_t>(kChunkCount));
+  ASSERT_FALSE(encodingLayoutsEqual(uncached[0], uncached[1]));
+
+  bool failNextReplay = true;
+  int fullSelectionCount = 0;
+  int replayCount = 0;
+  SCOPED_TESTVALUE_SET(
+      "facebook::nimble::encode",
+      std::function<void(const bool*)>([&](const bool* hasEncodingLayout) {
+        if (!*hasEncodingLayout) {
+          ++fullSelectionCount;
+          return;
+        }
+        ++replayCount;
+        if (failNextReplay) {
+          failNextReplay = false;
+          throw std::runtime_error("injected replay failure");
+        }
+      }));
+
+  const auto cached = writeAndCaptureChunkLayouts(
+      chunkData,
+      makeOptions(/*enableEncodingSelectionCache=*/true),
+      /*expectedStripeCount=*/1);
+  ASSERT_EQ(cached.size(), static_cast<size_t>(kChunkCount));
+
+  EXPECT_EQ(fullSelectionCount, 2); // chunk 0 seed + chunk 1 fallback.
+  EXPECT_EQ(replayCount, 2); // chunk 1 fails, chunk 2 replays refreshed cache.
+  EXPECT_TRUE(encodingLayoutsEqual(cached[0], uncached[0]));
+  EXPECT_TRUE(encodingLayoutsEqual(cached[1], uncached[1]));
+  EXPECT_FALSE(encodingLayoutsEqual(cached[2], cached[0]));
+  EXPECT_TRUE(encodingLayoutsEqual(cached[2], cached[1]));
 }
 
 DEBUG_ONLY_TEST_F(VeloxWriterTest, cachedEncodingLayoutSelectionCount) {


### PR DESCRIPTION
Summary:
This changes the encoding-selection cache replay behavior for Nimble writer chunk encoding.

Previous cache-on behavior:
- Cache the first successfully selected encoding layout for a stream.
- Replay that layout for later chunks.
- If replay fails, fresh-select for that chunk, but keep the old cached layout.

New behavior:
- Replay the cached layout for later chunks.
- If replay fails, fresh-select for that chunk and update the cache to the last successful layout.
- This reduces repeated replay-fail + fresh-selection work, but the refreshed layout is only guaranteed compatible, not globally size-best for later chunks.

DataFM full cluster-index benchmark, same input/sample/model, both arms with `--nimble_enable_encoding_selection_cache=true`:

- Old cache-on strategy: parent strategy plus benchmark flag plumbing only.
- New cache-on strategy: this diff.
- Input: `/data/users/duxiao/rexdb/d114231357_datafm_full_ab_20260730/input_full.rio`
- Sample: `/data/users/duxiao/rexdb/datafm_samples_aligned_20260720/00000.rio`
- Decode: `index_projector`, `bm_num_batches=5000`, `bm_sample_batch_size=128`, `sequence_id=fb_video_positive`, `model_type=facebook_reels_udd_hstu_expert`.

Results:

| Metric | Old cache-on | New cache-on | Delta |
|---|---:|---:|---:|
| File size | 29.053 GB | 29.954 GB | +3.10% worse |
| Encode elapsed | 12:19.19 | 12:04.79 | -1.95% |
| Encode user CPU | 1631.59s | 1589.53s | -2.58% |
| Encode sys CPU | 3785.55s | 3335.34s | -11.89% |
| Encode total CPU | 5417.14s | 4924.87s | -9.09% better |
| Encode max RSS | 39.0 GB | 64.9 GB | +66% worse |
| Projected | 20.29 MB/batch | 20.29 MB/batch | no change |
| Total read | 3.82 MB/batch | 3.82 MB/batch | no change |
| Decode CPU | 15.12 ms/batch | 15.10 ms/batch | effectively no change |

Strobelight:

- Old encode: https://fburl.com/ix1ni30g
- New encode: https://fburl.com/3zfy88hy
- Old decode: https://fburl.com/9ovuadqp
- New decode: https://fburl.com/uzaybc3c

Takeaway:

The new strategy reduces write-side CPU by about 9% by reducing repeated encoding-selection work, but it currently regresses file size by about 3.1% and peak RSS by about 66%. Read-side projected bytes, total read bytes, and decode CPU are effectively unchanged. This is a write-CPU tradeoff, not a pure win for cluster-index files yet.

Differential Revision: D114319343


