### PR TITLE
fix(compression): Make encoding respect uncompressed setting (#1060)

### DIFF
--- a/dwio/nimble/compression/CompressionPolicy.cpp
+++ b/dwio/nimble/compression/CompressionPolicy.cpp
@@ -24,6 +24,10 @@ ConfiguredCompressionPolicy::ConfiguredCompressionPolicy(
       effectiveAcceptRatio_{getAcceptRatio(encodingType)} {}
 
 CompressionConfig ConfiguredCompressionPolicy::config() const {
+  if (compressionOptions_.compressionType == CompressionType::Uncompressed) {
+    return {.compressionType = CompressionType::Uncompressed};
+  }
+
   if (compressionOptions_.compressionType == CompressionType::Zstd) {
     CompressionConfig config{
         .compressionType = CompressionType::Zstd,

--- a/dwio/nimble/encodings/tests/CompressionTest.cpp
+++ b/dwio/nimble/encodings/tests/CompressionTest.cpp
@@ -163,6 +163,20 @@ TEST(CompressionTests, NoCompressionPolicy) {
       /*compressedSize=*/1));
 }
 
+TEST(CompressionTests, ConfiguredCompressionPolicy) {
+  auto checkCompressionType = [](nimble::CompressionType type) {
+    nimble::ConfiguredCompressionPolicy policy{
+        nimble::CompressionOptions{.compressionType = type},
+        nimble::EncodingType::FixedBitWidth};
+    EXPECT_EQ(policy.config().compressionType, type);
+  };
+  checkCompressionType(nimble::CompressionType::Uncompressed);
+  checkCompressionType(nimble::CompressionType::Zstd);
+  checkCompressionType(nimble::CompressionType::Lz4);
+  checkCompressionType(nimble::CompressionType::OpenZL);
+  checkCompressionType(nimble::CompressionType::MetaInternal);
+}
+
 TEST(CompressionTests, ConfiguredCompressionPolicyUsesCompressionOptions) {
   nimble::CompressionOptions options{
       .compressionType = nimble::CompressionType::Zstd,


### PR DESCRIPTION
Summary:

## Problem
`ConfiguredCompressionPolicy::config()` in `dwio/nimble/compression/CompressionPolicy.cpp` dispatches on `compressionOptions_.compressionType` and returns configs for `Zstd`, `Lz4`, `OpenZL`. Everything else — including `CompressionType::Uncompressed` — falls through to the last block, which returns `MetaInternal`. Callers that pass `Uncompressed` at write time get their streams silently MetaInternal-compressed.

`ReplayedCompressionPolicy::config()` in the same file already handles `Uncompressed` explicitly (line 100-103). The two policies should behave symmetrically for this compression type.

## Solution
Add an explicit `Uncompressed` branch at the top of `ConfiguredCompressionPolicy::config()` that returns `{.compressionType = Uncompressed}`.

Differential Revision: D114442345


