### PR TITLE
refactor(reader): Move the reader factory out of fb/ (#1069)

### DIFF
--- a/dwio/nimble/velox/CMakeLists.txt
+++ b/dwio/nimble/velox/CMakeLists.txt
@@ -174,5 +174,8 @@ target_link_libraries(
 
 add_subdirectory(index)
 add_subdirectory(selective)
+# Must follow selective: nimble_velox_reader_factory links
+# nimble_velox_selective.
+add_subdirectory(reader)
 add_subdirectory(stats)
 add_subdirectory(tests)

--- a/dwio/nimble/velox/reader/BatchReaderOSS.cpp
+++ b/dwio/nimble/velox/reader/BatchReaderOSS.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/velox/reader/NimbleReaderFactory.h"
+
+namespace facebook::velox::nimble::detail {
+
+// The batch reader reaches into internal-only code, so it is not part of the
+// open-source build. Returning nullptr makes the factory report a clear error
+// rather than fail to link.
+std::unique_ptr<dwio::common::Reader> createBatchReader(
+    const dwio::common::ReaderOptions& /*options*/,
+    const std::shared_ptr<ReadFile>& /*readFile*/) {
+  return nullptr;
+}
+
+} // namespace facebook::velox::nimble::detail

--- a/dwio/nimble/velox/reader/CMakeLists.txt
+++ b/dwio/nimble/velox/reader/CMakeLists.txt
@@ -1,0 +1,26 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# BatchReaderOSS.cpp stands in for fb/NimbleReader.cpp, which the Buck build
+# compiles instead: the batch reader depends on internal-only code.
+add_library(
+  nimble_velox_reader_factory
+  NimbleReaderFactory.cpp
+  BatchReaderOSS.cpp
+)
+target_link_libraries(
+  nimble_velox_reader_factory
+  nimble_velox_selective
+  velox_dwio_common
+)

--- a/dwio/nimble/velox/reader/NimbleReaderFactory.cpp
+++ b/dwio/nimble/velox/reader/NimbleReaderFactory.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "dwio/nimble/velox/reader/NimbleReaderFactory.h"
+
+#include "velox/common/base/RuntimeMetrics.h"
+
+namespace facebook::velox::nimble {
+
+std::unique_ptr<dwio::common::Reader> NimbleReaderFactory::createReader(
+    std::unique_ptr<dwio::common::BufferedInput> input,
+    const dwio::common::ReaderOptions& options) {
+  // Missing metadata IO stats are defaulted by
+  // `TabletReader::configureOptions`, which both branches below funnel
+  // through, so no fixup is needed here.
+  if (options.selectiveNimbleReaderEnabled()) {
+    addThreadLocalRuntimeStat("selectiveNimbleReader", RuntimeCounter(1));
+    return selectiveFactory_.createReader(std::move(input), options);
+  }
+
+  addThreadLocalRuntimeStat("batchNimbleReader", RuntimeCounter(1));
+  auto reader = detail::createBatchReader(options, input->getReadFile());
+  VELOX_CHECK_NOT_NULL(
+      reader,
+      "The batch NIMBLE reader is not available in this build. Leave "
+      "selective_nimble_reader_enabled at its default to use the selective "
+      "reader.");
+  return reader;
+}
+
+void registerNimbleReaderFactory() {
+  dwio::common::registerReaderFactory(std::make_shared<NimbleReaderFactory>());
+}
+
+void unregisterNimbleReaderFactory() {
+  dwio::common::unregisterReaderFactory(dwio::common::FileFormat::NIMBLE);
+}
+
+} // namespace facebook::velox::nimble

--- a/dwio/nimble/velox/reader/NimbleReaderFactory.h
+++ b/dwio/nimble/velox/reader/NimbleReaderFactory.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "dwio/nimble/velox/selective/SelectiveNimbleReader.h"
+#include "velox/dwio/common/ReaderFactory.h"
+
+namespace facebook::velox::nimble {
+
+namespace detail {
+
+/// Creates the batch (non-selective) NIMBLE reader, or nullptr when that
+/// reader is not part of the build. Defined once per build flavour: the batch
+/// reader depends on internal-only code, so only the internal build can supply
+/// it.
+std::unique_ptr<dwio::common::Reader> createBatchReader(
+    const dwio::common::ReaderOptions& options,
+    const std::shared_ptr<ReadFile>& readFile);
+
+} // namespace detail
+
+/// Registered against FileFormat::NIMBLE. Chooses between the selective reader
+/// and the batch reader per read, based on
+/// `ReaderOptions::selectiveNimbleReaderEnabled()`.
+class NimbleReaderFactory : public dwio::common::ReaderFactory {
+ public:
+  NimbleReaderFactory() : ReaderFactory(dwio::common::FileFormat::NIMBLE) {}
+
+  std::unique_ptr<dwio::common::Reader> createReader(
+      std::unique_ptr<dwio::common::BufferedInput>,
+      const dwio::common::ReaderOptions&) override;
+
+ private:
+  facebook::nimble::SelectiveNimbleReaderFactory selectiveFactory_;
+};
+
+void registerNimbleReaderFactory();
+
+void unregisterNimbleReaderFactory();
+
+} // namespace facebook::velox::nimble


### PR DESCRIPTION
Summary:

Gets the NIMBLE reader's registration surface out of `fb/`, so that internal and open-source builds register the same factory instead of each having their own entry point.

Before this, `NimbleReaderFactory` -- and with it `registerNimbleReaderFactory()`, which is what Prism, Gluten, Axel, Axiom, and a long tail of tools call -- lived in `dwio/nimble/velox/reader/fb/NimbleReader.h`. Nothing about the factory is internal: it holds a `SelectiveNimbleReaderFactory`, reads one flag, and picks a reader. It was stuck in `fb/` by a single edge, namely that it constructs the batch reader, which does depend on internal-only code (`//dwio/api:velox-util`).

So the edge is inverted rather than the factory being kept hostage to it:

- `dwio/nimble/velox/reader/NimbleReaderFactory.{h,cpp}` is new, OSS-clean, and holds the factory, the dispatch, and the register/unregister pair.
- The batch branch now goes through `detail::createBatchReader()`, declared in that header and defined once per build flavour: `fb/NimbleReader.cpp` for Buck, `BatchReaderOSS.cpp` for CMake. This is the same ODR-based split already used for `detail::defaultMetadata()` (`VeloxWriterDefaultMetadataOSS.cpp`) and `detail::initHook()` (`SelectiveNimbleReaderInitHookOSS.cpp`).
- `fb/NimbleReader.h` is deleted. With the factory gone it declared nothing, since the batch `NimbleReader` and `NimbleRowReader` live in an anonymous namespace in the `.cpp`.
- `fb/` keeps what is genuinely internal: the batch reader, the Iceberg field-id projection helpers, and `FieldIdResolver`.

In the open-source build the hook returns nullptr and the factory raises a clear error naming the session property, rather than failing to link. That path is unreachable in practice: `FileConfig::kSelectiveNimbleReaderEnabledSession` and `QueryConfig::kSelectiveNimbleReaderEnabled` both default to true, so every engine-driven read already takes the selective branch.

The 28 `#include` sites move to the new header. They have to change in this commit rather than a follow-up, because deleting the old header breaks them immediately.

On the CMake side, `nimble_velox_reader_factory` is a new library and `add_subdirectory(reader)` is ordered after `selective`, which it links.

Behavior is unchanged on both branches; this is placement and linkage only.

Note for reviewers: `mrs/ranklake/table_service/src/storage/table:nimble_index_tablet` is one of the 28 consumers and does not build. That is pre-existing on trunk -- it constructs `ReaderOptions{pool, &dataIoStats, &metadataIoStats}` against a class that only has a one-argument constructor -- and I verified it fails identically with this change shelved. Its include is updated for consistency, but the target is left otherwise untouched.

Reviewed By: xiaoxmeng

Differential Revision: D114807828


