### PR TITLE
feat: Add shared dictionary types (#1063)

### DIFF
--- a/dwio/nimble/encodings/CMakeLists.txt
+++ b/dwio/nimble/encodings/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   MainlyConstantEncoding.cpp
   PrefixEncoding.cpp
   RLEEncoding.cpp
+  SharedDictionaryTypes.cpp
   SparseBoolEncoding.cpp
   TrivialEncoding.cpp
   common/Encoding.cpp

--- a/dwio/nimble/encodings/SharedDictionaryTypes.cpp
+++ b/dwio/nimble/encodings/SharedDictionaryTypes.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/SharedDictionaryTypes.h"
+
+#include "velox/common/EnumDefine.h"
+
+namespace facebook::nimble {
+
+namespace {
+const auto& sharedDictionaryScopeNames() {
+  static const folly::F14FastMap<SharedDictionaryScope, std::string_view>
+      kNames = {
+          {SharedDictionaryScope::Stripe, "Stripe"},
+          {SharedDictionaryScope::File, "File"},
+          {SharedDictionaryScope::External, "External"},
+      };
+  return kNames;
+}
+} // namespace
+
+VELOX_DEFINE_ENUM_NAME(SharedDictionaryScope, sharedDictionaryScopeNames)
+
+SharedDictionaryAlphabet::SharedDictionaryAlphabet(DataType dataType)
+    : dataType_{dataType} {}
+
+SharedDictionaryAlphabet::DecodedChunk SharedDictionaryAlphabet::decodedChunk(
+    uint32_t begin,
+    uint32_t count,
+    const void* entries,
+    std::shared_ptr<const void> owner) {
+  return DecodedChunk{
+      .begin = begin,
+      .count = count,
+      .entries = entries,
+      .owner = std::move(owner)};
+}
+
+SharedDictionaryAlphabet::EncodedChunk SharedDictionaryAlphabet::encodedChunk(
+    uint32_t begin,
+    std::shared_ptr<const EncodingView> view) {
+  return EncodedChunk{.begin = begin, .view = std::move(view)};
+}
+
+DataType SharedDictionaryAlphabet::dataType() const {
+  return dataType_;
+}
+
+uint32_t SharedDictionaryAlphabet::entryCount() const {
+  return entryCount_;
+}
+
+uint32_t SharedDictionaryAlphabet::validateDecodedChunks(
+    const std::vector<DecodedChunk>& chunks) {
+  uint32_t nextBegin{0};
+  for (const auto& chunk : chunks) {
+    NIMBLE_CHECK_EQ(
+        chunk.begin,
+        nextBegin,
+        "Shared dictionary alphabet chunks must be contiguous.");
+    NIMBLE_CHECK_NOT_NULL(chunk.entries);
+    NIMBLE_CHECK_NOT_NULL(chunk.owner);
+    NIMBLE_CHECK_LE(
+        chunk.count,
+        kMaxSharedDictionaryEntryCount - nextBegin,
+        "Shared dictionary alphabet chunk count overflows.");
+    nextBegin += chunk.count;
+  }
+  return nextBegin;
+}
+
+uint32_t SharedDictionaryAlphabet::validateEncodedChunks(
+    DataType dataType,
+    const std::vector<EncodedChunk>& chunks) {
+  uint32_t nextBegin{0};
+  for (const auto& chunk : chunks) {
+    NIMBLE_CHECK_EQ(
+        chunk.begin,
+        nextBegin,
+        "Shared dictionary alphabet chunks must be contiguous.");
+    NIMBLE_CHECK_NOT_NULL(chunk.view);
+    NIMBLE_CHECK_EQ(
+        chunk.view->dataType(),
+        dataType,
+        "Shared dictionary encoded chunk has unexpected type.");
+    const auto rowCount = chunk.view->rowCount();
+    NIMBLE_CHECK_LE(
+        rowCount,
+        kMaxSharedDictionaryEntryCount - nextBegin,
+        "Shared dictionary alphabet chunk count overflows.");
+    nextBegin += rowCount;
+  }
+  return nextBegin;
+}
+
+void SharedDictionaryAlphabet::setEntryCount(uint32_t entryCount) {
+  entryCount_ = entryCount;
+}
+
+std::shared_ptr<const SharedDictionaryAlphabet>
+SharedDictionaryAlphabet::createDecoded(
+    DataType dataType,
+    std::vector<DecodedChunk> chunks) {
+  return std::make_shared<DecodedSharedDictionaryAlphabet>(
+      dataType, std::move(chunks));
+}
+
+std::shared_ptr<const SharedDictionaryAlphabet>
+SharedDictionaryAlphabet::createEncoded(
+    DataType dataType,
+    std::vector<EncodedChunk> chunks) {
+  return std::make_shared<EncodedSharedDictionaryAlphabet>(
+      dataType, std::move(chunks));
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/SharedDictionaryTypes.h
+++ b/dwio/nimble/encodings/SharedDictionaryTypes.h
@@ -1,0 +1,378 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include "dwio/nimble/common/DataTypeDispatch.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/common/EncodingType.h"
+#include "dwio/nimble/encodings/views/EncodingViewFactory.h"
+#include "velox/common/EnumDeclare.h"
+
+namespace facebook::nimble {
+
+/// Identifies where an alphabet is stored or resolved, and the namespace used
+/// by SharedDictionaryConfig::dictionaryId. The scope controls both dictionary
+/// lifetime and whether the reader loads an in-stripe auxiliary stream, the
+/// file catalog, or an external catalog.
+enum class SharedDictionaryScope : uint8_t {
+  /// Alphabet is stored as an auxiliary stream in the current stripe, and its
+  /// dictionary id is local to that stripe.
+  Stripe = 0,
+  /// Alphabet is stored once in the file shared dictionary catalog, and its
+  /// dictionary id is local to that file. Value 1 is reserved so unknown
+  /// historical values remain invalid.
+  File = 2,
+  /// Alphabet is resolved from an external catalog, and its dictionary id is
+  /// interpreted by the configured resolver.
+  External = 3,
+};
+
+VELOX_DECLARE_ENUM_NAME(SharedDictionaryScope);
+
+inline std::string_view sharedDictionaryScopeString(
+    SharedDictionaryScope scope) {
+  return SharedDictionaryScopeName::toName(scope);
+}
+
+inline SharedDictionaryScope toSharedDictionaryScope(uint8_t value) {
+  const auto scope = static_cast<SharedDictionaryScope>(value);
+  switch (scope) {
+    case SharedDictionaryScope::Stripe:
+    case SharedDictionaryScope::File:
+    case SharedDictionaryScope::External:
+      return scope;
+  }
+  NIMBLE_UNSUPPORTED(
+      "Unsupported shared dictionary scope {}.", static_cast<int>(value));
+}
+
+inline constexpr uint32_t kMaxSharedDictionaryEntryCount =
+    std::numeric_limits<uint32_t>::max();
+
+inline constexpr uint32_t kInvalidSharedDictionaryId =
+    std::numeric_limits<uint32_t>::max();
+
+/// Enables a shared dictionary for one logical scalar stream.
+struct SharedDictionaryConfig {
+  SharedDictionaryScope scope{SharedDictionaryScope::Stripe};
+
+  /// Identifies the dictionary within its scope:
+  /// - Stripe: auxiliary stream id in the current stripe that stores the
+  ///   alphabet.
+  /// - File: entry id in the file shared dictionary catalog.
+  /// - External: id passed through to the external resolver.
+  /// The sentinel default catches accidental use before the writer assigns an
+  /// id in the selected scope.
+  uint32_t dictionaryId{kInvalidSharedDictionaryId};
+
+  /// Uses an externally determined alphabet from the configured resolver
+  /// instead of growing it while encoding values. External-scope dictionaries
+  /// always use a prebuilt alphabet; file-scope dictionaries use one when this
+  /// is set. Forced alphabetEncoding is only allowed when the alphabet is
+  /// prebuilt.
+  bool usesPrebuiltAlphabet{false};
+
+  /// Overrides the encoding used for the stored dictionary alphabet. Empty uses
+  /// regular encoding selection.
+  std::optional<EncodingType> alphabetEncoding;
+};
+
+/// Provides indexed access to one immutable shared dictionary alphabet.
+class SharedDictionaryAlphabet {
+ public:
+  struct DecodedChunk {
+    uint32_t begin{};
+    uint32_t count{};
+    const void* entries{};
+    /// Keeps entries alive for this chunk.
+    std::shared_ptr<const void> owner;
+  };
+
+  struct EncodedChunk {
+    uint32_t begin{};
+    /// Random-access view over the encoded alphabet chunk.
+    std::shared_ptr<const EncodingView> view;
+  };
+
+  virtual ~SharedDictionaryAlphabet() = default;
+
+  static DecodedChunk decodedChunk(
+      uint32_t begin,
+      uint32_t count,
+      const void* entries,
+      std::shared_ptr<const void> owner);
+
+  static EncodedChunk encodedChunk(
+      uint32_t begin,
+      std::shared_ptr<const EncodingView> view);
+
+  static std::shared_ptr<const SharedDictionaryAlphabet> createDecoded(
+      DataType dataType,
+      std::vector<DecodedChunk> chunks);
+
+  static std::shared_ptr<const SharedDictionaryAlphabet> createEncoded(
+      DataType dataType,
+      std::vector<EncodedChunk> chunks);
+
+  DataType dataType() const;
+
+  uint32_t entryCount() const;
+
+  template <typename T>
+  typename TypeTraits<T>::physicalType physicalValueAt(uint32_t index) const {
+    static_assert(
+        !std::is_same_v<T, std::string>,
+        "Use std::string_view for shared dictionary string alphabets.");
+    NIMBLE_CHECK_EQ(
+        dataType(),
+        TypeTraits<T>::dataType,
+        "Shared dictionary has unexpected type.");
+    typename TypeTraits<T>::physicalType output;
+    physicalValueAtImpl(index, &output);
+    return output;
+  }
+
+  template <typename T>
+  void materialize(
+      std::span<const uint32_t> indices,
+      typename TypeTraits<T>::physicalType* output) const {
+    static_assert(
+        !std::is_same_v<T, std::string>,
+        "Use std::string_view for shared dictionary string alphabets.");
+    NIMBLE_CHECK_EQ(
+        dataType(),
+        TypeTraits<T>::dataType,
+        "Shared dictionary has unexpected type.");
+    materializeImpl(indices, output);
+  }
+
+ protected:
+  explicit SharedDictionaryAlphabet(DataType dataType);
+
+  static uint32_t validateDecodedChunks(
+      const std::vector<DecodedChunk>& chunks);
+
+  static uint32_t validateEncodedChunks(
+      DataType dataType,
+      const std::vector<EncodedChunk>& chunks);
+
+  void setEntryCount(uint32_t entryCount);
+
+ private:
+  virtual void physicalValueAtImpl(uint32_t index, void* output) const = 0;
+
+  virtual void materializeImpl(std::span<const uint32_t> indices, void* output)
+      const = 0;
+
+  const DataType dataType_;
+  uint32_t entryCount_{0};
+};
+
+/// Owns an immutable, decoded shared dictionary alphabet split into chunks.
+class DecodedSharedDictionaryAlphabet final : public SharedDictionaryAlphabet {
+ public:
+  using Chunk = SharedDictionaryAlphabet::DecodedChunk;
+
+  DecodedSharedDictionaryAlphabet(DataType dataType, std::vector<Chunk> chunks)
+      : SharedDictionaryAlphabet{dataType}, chunks_{std::move(chunks)} {
+    setEntryCount(validateDecodedChunks(chunks_));
+  }
+
+ private:
+  template <typename T>
+  void getPhysicalValueTyped(uint32_t index, void* output) const {
+    const auto& chunk = chunkForIndex(index);
+    *static_cast<typename TypeTraits<T>::physicalType*>(output) =
+        static_cast<const typename TypeTraits<T>::physicalType*>(
+            chunk.entries)[index - chunk.begin];
+  }
+
+  template <typename T>
+  void materializeTyped(
+      std::span<const uint32_t> indices,
+      typename TypeTraits<T>::physicalType* output) const {
+    if (chunks_.size() == 1) {
+      const auto* entries =
+          static_cast<const typename TypeTraits<T>::physicalType*>(
+              chunks_[0].entries);
+      for (size_t i = 0; i < indices.size(); ++i) {
+        NIMBLE_CHECK_LT(
+            indices[i],
+            entryCount(),
+            "Shared dictionary index exceeds alphabet size.");
+        output[i] = entries[indices[i]];
+      }
+      return;
+    }
+    for (size_t i = 0; i < indices.size(); ++i) {
+      const auto& chunk = chunkForIndex(indices[i]);
+      output[i] = static_cast<const typename TypeTraits<T>::physicalType*>(
+          chunk.entries)[indices[i] - chunk.begin];
+    }
+  }
+
+  void physicalValueAtImpl(uint32_t index, void* output) const final {
+    NIMBLE_RETURN_BY_DATA_TYPE_OR(
+        dataType(),
+        T,
+        (getPhysicalValueTyped<T>(index, output), void()),
+        NIMBLE_UNSUPPORTED(
+            "{} is not supported by shared dictionary alphabets.", dataType()));
+  }
+
+  void materializeImpl(std::span<const uint32_t> indices, void* output)
+      const final {
+    NIMBLE_RETURN_BY_DATA_TYPE_OR(
+        dataType(),
+        T,
+        (materializeTyped<T>(
+             indices,
+             static_cast<typename TypeTraits<T>::physicalType*>(output)),
+         void()),
+        NIMBLE_UNSUPPORTED(
+            "{} is not supported by shared dictionary alphabets.", dataType()));
+  }
+
+  const Chunk& chunkForIndex(uint32_t index) const {
+    NIMBLE_CHECK_LT(
+        index, entryCount(), "Shared dictionary index exceeds alphabet size.");
+    if (chunks_.size() == 1) {
+      return chunks_.front();
+    }
+    const auto it = std::upper_bound(
+        chunks_.begin(),
+        chunks_.end(),
+        index,
+        [](uint32_t value, const Chunk& chunk) { return value < chunk.begin; });
+    NIMBLE_CHECK(it != chunks_.begin());
+    return *std::prev(it);
+  }
+
+  const std::vector<Chunk> chunks_;
+};
+
+/// Owns immutable, encoded shared dictionary alphabet chunks in memory.
+class EncodedSharedDictionaryAlphabet final : public SharedDictionaryAlphabet {
+ public:
+  using Chunk = SharedDictionaryAlphabet::EncodedChunk;
+
+  EncodedSharedDictionaryAlphabet(DataType dataType, std::vector<Chunk> chunks)
+      : SharedDictionaryAlphabet{dataType}, chunks_{std::move(chunks)} {
+    setEntryCount(validateEncodedChunks(dataType, chunks_));
+  }
+
+ private:
+  void readPhysicalValue(uint32_t index, void* output) const {
+    const auto chunkIndex = chunkIndexForIndex(index);
+    const auto& chunk = chunks_[chunkIndex];
+    chunk.view->readAt(index - chunk.begin, output);
+  }
+
+  template <typename T>
+  void materializeTyped(
+      std::span<const uint32_t> indices,
+      typename TypeTraits<T>::physicalType* output) const {
+    if (chunks_.size() == 1) {
+      const auto& chunk = chunks_.front();
+      for (size_t i = 0; i < indices.size(); ++i) {
+        NIMBLE_CHECK_LT(
+            indices[i],
+            entryCount(),
+            "Shared dictionary index exceeds alphabet size.");
+        chunk.view->readAt(indices[i], output + i);
+      }
+      return;
+    }
+    for (size_t i = 0; i < indices.size(); ++i) {
+      const auto chunkIndex = chunkIndexForIndex(indices[i]);
+      const auto& chunk = chunks_[chunkIndex];
+      chunk.view->readAt(indices[i] - chunk.begin, output + i);
+    }
+  }
+
+  void physicalValueAtImpl(uint32_t index, void* output) const final {
+    readPhysicalValue(index, output);
+  }
+
+  void materializeImpl(std::span<const uint32_t> indices, void* output)
+      const final {
+    NIMBLE_RETURN_BY_DATA_TYPE_OR(
+        dataType(),
+        T,
+        (materializeTyped<T>(
+             indices,
+             static_cast<typename TypeTraits<T>::physicalType*>(output)),
+         void()),
+        NIMBLE_UNSUPPORTED(
+            "{} is not supported by shared dictionary alphabets.", dataType()));
+  }
+
+  size_t chunkIndexForIndex(uint32_t index) const {
+    NIMBLE_CHECK_LT(
+        index, entryCount(), "Shared dictionary index exceeds alphabet size.");
+    if (chunks_.size() == 1) {
+      return 0;
+    }
+    const auto it = std::upper_bound(
+        chunks_.begin(),
+        chunks_.end(),
+        index,
+        [](uint32_t value, const Chunk& chunk) { return value < chunk.begin; });
+    NIMBLE_CHECK(it != chunks_.begin());
+    return static_cast<size_t>(std::distance(chunks_.begin(), std::prev(it)));
+  }
+
+  const std::vector<Chunk> chunks_;
+};
+
+/// Resolves a dictionary ID within the current reader's decode context.
+class SharedDictionaryResolver {
+ public:
+  virtual ~SharedDictionaryResolver() = default;
+
+  virtual std::shared_ptr<const SharedDictionaryAlphabet> resolve(
+      SharedDictionaryScope scope,
+      uint32_t dictionaryId,
+      DataType dataType) const = 0;
+};
+
+} // namespace facebook::nimble
+
+template <>
+struct fmt::formatter<facebook::nimble::SharedDictionaryScope>
+    : fmt::formatter<std::string_view> {
+  auto format(
+      facebook::nimble::SharedDictionaryScope scope,
+      format_context& ctx) const {
+    return fmt::formatter<std::string_view>::format(
+        facebook::nimble::SharedDictionaryScopeName::toName(scope), ctx);
+  }
+};

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(
   RLEEncodingViewTest.cpp
   RLEEncodingTest.cpp
   SentinelEncodingTest.cpp
+  SharedDictionaryTypesTest.cpp
   SimdForBitpackEncodingViewTest.cpp
   SliceEncodingTest.cpp
   SparseBoolEncodingViewTest.cpp

--- a/dwio/nimble/encodings/tests/SharedDictionaryTypesTest.cpp
+++ b/dwio/nimble/encodings/tests/SharedDictionaryTypesTest.cpp
@@ -1,0 +1,669 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
+#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
+#include "dwio/nimble/encodings/SharedDictionaryTypes.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::nimble {
+namespace {
+
+enum class AlphabetStorageKind {
+  DecodedChunk,
+  EncodedView,
+};
+
+enum class AlphabetValueKind {
+  Int16,
+  Uint32,
+  Int64,
+  String,
+};
+
+struct AlphabetMaterializeCase {
+  AlphabetStorageKind storage{AlphabetStorageKind::DecodedChunk};
+  AlphabetValueKind value{AlphabetValueKind::Int16};
+  EncodingType encodingType{EncodingType::Trivial};
+  std::vector<std::vector<int64_t>> numberChunks;
+  std::vector<std::vector<std::string_view>> stringChunks;
+  uint32_t valueAtIndex{};
+  std::vector<uint32_t> indices;
+};
+
+std::string alphabetStorageKindName(AlphabetStorageKind storage) {
+  switch (storage) {
+    case AlphabetStorageKind::DecodedChunk:
+      return "decodedChunk";
+    case AlphabetStorageKind::EncodedView:
+      return "encodedView";
+  }
+  return fmt::format("unknownStorage{}", static_cast<int>(storage));
+}
+
+std::string alphabetValueKindName(AlphabetValueKind kind) {
+  switch (kind) {
+    case AlphabetValueKind::Int16:
+      return "int16";
+    case AlphabetValueKind::Uint32:
+      return "uint32";
+    case AlphabetValueKind::Int64:
+      return "int64";
+    case AlphabetValueKind::String:
+      return "string";
+  }
+  return fmt::format("unknownValue{}", static_cast<int>(kind));
+}
+
+std::string alphabetEncodingTypeName(EncodingType encodingType) {
+  if (encodingType == EncodingType::Trivial) {
+    return "trivial";
+  }
+  if (encodingType == EncodingType::BlockBitPacking) {
+    return "blockBitPacking";
+  }
+  if (encodingType == EncodingType::DeltaBlock) {
+    return "deltaBlock";
+  }
+  return fmt::format("encoding{}", static_cast<int>(encodingType));
+}
+
+std::string alphabetMaterializeCaseName(
+    const testing::TestParamInfo<AlphabetMaterializeCase>& info) {
+  auto name = alphabetStorageKindName(info.param.storage) + "_" +
+      alphabetValueKindName(info.param.value);
+  if (info.param.storage == AlphabetStorageKind::EncodedView) {
+    name += "_" + alphabetEncodingTypeName(info.param.encodingType);
+  }
+  return name;
+}
+
+std::string alphabetMaterializeCaseDescription(
+    const AlphabetMaterializeCase& testCase) {
+  return fmt::format(
+      "{}_{}_{}",
+      alphabetStorageKindName(testCase.storage),
+      alphabetValueKindName(testCase.value),
+      alphabetEncodingTypeName(testCase.encodingType));
+}
+
+uint32_t alphabetMaterializeCaseSeed(const AlphabetMaterializeCase& testCase) {
+  return 0x5EED'1000u ^ (static_cast<uint32_t>(testCase.storage) << 16) ^
+      (static_cast<uint32_t>(testCase.value) << 8) ^
+      static_cast<uint32_t>(testCase.encodingType);
+}
+
+constexpr size_t kNumberValuesPerChunk{18};
+constexpr size_t kNumberChunkCount{3};
+constexpr size_t kRandomReadIterations{64};
+
+std::vector<uint32_t> numberMaterializeIndices() {
+  return {17, 0, 28, 3, 45, 21, 53, 12, 37};
+}
+
+std::vector<uint32_t> stringMaterializeIndices() {
+  return {7, 0, 10, 3, 17, 12, 23};
+}
+
+std::vector<std::vector<int64_t>> unsortedSignedNumberChunks() {
+  std::vector<std::vector<int64_t>> chunks;
+  chunks.reserve(kNumberChunkCount);
+  for (size_t chunkIndex{0}; chunkIndex < kNumberChunkCount; ++chunkIndex) {
+    auto& chunk = chunks.emplace_back();
+    chunk.reserve(kNumberValuesPerChunk);
+    for (size_t i{0}; i < kNumberValuesPerChunk; ++i) {
+      const auto magnitude =
+          static_cast<int64_t>((chunkIndex + 1) * 100 + i * 11);
+      chunk.push_back(i % 2 == 0 ? magnitude : -magnitude);
+    }
+  }
+  return chunks;
+}
+
+std::vector<std::vector<int64_t>> sortedSignedNumberChunks() {
+  std::vector<std::vector<int64_t>> chunks;
+  chunks.reserve(kNumberChunkCount);
+  for (size_t chunkIndex{0}; chunkIndex < kNumberChunkCount; ++chunkIndex) {
+    auto& chunk = chunks.emplace_back();
+    chunk.reserve(kNumberValuesPerChunk);
+    const auto first = static_cast<int64_t>(chunkIndex * 1'000) - 800;
+    for (size_t i{0}; i < kNumberValuesPerChunk; ++i) {
+      chunk.push_back(first + static_cast<int64_t>(i * 13));
+    }
+  }
+  return chunks;
+}
+
+std::vector<std::vector<int64_t>> unsortedUnsignedNumberChunks() {
+  std::vector<std::vector<int64_t>> chunks;
+  chunks.reserve(kNumberChunkCount);
+  for (size_t chunkIndex{0}; chunkIndex < kNumberChunkCount; ++chunkIndex) {
+    auto& chunk = chunks.emplace_back();
+    chunk.reserve(kNumberValuesPerChunk);
+    for (size_t i{0}; i < kNumberValuesPerChunk; ++i) {
+      chunk.push_back(
+          static_cast<int64_t>((chunkIndex + 1) * 1'000 + i) +
+          static_cast<int64_t>((i * 7) % kNumberValuesPerChunk) * 31);
+    }
+  }
+  return chunks;
+}
+
+std::vector<std::vector<std::string_view>> stringChunks() {
+  return {
+      {"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"},
+      {"iota", "kappa", "lambda", "mu", "nu", "xi", "omicron", "pi"},
+      {"rho", "sigma", "tau", "upsilon", "phi", "chi", "psi", "omega"}};
+}
+
+AlphabetMaterializeCase numberCase(
+    AlphabetStorageKind storage,
+    AlphabetValueKind value,
+    EncodingType encodingType,
+    std::vector<std::vector<int64_t>> chunks) {
+  AlphabetMaterializeCase testCase;
+  testCase.storage = storage;
+  testCase.value = value;
+  testCase.encodingType = encodingType;
+  testCase.numberChunks = std::move(chunks);
+  testCase.valueAtIndex = 45;
+  testCase.indices = numberMaterializeIndices();
+  return testCase;
+}
+
+AlphabetMaterializeCase stringCase(
+    AlphabetStorageKind storage,
+    EncodingType encodingType) {
+  AlphabetMaterializeCase testCase;
+  testCase.storage = storage;
+  testCase.value = AlphabetValueKind::String;
+  testCase.encodingType = encodingType;
+  testCase.stringChunks = stringChunks();
+  testCase.valueAtIndex = 17;
+  testCase.indices = stringMaterializeIndices();
+  return testCase;
+}
+
+class SharedDictionaryTypesTestBase : public testing::Test {
+ protected:
+  void SetUp() final {
+    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+    buffer_ = std::make_unique<Buffer>(*pool_);
+  }
+
+  template <typename T>
+  Vector<T> makeVector(const std::vector<T>& values) {
+    Vector<T> out{pool_.get()};
+    out.insert(out.end(), values.data(), values.data() + values.size());
+    return out;
+  }
+
+  SharedDictionaryAlphabet::EncodedChunk makeEncodedChunk(
+      uint32_t begin,
+      std::string_view encoded,
+      const Encoding::Options& options) {
+    auto owner = std::make_shared<std::string>(encoded);
+    auto view = createEncodingView(
+        std::string_view{owner->data(), owner->size()}, pool_.get(), options);
+    encodedOwners_.push_back(owner);
+    return SharedDictionaryAlphabet::encodedChunk(
+        begin, std::shared_ptr<const EncodingView>{std::move(view)});
+  }
+
+  template <typename T>
+  static typename TypeTraits<T>::physicalType physical(T value) {
+    return EncodingPhysicalType<T>::asEncodingPhysicalType(value);
+  }
+
+  template <typename T>
+  static std::vector<std::vector<T>> valueChunks(
+      const AlphabetMaterializeCase& testCase) {
+    if constexpr (std::is_same_v<T, std::string_view>) {
+      return testCase.stringChunks;
+    } else {
+      std::vector<std::vector<T>> out;
+      out.reserve(testCase.numberChunks.size());
+      for (const auto& chunk : testCase.numberChunks) {
+        auto& typedChunk = out.emplace_back();
+        typedChunk.reserve(chunk.size());
+        for (const auto value : chunk) {
+          typedChunk.push_back(static_cast<T>(value));
+        }
+      }
+      return out;
+    }
+  }
+
+  template <typename T>
+  static std::vector<T> flattenedValues(
+      const AlphabetMaterializeCase& testCase) {
+    std::vector<T> out;
+    for (const auto& chunk : valueChunks<T>(testCase)) {
+      out.insert(out.end(), chunk.begin(), chunk.end());
+    }
+    return out;
+  }
+
+  template <typename T>
+  static std::vector<T> expectedValues(
+      const AlphabetMaterializeCase& testCase) {
+    return expectedValues<T>(
+        testCase,
+        std::span<const uint32_t>{
+            testCase.indices.data(), testCase.indices.size()});
+  }
+
+  template <typename T>
+  static std::vector<T> expectedValues(
+      const AlphabetMaterializeCase& testCase,
+      std::span<const uint32_t> indices) {
+    const auto values = flattenedValues<T>(testCase);
+    std::vector<T> out;
+    out.reserve(indices.size());
+    for (const auto index : indices) {
+      NIMBLE_CHECK_LT(index, values.size());
+      out.push_back(values[index]);
+    }
+    return out;
+  }
+
+  template <typename T>
+  std::shared_ptr<std::vector<typename TypeTraits<T>::physicalType>>
+  makePhysicalVector(const std::vector<T>& values) {
+    auto out =
+        std::make_shared<std::vector<typename TypeTraits<T>::physicalType>>();
+    out->reserve(values.size());
+    for (const auto& value : values) {
+      out->push_back(physical<T>(value));
+    }
+    return out;
+  }
+
+  template <typename T>
+  std::shared_ptr<const SharedDictionaryAlphabet> makeDecodedAlphabet(
+      const AlphabetMaterializeCase& testCase) {
+    std::vector<SharedDictionaryAlphabet::DecodedChunk> decodedChunks;
+    uint32_t begin{0};
+    for (const auto& chunk : valueChunks<T>(testCase)) {
+      auto entries = makePhysicalVector<T>(chunk);
+      decodedChunks.push_back(
+          SharedDictionaryAlphabet::decodedChunk(
+              begin,
+              static_cast<uint32_t>(entries->size()),
+              entries->data(),
+              entries));
+      begin += static_cast<uint32_t>(entries->size());
+    }
+    return SharedDictionaryAlphabet::createDecoded(
+        TypeTraits<T>::dataType, std::move(decodedChunks));
+  }
+
+  template <typename T>
+  std::string_view encodeWithTrivial(
+      const std::vector<T>& values,
+      const Encoding::Options& options) {
+    return test::Encoder<TrivialEncoding<T>>::encode(
+        *buffer_,
+        makeVector<T>(values),
+        CompressionType::Uncompressed,
+        options);
+  }
+
+  template <typename T>
+  std::string_view encodeWithBlockBitPacking(
+      const std::vector<T>& values,
+      const Encoding::Options& options) {
+    if constexpr (isNumericType<typename TypeTraits<T>::physicalType>()) {
+      return test::Encoder<BlockBitPackingEncoding<T>>::encode(
+          *buffer_,
+          makeVector<T>(values),
+          CompressionType::Uncompressed,
+          options);
+    }
+    NIMBLE_UNSUPPORTED(
+        "BlockBitPacking test mode does not support {}.",
+        TypeTraits<T>::dataType);
+  }
+
+  template <typename T>
+  std::string_view encodeWithDeltaBlock(
+      const std::vector<T>& values,
+      const Encoding::Options& options) {
+    if constexpr (isIntegralType<T>() && !std::is_same_v<T, bool>) {
+      return test::Encoder<DeltaBlockEncoding<T>>::encode(
+          *buffer_,
+          makeVector<T>(values),
+          CompressionType::Uncompressed,
+          options);
+    }
+    NIMBLE_UNSUPPORTED(
+        "DeltaBlock test mode does not support {}.", TypeTraits<T>::dataType);
+  }
+
+  Encoding::Options encodingOptions(EncodingType encodingType) const {
+    Encoding::Options options;
+    if (encodingType == EncodingType::DeltaBlock) {
+      options.deltaBlockSize = 16;
+    }
+    return options;
+  }
+
+  template <typename T>
+  std::string_view encodeValues(
+      const std::vector<T>& values,
+      EncodingType encodingType,
+      const Encoding::Options& options) {
+    if (encodingType == EncodingType::Trivial) {
+      return encodeWithTrivial<T>(values, options);
+    }
+    if (encodingType == EncodingType::BlockBitPacking) {
+      return encodeWithBlockBitPacking<T>(values, options);
+    }
+    if (encodingType == EncodingType::DeltaBlock) {
+      return encodeWithDeltaBlock<T>(values, options);
+    }
+    NIMBLE_UNSUPPORTED(
+        "{} test mode is not supported by shared dictionary tests.",
+        encodingType);
+  }
+
+  template <typename T>
+  SharedDictionaryAlphabet::EncodedChunk makeEncodedChunk(
+      uint32_t begin,
+      const std::vector<T>& values,
+      EncodingType encodingType) {
+    const auto options = encodingOptions(encodingType);
+    return makeEncodedChunk(
+        begin, encodeValues<T>(values, encodingType, options), options);
+  }
+
+  template <typename T>
+  std::shared_ptr<const SharedDictionaryAlphabet> makeEncodedAlphabet(
+      const AlphabetMaterializeCase& testCase) {
+    std::vector<SharedDictionaryAlphabet::EncodedChunk> encodedChunks;
+    uint32_t begin{0};
+    for (const auto& chunk : valueChunks<T>(testCase)) {
+      encodedChunks.push_back(
+          makeEncodedChunk<T>(begin, chunk, testCase.encodingType));
+      begin += static_cast<uint32_t>(chunk.size());
+    }
+    return SharedDictionaryAlphabet::createEncoded(
+        TypeTraits<T>::dataType, std::move(encodedChunks));
+  }
+
+  template <typename T>
+  std::shared_ptr<const SharedDictionaryAlphabet> makeAlphabet(
+      const AlphabetMaterializeCase& testCase) {
+    switch (testCase.storage) {
+      case AlphabetStorageKind::DecodedChunk:
+        return makeDecodedAlphabet<T>(testCase);
+      case AlphabetStorageKind::EncodedView:
+        return makeEncodedAlphabet<T>(testCase);
+    }
+    NIMBLE_UNSUPPORTED(
+        "Unsupported alphabet storage kind {}.",
+        alphabetStorageKindName(testCase.storage));
+  }
+
+  template <typename T>
+  static std::vector<T> logicalValues(
+      const std::vector<typename TypeTraits<T>::physicalType>& values) {
+    std::vector<T> out;
+    out.reserve(values.size());
+    for (const auto& value : values) {
+      out.push_back(EncodingPhysicalType<T>::asEncodingLogicalType(value));
+    }
+    return out;
+  }
+
+  template <typename T>
+  void verifyMaterialize(const AlphabetMaterializeCase& testCase) {
+    const auto alphabet = makeAlphabet<T>(testCase);
+
+    EXPECT_EQ(alphabet->entryCount(), flattenedValues<T>(testCase).size());
+    EXPECT_EQ(
+        EncodingPhysicalType<T>::asEncodingLogicalType(
+            alphabet->template physicalValueAt<T>(testCase.valueAtIndex)),
+        flattenedValues<T>(testCase)[testCase.valueAtIndex]);
+
+    std::vector<typename TypeTraits<T>::physicalType> values(
+        testCase.indices.size());
+    alphabet->template materialize<T>(
+        std::span<const uint32_t>{
+            testCase.indices.data(), testCase.indices.size()},
+        values.data());
+    EXPECT_EQ(logicalValues<T>(values), expectedValues<T>(testCase));
+  }
+
+  template <typename T>
+  void verifyMaterialize(
+      const SharedDictionaryAlphabet& alphabet,
+      const AlphabetMaterializeCase& testCase,
+      std::span<const uint32_t> indices) {
+    std::vector<typename TypeTraits<T>::physicalType> values(indices.size());
+    alphabet.template materialize<T>(indices, values.data());
+    EXPECT_EQ(logicalValues<T>(values), expectedValues<T>(testCase, indices));
+  }
+
+  std::vector<uint32_t> rangeIndices(uint32_t begin, uint32_t count) {
+    std::vector<uint32_t> indices;
+    indices.reserve(count);
+    for (uint32_t offset{0}; offset < count; ++offset) {
+      indices.push_back(begin + offset);
+    }
+    return indices;
+  }
+
+  std::vector<uint32_t> randomIndices(
+      std::mt19937& random,
+      uint32_t entryCount) {
+    std::uniform_int_distribution<uint32_t> sizeDistribution{1, entryCount};
+    std::uniform_int_distribution<uint32_t> indexDistribution{
+        0, entryCount - 1};
+    const auto size = sizeDistribution(random);
+    std::vector<uint32_t> indices;
+    indices.reserve(size);
+    for (uint32_t i{0}; i < size; ++i) {
+      indices.push_back(indexDistribution(random));
+    }
+    return indices;
+  }
+
+  std::vector<uint32_t> randomRangeIndices(
+      std::mt19937& random,
+      uint32_t entryCount) {
+    std::uniform_int_distribution<uint32_t> beginDistribution{
+        0, entryCount - 1};
+    const auto begin = beginDistribution(random);
+    std::uniform_int_distribution<uint32_t> countDistribution{
+        1, entryCount - begin};
+    return rangeIndices(begin, countDistribution(random));
+  }
+
+  template <typename T>
+  void verifyRandomMaterialize(const AlphabetMaterializeCase& testCase) {
+    const auto alphabet = makeAlphabet<T>(testCase);
+    const auto values = flattenedValues<T>(testCase);
+    ASSERT_EQ(alphabet->entryCount(), values.size());
+    ASSERT_GT(alphabet->entryCount(), 0);
+
+    auto random = std::mt19937{alphabetMaterializeCaseSeed(testCase)};
+    const auto entryCount = alphabet->entryCount();
+
+    const auto verifyIndices = [&](std::string_view label,
+                                   const std::vector<uint32_t>& indices) {
+      SCOPED_TRACE(
+          fmt::format(
+              "{} {} size={}",
+              alphabetMaterializeCaseDescription(testCase),
+              label,
+              indices.size()));
+      verifyMaterialize<T>(
+          *alphabet,
+          testCase,
+          std::span<const uint32_t>{indices.data(), indices.size()});
+    };
+
+    verifyIndices("singleValueRange", rangeIndices(entryCount / 2, 1));
+    verifyIndices("fullRange", rangeIndices(/*begin=*/0, entryCount));
+
+    std::uniform_int_distribution<uint32_t> indexDistribution{
+        0, entryCount - 1};
+    for (size_t i{0}; i < kRandomReadIterations; ++i) {
+      SCOPED_TRACE(
+          fmt::format(
+              "{} iteration={}",
+              alphabetMaterializeCaseDescription(testCase),
+              i));
+      const auto index = indexDistribution(random);
+      EXPECT_EQ(
+          EncodingPhysicalType<T>::asEncodingLogicalType(
+              alphabet->template physicalValueAt<T>(index)),
+          values[index]);
+      verifyIndices("randomIndices", randomIndices(random, entryCount));
+      verifyIndices("randomRange", randomRangeIndices(random, entryCount));
+    }
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<Buffer> buffer_;
+  std::vector<std::shared_ptr<const std::string>> encodedOwners_;
+};
+
+class SharedDictionaryTypesTest
+    : public SharedDictionaryTypesTestBase,
+      public testing::WithParamInterface<AlphabetMaterializeCase> {
+ protected:
+  void verifyMaterialize() {
+    const auto& testCase = GetParam();
+    switch (testCase.value) {
+      case AlphabetValueKind::Int16:
+        SharedDictionaryTypesTestBase::verifyMaterialize<int16_t>(testCase);
+        return;
+      case AlphabetValueKind::Uint32:
+        SharedDictionaryTypesTestBase::verifyMaterialize<uint32_t>(testCase);
+        return;
+      case AlphabetValueKind::Int64:
+        SharedDictionaryTypesTestBase::verifyMaterialize<int64_t>(testCase);
+        return;
+      case AlphabetValueKind::String:
+        SharedDictionaryTypesTestBase::verifyMaterialize<std::string_view>(
+            testCase);
+        return;
+    }
+  }
+
+  void verifyRandomMaterialize() {
+    const auto& testCase = GetParam();
+    switch (testCase.value) {
+      case AlphabetValueKind::Int16:
+        SharedDictionaryTypesTestBase::verifyRandomMaterialize<int16_t>(
+            testCase);
+        return;
+      case AlphabetValueKind::Uint32:
+        SharedDictionaryTypesTestBase::verifyRandomMaterialize<uint32_t>(
+            testCase);
+        return;
+      case AlphabetValueKind::Int64:
+        SharedDictionaryTypesTestBase::verifyRandomMaterialize<int64_t>(
+            testCase);
+        return;
+      case AlphabetValueKind::String:
+        SharedDictionaryTypesTestBase::verifyRandomMaterialize<
+            std::string_view>(testCase);
+        return;
+    }
+  }
+};
+
+TEST_P(SharedDictionaryTypesTest, materializesAcrossChunks) {
+  verifyMaterialize();
+}
+
+TEST_P(SharedDictionaryTypesTest, materializesRandomIndicesAndRanges) {
+  verifyRandomMaterialize();
+}
+
+TEST(SharedDictionaryScopeTest, formatsNames) {
+  EXPECT_EQ(
+      SharedDictionaryScopeName::toName(SharedDictionaryScope::Stripe),
+      "Stripe");
+  EXPECT_EQ(
+      SharedDictionaryScopeName::toSharedDictionaryScope("File"),
+      SharedDictionaryScope::File);
+  EXPECT_EQ(fmt::format("{}", SharedDictionaryScope::External), "External");
+  EXPECT_FALSE(
+      SharedDictionaryScopeName::tryToSharedDictionaryScope("Unknown"));
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    sharedDictionaryAlphabet,
+    SharedDictionaryTypesTest,
+    testing::Values(
+        numberCase(
+            AlphabetStorageKind::DecodedChunk,
+            AlphabetValueKind::Int16,
+            EncodingType::Trivial,
+            unsortedSignedNumberChunks()),
+        numberCase(
+            AlphabetStorageKind::EncodedView,
+            AlphabetValueKind::Int16,
+            EncodingType::Trivial,
+            unsortedSignedNumberChunks()),
+        numberCase(
+            AlphabetStorageKind::DecodedChunk,
+            AlphabetValueKind::Uint32,
+            EncodingType::Trivial,
+            unsortedUnsignedNumberChunks()),
+        numberCase(
+            AlphabetStorageKind::EncodedView,
+            AlphabetValueKind::Uint32,
+            EncodingType::BlockBitPacking,
+            unsortedUnsignedNumberChunks()),
+        numberCase(
+            AlphabetStorageKind::DecodedChunk,
+            AlphabetValueKind::Int64,
+            EncodingType::Trivial,
+            unsortedSignedNumberChunks()),
+        numberCase(
+            AlphabetStorageKind::EncodedView,
+            AlphabetValueKind::Int64,
+            EncodingType::DeltaBlock,
+            sortedSignedNumberChunks()),
+        stringCase(AlphabetStorageKind::DecodedChunk, EncodingType::Trivial),
+        stringCase(AlphabetStorageKind::EncodedView, EncodingType::Trivial)),
+    alphabetMaterializeCaseName);
+
+} // namespace
+} // namespace facebook::nimble


### PR DESCRIPTION
Summary:

Add shared dictionary scope/config and decoded/encoded alphabet abstractions with focused tests. This splits the shared dictionary type definitions into the bottom diff before the writer and encoding diffs.

Reviewed By: HuamengJiang

Differential Revision: D114648770


