### PR TITLE
fix(reader): Default metadata IO stats in configureOptions

### DIFF
--- a/dwio/nimble/tablet/TabletReader.cpp
+++ b/dwio/nimble/tablet/TabletReader.cpp
@@ -94,6 +94,18 @@ TabletReader::Options TabletReader::configureOptions(
   tabletOptions.fileHandle = options.fileHandle();
   tabletOptions.cache = options.cache();
   tabletOptions.ioOptions = options;
+
+  // TODO(T272495998): Temporary shim. Remove once HiveDataSource plumbs a
+  // real `metadataIoStats` through `ReaderOptions` that the operator /
+  // connector exposes for observability. Until then, synthesize a default
+  // when the caller does not supply one, so that callers reaching a reader
+  // via Velox's HiveDataSource (which builds ReaderOptions without setting IO
+  // stats) continue to work rather than tripping the constructor's check.
+  // Only the sliced copy is touched, so the caller's options are unchanged.
+  if (tabletOptions.ioOptions->metadataIoStats() == nullptr) {
+    tabletOptions.ioOptions->setMetadataIoStats(
+        std::make_shared<velox::io::IoStatistics>());
+  }
   return tabletOptions;
 }
 

--- a/dwio/nimble/tablet/tests/TabletTest.cpp
+++ b/dwio/nimble/tablet/tests/TabletTest.cpp
@@ -5005,6 +5005,28 @@ TEST_P(TabletTest, readerOptionsSpeculativeMode) {
   EXPECT_FALSE(tablet->stats().footerCacheHit);
 }
 
+TEST_P(TabletTest, configureOptionsDefaultsMetadataIoStats) {
+  // The TabletReader constructor requires non-null metadata IO stats, but
+  // ReaderOptions built through Velox's connector path arrive without them.
+  // configureOptions must supply a default so every reader entry point works.
+  velox::dwio::common::ReaderOptions readerOptions(pool_.get());
+  ASSERT_EQ(readerOptions.metadataIoStats(), nullptr);
+
+  auto opts = nimble::TabletReader::configureOptions(readerOptions);
+  ASSERT_TRUE(opts.ioOptions.has_value());
+  EXPECT_NE(opts.ioOptions->metadataIoStats(), nullptr);
+
+  // The caller's options are untouched: only the sliced copy is defaulted.
+  EXPECT_EQ(readerOptions.metadataIoStats(), nullptr);
+
+  // A caller-supplied instance is preserved rather than replaced.
+  velox::dwio::common::ReaderOptions withStats(pool_.get());
+  withStats.setMetadataIoStats(metadataIoStats_);
+  auto optsWithStats = nimble::TabletReader::configureOptions(withStats);
+  ASSERT_TRUE(optsWithStats.ioOptions.has_value());
+  EXPECT_EQ(optsWithStats.ioOptions->metadataIoStats(), metadataIoStats_);
+}
+
 TEST_P(TabletTest, configureOptionsIndexFlags) {
   // Verify configureOptions wires loadClusterIndex/loadChunkStats from
   // ReaderOptions into TabletReader::Options, both as bools and as entries

--- a/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
+++ b/dwio/nimble/velox/selective/tests/SelectiveNimbleReaderTest.cpp
@@ -734,6 +734,35 @@ TEST_P(SelectiveNimbleReaderTest, currentStripe) {
   EXPECT_EQ(readers.rowReader->currentStripe(), 0u);
 }
 
+TEST_P(SelectiveNimbleReaderTest, readsWithoutMetadataIoStats) {
+  // Velox's connector path (HiveDataSource) builds ReaderOptions without
+  // metadata IO stats, while TabletReader requires them. Reading has to work
+  // anyway, so that this factory is usable on its own rather than only behind
+  // a wrapper that fills them in.
+  auto input = makeRowVector({
+      makeFlatVector<int64_t>(200, folly::identity),
+  });
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*input->type());
+
+  const auto file = test::createNimbleFile(*rootPool(), input);
+  dwio::common::ReaderOptions options(pool());
+  options.setScanSpec(scanSpec);
+  ASSERT_EQ(options.metadataIoStats(), nullptr);
+
+  auto reader = SelectiveNimbleReaderFactory().createReader(
+      std::make_unique<dwio::common::BufferedInput>(
+          std::make_shared<InMemoryReadFile>(file), *pool()),
+      options);
+  EXPECT_EQ(reader->numberOfRows(), input->size());
+
+  dwio::common::RowReaderOptions rowOptions;
+  rowOptions.setScanSpec(scanSpec);
+  rowOptions.setRequestedType(asRowType(input->type()));
+  auto rowReader = reader->createRowReader(rowOptions);
+  validate(*input, *rowReader, 101, [](auto /*i*/) { return true; });
+}
+
 TEST_P(SelectiveNimbleReaderTest, denseWithNulls) {
   const bool stringDecoderZeroCopy = this->stringDecoderZeroCopy();
   auto input = makeRowVector({


### PR DESCRIPTION
Summary:
Makes `SelectiveNimbleReaderFactory` usable on its own, which is what an open-source engine needs in order to read Nimble.

`TabletReader` requires non-null metadata IO stats -- its constructor enforces this:

```
NIMBLE_CHECK_NOT_NULL(
    options.ioOptions->metadataIoStats(), "metadataIoStats is null.");
```

but Velox's connector path does not supply them: `HiveDataSource` builds `ReaderOptions` without IO stats. The only thing bridging that gap was a shim inside `dwio/nimble/velox/reader/fb/NimbleReader.cpp`, which synthesized a default before delegating to the selective factory. So the selective reader worked only when reached *through* the internal `fb/` factory. An engine that registered `registerSelectiveNimbleReaderFactory()` directly -- the OSS-clean entry point, and the only one available outside `fb/` -- tripped the check instead.

Nothing about that shim was ever internal. `velox::io::IoStatistics` is ordinary OSS Velox (`velox_common_io`), already an exported dep of `//dwio/nimble/tablet:tablet_reader` and already included via `TabletReader.h`. It lived under `fb/` only because it happened to be written inside the `fb/` factory.

So this moves the default down to `TabletReader::configureOptions()` -- the adapter from Velox `ReaderOptions` to `TabletReader::Options`, and the same translation step that every reader entry point already funnels through:

- `ReaderBase::create()`, for the selective reader
- the batch `NimbleReader` constructor, in `fb/`
- `NimbleIndexProjector::create()`
- `rocks/nimble/NimbleTable.cpp` and the rexdb index benchmark

One implementation now serves all of them, and the `fb/` shim is deleted rather than duplicated. `TabletReader`'s constructor check is left in place, so anyone hand-building `Options` is still caught.

Note that `tabletOptions.ioOptions = options` slices `dwio::common::ReaderOptions` down to its `velox::io::ReaderOptions` base, so the default lands on a copy and the caller's own options are left untouched. That differs from the old shim, which passed its mutated copy onward. Nothing downstream reads `metadataIoStats()` back off `ReaderOptions` -- the selective reader tree has no references to it at all -- so the difference is inert.

Non-goals, both deliberate:

- The two registration surfaces are untouched. Internal engines still call `velox::nimble::registerNimbleReaderFactory()` (which dispatches selective vs. batch) and OSS would call `nimble::registerSelectiveNimbleReaderFactory()`. Collapsing those is a separate change; it churns 19 call sites and is better sequenced once the batch reader's future is settled.
- No Iceberg field-id support is added to the selective path. That remains batch-only and is not needed for open source right now.

Reviewed By: xiaoxmeng

Differential Revision: D114759730


