### PR TITLE
fix(nimble): Preserve Iceberg IDs in flat maps

### DIFF
--- a/dwio/nimble/velox/tests/VeloxReaderTest.cpp
+++ b/dwio/nimble/velox/tests/VeloxReaderTest.cpp
@@ -7815,6 +7815,158 @@ TEST_P(VeloxReaderTest, attributesByColumnRoundTripCollections) {
   EXPECT_EQ(kValueAttrs, mapType.values()->attributes());
 }
 
+TEST_P(VeloxReaderTest, flatMapIcebergAttributesUseRepresentativeValue) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto type =
+      velox::ROW({"scores"}, {velox::MAP(velox::INTEGER(), velox::DOUBLE())});
+
+  facebook::nimble::VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns["scores"];
+  // Pre-order node ids: scores=1, key=2, value=3.
+  writerOptions.schemaAttributes[1] = {{"iceberg.id", "20"}};
+  writerOptions.schemaAttributes[2] = {{"iceberg.id", "21"}};
+  writerOptions.schemaAttributes[3] = {{"iceberg.id", "22"}};
+
+  auto scores = vectorMaker.mapVector(
+      {0},
+      vectorMaker.flatVector<int32_t>({7, 9}),
+      vectorMaker.flatVector<double>({1.5, 2.5}));
+  auto vector = vectorMaker.rowVector({"scores"}, {scores});
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_, vector, std::move(writerOptions));
+
+  velox::InMemoryReadFile readFile(file);
+  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
+  nimble::VeloxReader reader(
+      &readFile, *leafPool_, std::move(selector), createReadParams());
+  const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+  ASSERT_EQ(2, flatMap.childrenCount());
+  const std::vector<std::pair<std::string, std::string>> kFlatMapAttrs = {
+      {"iceberg.id", "20"},
+      {"iceberg.key.id", "21"},
+  };
+  EXPECT_EQ(kFlatMapAttrs, flatMap.attributes());
+  const std::vector<std::pair<std::string, std::string>> kValueAttrs = {
+      {"iceberg.id", "22"},
+  };
+  EXPECT_EQ(kValueAttrs, flatMap.childAt(0)->attributes());
+  EXPECT_TRUE(flatMap.childAt(1)->attributes().empty());
+}
+
+TEST_P(VeloxReaderTest, emptyFlatMapIcebergAttributesUseDummyValue) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto type =
+      velox::ROW({"scores"}, {velox::MAP(velox::INTEGER(), velox::DOUBLE())});
+
+  facebook::nimble::VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns["scores"];
+  writerOptions.schemaAttributes[1] = {{"iceberg.id", "20"}};
+  writerOptions.schemaAttributes[2] = {{"iceberg.id", "21"}};
+  writerOptions.schemaAttributes[3] = {{"iceberg.id", "22"}};
+
+  auto scores = vectorMaker.mapVector(
+      {0},
+      vectorMaker.flatVector<int32_t>({}),
+      vectorMaker.flatVector<double>({}));
+  auto vector = vectorMaker.rowVector({"scores"}, {scores});
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_, vector, std::move(writerOptions));
+
+  velox::InMemoryReadFile readFile(file);
+  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
+  nimble::VeloxReader reader(
+      &readFile, *leafPool_, std::move(selector), createReadParams());
+  const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+  ASSERT_EQ(1, flatMap.childrenCount());
+  const std::vector<std::pair<std::string, std::string>> kFlatMapAttrs = {
+      {"iceberg.id", "20"},
+      {"iceberg.key.id", "21"},
+  };
+  EXPECT_EQ(kFlatMapAttrs, flatMap.attributes());
+  const std::vector<std::pair<std::string, std::string>> kValueAttrs = {
+      {"iceberg.id", "22"},
+  };
+  EXPECT_EQ(kValueAttrs, flatMap.childAt(0)->attributes());
+}
+
+TEST_P(VeloxReaderTest, flatMapNestedIcebergAttributesUseRepresentativeValue) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto valueType =
+      velox::ROW({"name", "age"}, {velox::VARCHAR(), velox::INTEGER()});
+  auto type =
+      velox::ROW({"profiles"}, {velox::MAP(velox::INTEGER(), valueType)});
+
+  facebook::nimble::VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns["profiles"];
+  // Pre-order node ids: profiles=1, key=2, value=3, name=4, age=5.
+  writerOptions.schemaAttributes[1] = {{"iceberg.id", "30"}};
+  writerOptions.schemaAttributes[2] = {{"iceberg.id", "31"}};
+  writerOptions.schemaAttributes[3] = {{"iceberg.id", "32"}};
+  writerOptions.schemaAttributes[4] = {{"iceberg.id", "33"}};
+  writerOptions.schemaAttributes[5] = {{"iceberg.id", "34"}};
+
+  auto values = vectorMaker.rowVector(
+      {"name", "age"},
+      {vectorMaker.flatVector<velox::StringView>({"alice", "bob"}),
+       vectorMaker.flatVector<int32_t>({30, 40})});
+  auto profiles = vectorMaker.mapVector(
+      {0}, vectorMaker.flatVector<int32_t>({7, 9}), values);
+  auto vector = vectorMaker.rowVector({"profiles"}, {profiles});
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_, vector, std::move(writerOptions));
+
+  velox::InMemoryReadFile readFile(file);
+  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
+  nimble::VeloxReader reader(
+      &readFile, *leafPool_, std::move(selector), createReadParams());
+  const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+  ASSERT_EQ(2, flatMap.childrenCount());
+  const auto& representativeValue = flatMap.childAt(0)->asRow();
+  const std::vector<std::pair<std::string, std::string>> kValueAttrs = {
+      {"iceberg.id", "32"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kNameAttrs = {
+      {"iceberg.id", "33"},
+  };
+  const std::vector<std::pair<std::string, std::string>> kAgeAttrs = {
+      {"iceberg.id", "34"},
+  };
+  EXPECT_EQ(kValueAttrs, representativeValue.attributes());
+  EXPECT_EQ(kNameAttrs, representativeValue.childAt(0)->attributes());
+  EXPECT_EQ(kAgeAttrs, representativeValue.childAt(1)->attributes());
+
+  const auto& duplicateValue = flatMap.childAt(1)->asRow();
+  EXPECT_TRUE(duplicateValue.attributes().empty());
+  EXPECT_TRUE(duplicateValue.childAt(0)->attributes().empty());
+  EXPECT_TRUE(duplicateValue.childAt(1)->attributes().empty());
+}
+
+TEST_P(VeloxReaderTest, flatMapAttributesEmptyByDefault) {
+  facebook::velox::test::VectorMaker vectorMaker(leafPool_.get());
+  auto type =
+      velox::ROW({"scores"}, {velox::MAP(velox::INTEGER(), velox::DOUBLE())});
+
+  facebook::nimble::VeloxWriterOptions writerOptions;
+  writerOptions.flatMapColumns["scores"];
+  auto scores = vectorMaker.mapVector(
+      {0},
+      vectorMaker.flatVector<int32_t>({7, 9}),
+      vectorMaker.flatVector<double>({1.5, 2.5}));
+  auto vector = vectorMaker.rowVector({"scores"}, {scores});
+  auto file = nimble::test::createNimbleFile(
+      *rootPool_, vector, std::move(writerOptions));
+
+  velox::InMemoryReadFile readFile(file);
+  auto selector = std::make_shared<velox::dwio::common::ColumnSelector>(type);
+  nimble::VeloxReader reader(
+      &readFile, *leafPool_, std::move(selector), createReadParams());
+  const auto& flatMap = reader.schema()->asRow().childAt(0)->asFlatMap();
+  ASSERT_EQ(2, flatMap.childrenCount());
+  EXPECT_TRUE(flatMap.attributes().empty());
+  EXPECT_TRUE(flatMap.childAt(0)->attributes().empty());
+  EXPECT_TRUE(flatMap.childAt(1)->attributes().empty());
+}
+
 // Backward-compat: a writer that does NOT set schemaAttributes must
 // produce a NIMBLE file whose deserialized Type tree exposes empty
 // attributes on every node. Pins the no-op upgrade path for every

--- a/dwio/nimble/writer/VeloxWriter.cpp
+++ b/dwio/nimble/writer/VeloxWriter.cpp
@@ -22,6 +22,9 @@
 #include <unordered_set>
 #include <vector>
 
+#include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
+
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
@@ -802,11 +805,20 @@ WriterStreamContext& streamContext(const StreamDescriptorBuilder& descriptor) {
 std::unique_ptr<FieldWriter> createRootFieldWriter(
     const std::shared_ptr<const velox::dwio::common::TypeWithId>& type,
     detail::WriterContext& context) {
+  folly::F14FastMap<uint32_t, uint32_t> flatMapKeyIdByMapId;
+  folly::F14FastSet<uint32_t> flatMapValueNodeIds;
   if (!context.options().flatMapColumns.empty()) {
     context.reserveFlatMapNodes(context.options().flatMapColumns.size());
+    flatMapKeyIdByMapId.reserve(context.options().flatMapColumns.size());
     for (const auto& [columnName, keys] : context.options().flatMapColumns) {
-      auto nodeId = type->childByName(columnName)->id();
-      context.addFlatMapNodeId(nodeId, keys);
+      const auto& flatMapType = type->childByName(columnName);
+      const auto mapNodeId = flatMapType->id();
+      context.addFlatMapNodeId(mapNodeId, keys);
+      flatMapKeyIdByMapId.emplace(mapNodeId, flatMapType->childAt(0)->id());
+      findNodeIds(
+          *flatMapType->childAt(1), flatMapValueNodeIds, [](const TypeWithId&) {
+            return true;
+          });
     }
   }
 
@@ -845,17 +857,53 @@ std::unique_ptr<FieldWriter> createRootFieldWriter(
   // receives, so the lookup is a direct O(1) hit as each TypeBuilder is
   // constructed. Ids with no matching node are simply never looked up.
   return FieldWriter::create(
-      context, type, [&context](TypeBuilder& type, uint32_t nodeId) {
+      context,
+      type,
+      [&context,
+       flatMapKeyIdByMapId = std::move(flatMapKeyIdByMapId),
+       flatMapValueNodeIds = std::move(flatMapValueNodeIds),
+       stampedFlatMapValueNodeIds = folly::F14FastSet<uint32_t>{}](
+          TypeBuilder& type, uint32_t nodeId) mutable {
         if (type.kind() == Kind::Row) {
           streamContext(type.asRow().nullsDescriptor()).setIsNullStream(true);
         } else if (type.kind() == Kind::FlatMap) {
           streamContext(type.asFlatMap().nullsDescriptor())
               .setIsNullStream(true);
         }
+
         const auto& schemaAttributes = context.options().schemaAttributes;
-        auto it = schemaAttributes.find(nodeId);
-        if (it != schemaAttributes.end()) {
-          type.setAttributes(it->second);
+        if (type.kind() == Kind::FlatMap) {
+          std::vector<std::pair<std::string, std::string>> attributes;
+          if (const auto mapAttributes = schemaAttributes.find(nodeId);
+              mapAttributes != schemaAttributes.end()) {
+            attributes = mapAttributes->second;
+          }
+          if (const auto keyNode = flatMapKeyIdByMapId.find(nodeId);
+              keyNode != flatMapKeyIdByMapId.end()) {
+            if (const auto keyAttributes =
+                    schemaAttributes.find(keyNode->second);
+                keyAttributes != schemaAttributes.end()) {
+              for (const auto& [key, value] : keyAttributes->second) {
+                if (key == "iceberg.id") {
+                  attributes.emplace_back("iceberg.key.id", value);
+                  break;
+                }
+              }
+            }
+          }
+          if (!attributes.empty()) {
+            type.setAttributes(std::move(attributes));
+          }
+          return;
+        }
+
+        if (flatMapValueNodeIds.contains(nodeId) &&
+            !stampedFlatMapValueNodeIds.insert(nodeId).second) {
+          return;
+        }
+        if (const auto attributes = schemaAttributes.find(nodeId);
+            attributes != schemaAttributes.end()) {
+          type.setAttributes(attributes->second);
         }
       });
 }

--- a/dwio/nimble/writer/VeloxWriterOptions.h
+++ b/dwio/nimble/writer/VeloxWriterOptions.h
@@ -148,6 +148,12 @@ struct VeloxWriterOptions {
   /// so callers may submit a superset and let schema evolution drop entries
   /// that no longer apply.
   ///
+  /// Flat-map producers still provide the logical MAP node ids (map, key, then
+  /// value subtree). Because a NIMBLE flat map has no physical key node and
+  /// duplicates its value subtree once per key, the writer folds the key's
+  /// `iceberg.id` into `iceberg.key.id` on the flat-map node and stamps
+  /// ordinary value-subtree attributes only on the first physical value copy.
+  ///
   /// Empty map (default) is a no-op: every existing NIMBLE writer produces
   /// byte-identical files.
   folly::F14FastMap<uint32_t, std::vector<std::pair<std::string, std::string>>>


### PR DESCRIPTION
Summary: Nimble flat maps previously dropped the logical map key field ID and repeated the value field IDs for every physical key, violating Iceberg schema uniqueness and preventing reliable field-ID resolution. Preserve the logical map identity through the flat representation by carrying the key ID on the flat-map node, keeping value IDs on one representative subtree, and reconstructing that logical view on read.

Differential Revision: D114811577


