### PR TITLE
feat(serializer): Allow accessing encoding layouts post-write (#1071)

### DIFF
--- a/dwio/nimble/serializer/Options.h
+++ b/dwio/nimble/serializer/Options.h
@@ -226,6 +226,11 @@ struct SerializerOptions {
   /// tree.
   std::optional<EncodingLayoutTree> encodingLayoutTree{};
 
+  /// Cache the selected encoding layout in the Serializer and reuse it for
+  /// subsequent calls. The cached layout, if present, is available via
+  /// Serializer::getCachedEncodingLayout().
+  bool cacheEncodingLayout{false};
+
   /// Compression options used with encodingLayoutTree.
   /// When encodingLayoutTree is specified, these options are passed to
   /// ReplayedEncodingSelectionPolicy to control compression during encoding

--- a/dwio/nimble/serializer/Serializer.cpp
+++ b/dwio/nimble/serializer/Serializer.cpp
@@ -17,6 +17,9 @@
 
 #include <glog/logging.h>
 
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/writer/EncodingLayoutStreamContext.h"
+
 namespace facebook::nimble {
 
 namespace {
@@ -113,7 +116,7 @@ Serializer::Serializer(
             if (ctx != nullptr) {
               auto it = ctx->keyEncodings_.find(fieldKey);
               if (it != ctx->keyEncodings_.end()) {
-                initEncodingLayouts(*it->second, fieldType);
+                initializeEncodingLayouts(fieldType, *it->second);
               }
             }
           }
@@ -126,7 +129,11 @@ Serializer::Serializer(
   // in all field writers (their null statisticsCollector_ guards handle this).
   writer_ = FieldWriter::create(context_, typeWithId);
 
-  buildStreamEncodingLayouts();
+  if (options_.encodingLayoutTree.has_value()) {
+    const auto& rootType = context_.schemaBuilder().root();
+    NIMBLE_CHECK_NOT_NULL(rootType, "SchemaBuilder root must be set");
+    initializeEncodingLayouts(*rootType, options_.encodingLayoutTree.value());
+  }
 }
 
 std::string_view Serializer::serialize(
@@ -155,43 +162,26 @@ void Serializer::validateSupportedInput(
       "Top-level row nulls are not supported when serializing FlatMap columns.");
 }
 
-void Serializer::buildStreamEncodingLayouts() {
-  if (!options_.encodingLayoutTree.has_value()) {
-    return;
-  }
+void Serializer::initializeEncodingLayouts(
+    const TypeBuilder& typeBuilder,
+    const EncodingLayoutTree& tree) {
+  const auto stampLayout =
+      [&tree](
+          const StreamDescriptorBuilder& descriptor,
+          EncodingLayoutTree::StreamIdentifier identifier) {
+        if (const auto* layout = tree.encodingLayout(identifier)) {
+          encodingLayoutContext(descriptor).setEncoding(*layout);
+        }
+      };
 
-  // NOTE: The event handler for dynamically discovered FlatMap keys is
-  // registered in the constructor, so keyed encoding layouts can be applied
-  // as keys appear.
-
-  // Traverse the encoding layout tree to build the stream encoding layouts map.
-  const auto& rootType = context_.schemaBuilder().root();
-  NIMBLE_CHECK_NOT_NULL(rootType, "SchemaBuilder root must be set");
-  initEncodingLayouts(options_.encodingLayoutTree.value(), *rootType);
-}
-
-void Serializer::initEncodingLayouts(
-    const EncodingLayoutTree& tree,
-    const TypeBuilder& typeBuilder) {
-  // Helper to add encoding layout to the map for a given stream identifier.
-  const auto addLayout = [this, &tree](
-                             uint32_t streamOffset,
-                             EncodingLayoutTree::StreamIdentifier identifier) {
-    if (const auto* layout = tree.encodingLayout(identifier)) {
-      streamEncodingLayouts_[streamOffset] = layout;
-    }
-  };
-
-  // Match the encoding layout tree schema kind with the type builder.
-  // For each stream, add the encoding layout to the map if it exists.
   switch (typeBuilder.kind()) {
     case Kind::Scalar: {
       NIMBLE_CHECK_EQ(
           tree.schemaKind(),
           Kind::Scalar,
           "Incompatible encoding layout node. Expecting scalar node.");
-      addLayout(
-          typeBuilder.asScalar().scalarDescriptor().offset(),
+      stampLayout(
+          typeBuilder.asScalar().scalarDescriptor(),
           EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream);
       break;
     }
@@ -200,16 +190,14 @@ void Serializer::initEncodingLayouts(
           tree.schemaKind(),
           Kind::Row,
           "Incompatible encoding layout node. Expecting row node.");
-      addLayout(
-          typeBuilder.asRow().nullsDescriptor().offset(),
-          EncodingLayoutTree::StreamIdentifiers::Row::NullsStream);
-
-      // Initialize encoding layouts for children.
       const auto& rowBuilder = typeBuilder.asRow();
+      stampLayout(
+          rowBuilder.nullsDescriptor(),
+          EncodingLayoutTree::StreamIdentifiers::Row::NullsStream);
       for (uint32_t i = 0;
            i < rowBuilder.childrenCount() && i < tree.childrenCount();
            ++i) {
-        initEncodingLayouts(tree.child(i), rowBuilder.childAt(i));
+        initializeEncodingLayouts(rowBuilder.childAt(i), tree.child(i));
       }
       break;
     }
@@ -218,13 +206,12 @@ void Serializer::initEncodingLayouts(
           tree.schemaKind(),
           Kind::Array,
           "Incompatible encoding layout node. Expecting array node.");
-      addLayout(
-          typeBuilder.asArray().lengthsDescriptor().offset(),
+      const auto& arrayBuilder = typeBuilder.asArray();
+      stampLayout(
+          arrayBuilder.lengthsDescriptor(),
           EncodingLayoutTree::StreamIdentifiers::Array::LengthsStream);
-
-      // Initialize encoding layouts for element child.
       if (tree.childrenCount() > 0) {
-        initEncodingLayouts(tree.child(0), typeBuilder.asArray().elements());
+        initializeEncodingLayouts(arrayBuilder.elements(), tree.child(0));
       }
       break;
     }
@@ -233,17 +220,15 @@ void Serializer::initEncodingLayouts(
           tree.schemaKind(),
           Kind::Map,
           "Incompatible encoding layout node. Expecting map node.");
-      addLayout(
-          typeBuilder.asMap().lengthsDescriptor().offset(),
-          EncodingLayoutTree::StreamIdentifiers::Map::LengthsStream);
-
-      // Initialize encoding layouts for key and value children.
       const auto& mapBuilder = typeBuilder.asMap();
+      stampLayout(
+          mapBuilder.lengthsDescriptor(),
+          EncodingLayoutTree::StreamIdentifiers::Map::LengthsStream);
       if (tree.childrenCount() > 0) {
-        initEncodingLayouts(tree.child(0), mapBuilder.keys());
+        initializeEncodingLayouts(mapBuilder.keys(), tree.child(0));
       }
       if (tree.childrenCount() > 1) {
-        initEncodingLayouts(tree.child(1), mapBuilder.values());
+        initializeEncodingLayouts(mapBuilder.values(), tree.child(1));
       }
       break;
     }
@@ -252,14 +237,14 @@ void Serializer::initEncodingLayouts(
           tree.schemaKind(),
           Kind::FlatMap,
           "Incompatible encoding layout node. Expecting flatmap node.");
-
       auto& flatMapBuilder = typeBuilder.asFlatMap();
-      addLayout(
-          flatMapBuilder.nullsDescriptor().offset(),
+      stampLayout(
+          flatMapBuilder.nullsDescriptor(),
           EncodingLayoutTree::StreamIdentifiers::FlatMap::NullsStream);
 
-      // For FlatMap, children are keyed by name, not position.
-      // Build a map from key name to encoding layout tree child.
+      // For FlatMap, children are keyed by name, not position. Register a
+      // context on the FlatMap builder so the dynamic-key handler can resolve
+      // per-key layouts as new keys are discovered during writing.
       folly::F14FastMap<std::string_view, const EncodingLayoutTree*>
           keyEncodings;
       keyEncodings.reserve(tree.childrenCount());
@@ -267,18 +252,97 @@ void Serializer::initEncodingLayouts(
         const auto& child = tree.child(i);
         keyEncodings.emplace(child.name(), &child);
       }
-
-      // Store context for dynamic key discovery during writing.
-      // FlatMap keys are discovered dynamically via
-      // FlatmapFieldAddedEventHandler.
       flatMapBuilder.setContext(
           std::make_unique<FlatmapEncodingLayoutContext>(keyEncodings));
       break;
     }
     default:
-      // Other types (ArrayWithOffsets, SlidingWindowMap, etc.) - skip for now.
       break;
   }
+}
+
+namespace {
+
+using LayoutMap =
+    std::unordered_map<EncodingLayoutTree::StreamIdentifier, EncodingLayout>;
+
+EncodingLayoutTree captureLayoutForType(
+    const TypeBuilder& typeBuilder,
+    const std::string& name = "") {
+  using StreamIds = EncodingLayoutTree::StreamIdentifiers;
+  LayoutMap layouts;
+
+  const auto captureStreamLayout =
+      [&](const StreamDescriptorBuilder& descriptor,
+          EncodingLayoutTree::StreamIdentifier id) {
+        if (const auto* ctx =
+                descriptor.context<EncodingLayoutStreamContext>()) {
+          if (const auto* layout = ctx->encoding()) {
+            layouts.emplace(id, *layout);
+          }
+        }
+      };
+
+  std::vector<EncodingLayoutTree> children;
+  switch (typeBuilder.kind()) {
+    case Kind::Scalar:
+      captureStreamLayout(
+          typeBuilder.asScalar().scalarDescriptor(),
+          StreamIds::Scalar::ScalarStream);
+      break;
+    case Kind::Row: {
+      const auto& row = typeBuilder.asRow();
+      captureStreamLayout(row.nullsDescriptor(), StreamIds::Row::NullsStream);
+      children.reserve(row.childrenCount());
+      for (uint32_t i = 0; i < row.childrenCount(); ++i) {
+        children.push_back(captureLayoutForType(row.childAt(i)));
+      }
+      break;
+    }
+    case Kind::Array: {
+      const auto& array = typeBuilder.asArray();
+      captureStreamLayout(
+          array.lengthsDescriptor(), StreamIds::Array::LengthsStream);
+      children.push_back(captureLayoutForType(array.elements()));
+      break;
+    }
+    case Kind::Map: {
+      const auto& map = typeBuilder.asMap();
+      captureStreamLayout(
+          map.lengthsDescriptor(), StreamIds::Map::LengthsStream);
+      children.reserve(2);
+      children.push_back(captureLayoutForType(map.keys()));
+      children.push_back(captureLayoutForType(map.values()));
+      break;
+    }
+    case Kind::FlatMap: {
+      const auto& flatMap = typeBuilder.asFlatMap();
+      captureStreamLayout(
+          flatMap.nullsDescriptor(), StreamIds::FlatMap::NullsStream);
+      children.reserve(flatMap.childrenCount());
+      for (uint32_t i = 0; i < flatMap.childrenCount(); ++i) {
+        children.push_back(captureLayoutForType(
+            flatMap.childAt(i), std::string{flatMap.nameAt(i)}));
+      }
+      break;
+    }
+    default:
+      break;
+  }
+
+  return EncodingLayoutTree{
+      typeBuilder.kind(), std::move(layouts), name, std::move(children)};
+}
+
+} // namespace
+
+void Serializer::assembleEncodingLayoutTree() const {
+  const auto rootType = context_.schemaBuilder().root();
+  if (rootType == nullptr) {
+    encodingLayoutTree_.reset();
+    return;
+  }
+  encodingLayoutTree_.emplace(captureLayoutForType(*rootType));
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/serializer/Serializer.h
+++ b/dwio/nimble/serializer/Serializer.h
@@ -19,6 +19,7 @@
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/serializer/StreamDataWriter.h"
 #include "dwio/nimble/velox/FieldWriter.h"
+#include "dwio/nimble/writer/EncodingLayoutTree.h"
 #include "folly/container/F14Set.h"
 #include "velox/dwio/common/TypeWithId.h"
 #include "velox/vector/BaseVector.h"
@@ -50,30 +51,28 @@ class Serializer {
       const OrderedRanges& ranges,
       T& buffer) const;
 
+  /// Returns the cached encoding layout. Present after a successful
+  /// serialize() call with options.cacheEncodingLayout set, or if a
+  /// caller-provided replayed layout was supplied via
+  /// options.encodingLayoutTree. nullopt otherwise.
+  const std::optional<EncodingLayoutTree>& getCachedEncodingLayout() const {
+    return encodingLayoutTree_;
+  }
+
   const SchemaBuilder& schemaBuilder() const {
     return context_.schemaBuilder();
   }
 
  private:
-  // Build stream encoding layouts map from the encoding layout tree.
-  // Also sets up event handler for dynamically discovered FlatMap keys.
-  // Called when encodingLayoutTree is specified.
-  void buildStreamEncodingLayouts();
+  // Traverses the EncodingLayoutTree and stamps each stream descriptor's
+  // context with the corresponding EncodingLayout for replay at encode time.
+  void initializeEncodingLayouts(
+      const TypeBuilder& typeBuilder,
+      const EncodingLayoutTree& tree);
 
-  // Helper to traverse the EncodingLayoutTree and populate
-  // streamEncodingLayouts_.
-  void initEncodingLayouts(
-      const EncodingLayoutTree& tree,
-      const TypeBuilder& typeBuilder);
-
-  // Returns pointer to streamEncodingLayouts_ if encoding is enabled and we
-  // have captured encodings to replay. Otherwise returns nullptr.
-  const std::unordered_map<uint32_t, const EncodingLayout*>*
-  getStreamEncodingLayouts() const {
-    return (options_.enableEncoding() && !streamEncodingLayouts_.empty())
-        ? &streamEncodingLayouts_
-        : nullptr;
-  }
+  // Assembles the cached encoding layout tree by walking the schema and
+  // reading each stream descriptor's EncodingLayoutStreamContext slot.
+  void assembleEncodingLayoutTree() const;
 
   // Validates input shapes that the serializer can write but the dense
   // deserializer cannot reconstruct.
@@ -89,11 +88,8 @@ class Serializer {
   std::shared_ptr<const velox::dwio::common::TypeWithId> typeWithId_;
   std::unique_ptr<FieldWriter> writer_;
   mutable Vector<char> buffer_;
-  // Map from stream offset to encoding layout for replaying captured encodings.
-  // Only populated when options_.encodingLayoutTree is set.
-  // Mutable because FlatMap keys can be added during const serialize().
-  mutable std::unordered_map<uint32_t, const EncodingLayout*>
-      streamEncodingLayouts_;
+  // Selected encoding layout assembled at the end of each call to serialize.
+  mutable std::optional<EncodingLayoutTree> encodingLayoutTree_;
   // In-map stream offsets for skipping constant FlatMap key-presence streams.
   // Mutable because FlatMap keys can be added during const serialize().
   mutable folly::F14FastSet<uint32_t> inMapStreamOffsets_;
@@ -111,8 +107,7 @@ void Serializer::serialize(
       options_,
       buffer,
       static_cast<uint32_t>(ranges.size()),
-      context_.bufferMemoryPool().get(),
-      getStreamEncodingLayouts()};
+      context_.bufferMemoryPool().get()};
   for (auto& [_, streamData] : context_.streams()) {
     if (streamData->isNullStream()) {
       // Omit any null stream that carries no actual nulls, even when a
@@ -138,6 +133,9 @@ void Serializer::serialize(
   }
   // Pass nodeCount for kLegacy to fill trailing zeros.
   streamWriter.close(context_.schemaBuilder().nodeCount());
+  if (options_.cacheEncodingLayout || options_.encodingLayoutTree.has_value()) {
+    assembleEncodingLayoutTree();
+  }
 
   writer_->reset();
   context_.resetStringBuffer();

--- a/dwio/nimble/serializer/StreamDataWriter.h
+++ b/dwio/nimble/serializer/StreamDataWriter.h
@@ -31,12 +31,14 @@
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/common/Zigzag.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/serializer/Options.h"
 #include "dwio/nimble/serializer/SerializationHeader.h"
 #include "dwio/nimble/velox/RowRange.h"
 #include "dwio/nimble/velox/StreamData.h"
+#include "dwio/nimble/writer/EncodingLayoutStreamContext.h"
 #include "folly/io/Cursor.h"
 #include "folly/io/IOBuf.h"
 #include "velox/common/Casts.h"
@@ -560,16 +562,11 @@ class StreamDataWriter {
   /// flags).
   ///
   /// @param pool Memory pool for encoding buffer allocation.
-  /// @param streamEncodingLayouts Optional encoding layouts for replaying
-  ///        captured encodings. When provided, looks up EncodingLayout by
-  ///        stream offset and uses ReplayedEncodingSelectionPolicy.
   StreamDataWriter(
       const SerializerOptions& options,
       T& buffer,
       uint32_t rowCount,
-      velox::memory::MemoryPool* pool,
-      const std::unordered_map<uint32_t, const EncodingLayout*>*
-          streamEncodingLayouts);
+      velox::memory::MemoryPool* pool);
 
   /// Write data for a single stream.
   void writeData(const nimble::StreamData& streamData);
@@ -580,8 +577,7 @@ class StreamDataWriter {
 
  private:
   void encodeStream(
-      ScalarKind scalarKind,
-      uint32_t streamOffset,
+      const StreamDescriptorBuilder& descriptor,
       std::string_view data,
       std::span<const bool> nonNulls = {});
 
@@ -591,10 +587,6 @@ class StreamDataWriter {
   velox::memory::MemoryPool* const pool_;
   // Scratch buffer holding one encoded stream before it is copied to output.
   const std::unique_ptr<nimble::Buffer> streamEncodingBuffer_;
-  // Optional map from stream offset to encoding layout for replaying captured
-  // encodings. Only set when options_.encodingLayoutTree is specified.
-  const std::unordered_map<uint32_t, const EncodingLayout*>* const
-      streamEncodingLayouts_;
 
   // --- Mutable members ---
   // Final serialized output. Encoded stream bytes and stream metadata are
@@ -616,19 +608,13 @@ StreamDataWriter<T>::StreamDataWriter(
     const SerializerOptions& options,
     T& buffer,
     uint32_t rowCount,
-    velox::memory::MemoryPool* pool,
-    const std::unordered_map<uint32_t, const EncodingLayout*>*
-        streamEncodingLayouts)
+    velox::memory::MemoryPool* pool)
     : options_{options},
       pool_{pool},
       streamEncodingBuffer_{
           options.enableEncoding() ? std::make_unique<nimble::Buffer>(*pool)
                                    : nullptr},
-      streamEncodingLayouts_{streamEncodingLayouts},
       outputBuffer_{buffer} {
-  NIMBLE_CHECK(
-      streamEncodingLayouts_ == nullptr || options_.enableEncoding(),
-      "streamEncodingLayouts can only be set when encoding is enabled");
   NIMBLE_CHECK_NOT_NULL(pool, "Memory pool cannot be null");
 
   std::optional<SerializationVersion> version;
@@ -655,8 +641,8 @@ StreamDataWriter<T>::StreamDataWriter(
 
 template <typename T>
 void StreamDataWriter<T>::writeData(const nimble::StreamData& streamData) {
-  const auto scalarKind = streamData.descriptor().scalarKind();
-  const auto streamOffset = streamData.descriptor().offset();
+  const auto& descriptor = streamData.descriptor();
+  const auto streamOffset = descriptor.offset();
   const auto nonNulls = streamData.nonNulls();
   const auto data = streamData.data();
 
@@ -679,7 +665,7 @@ void StreamDataWriter<T>::writeData(const nimble::StreamData& streamData) {
     NIMBLE_CHECK_LE(lastStream_ + 1, streamOffset, "unexpected stream offset");
     detail::writeMissingStreams(outputBuffer_, lastStream_, streamOffset);
     lastStream_ = streamOffset;
-    encodeStream(scalarKind, streamOffset, data);
+    encodeStream(descriptor, data);
     return;
   }
 
@@ -689,7 +675,7 @@ void StreamDataWriter<T>::writeData(const nimble::StreamData& streamData) {
         data.empty(), "null streams should not carry a separate data payload");
     const auto streamPayload = detail::boolsAsStringView(nonNulls);
     NIMBLE_CHECK(!streamPayload.empty(), "Expected null stream payload");
-    encodeStream(scalarKind, streamOffset, streamPayload);
+    encodeStream(descriptor, streamPayload);
     return;
   }
 
@@ -698,15 +684,17 @@ void StreamDataWriter<T>::writeData(const nimble::StreamData& streamData) {
   NIMBLE_CHECK(
       !data.empty() || streamData.hasNullValues(),
       "Expected content stream payload");
-  encodeStream(scalarKind, streamOffset, data, nonNulls);
+  encodeStream(descriptor, data, nonNulls);
 }
 
 template <typename T>
 void StreamDataWriter<T>::encodeStream(
-    ScalarKind scalarKind,
-    uint32_t streamOffset,
+    const StreamDescriptorBuilder& descriptor,
     std::string_view data,
     std::span<const bool> nonNulls) {
+  const auto scalarKind = descriptor.scalarKind();
+  const auto streamOffset = descriptor.offset();
+
   if (!options_.enableEncoding()) {
     if (scalarKind == ScalarKind::String || scalarKind == ScalarKind::Binary) {
       // Legacy string encoding: [total_size:u32][len_0:u32][data_0]...
@@ -728,13 +716,9 @@ void StreamDataWriter<T>::encodeStream(
     return;
   }
 
-  const EncodingLayout* encodingLayout = nullptr;
-  if (streamEncodingLayouts_ != nullptr) {
-    auto it = streamEncodingLayouts_->find(streamOffset);
-    if (it != streamEncodingLayouts_->end()) {
-      encodingLayout = it->second;
-    }
-  }
+  const auto* ctx = descriptor.context<EncodingLayoutStreamContext>();
+  const EncodingLayout* encodingLayout =
+      (ctx != nullptr) ? ctx->encoding() : nullptr;
 
   std::string_view encoded;
   if (!facebook::nimble::StreamData::hasNullValues(nonNulls)) {
@@ -755,6 +739,12 @@ void StreamDataWriter<T>::encodeStream(
         *streamEncodingBuffer_,
         encodingLayout,
         options_.encodingOptions);
+  }
+
+  if (options_.cacheEncodingLayout && encodingLayout == nullptr) {
+    encodingLayoutContext(descriptor)
+        .setEncoding(
+            EncodingLayoutCapture::capture(encoded, options_.encodingOptions));
   }
 
   // Track size for trailer.

--- a/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
+++ b/dwio/nimble/serializer/tests/SerializerDeserializerTest.cpp
@@ -7020,3 +7020,87 @@ INSTANTIATE_TEST_SUITE_P(
             .streamSizesEncodingType = EncodingType::Varint,
             .bufferPoolCapacity = 0}),
     formatName);
+
+namespace facebook::nimble {
+
+class GetCachedEncodingLayoutTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance(
+        velox::memory::MemoryManager::Options{});
+  }
+
+  void SetUp() override {
+    pool_ = velox::memory::memoryManager()->addLeafPool("layout_tree_test");
+    vm_ = std::make_shared<velox::test::VectorMaker>(pool_.get());
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::shared_ptr<velox::test::VectorMaker> vm_;
+};
+
+TEST_F(GetCachedEncodingLayoutTest, replayProducesIdenticalBytes) {
+  std::vector<std::string> stringData;
+  for (int i = 0; i < 200; ++i) {
+    stringData.push_back("value_" + std::to_string(i));
+  }
+
+  struct Case {
+    std::string label;
+    velox::TypePtr type;
+    velox::VectorPtr data;
+  };
+
+  const std::vector<Case> cases{
+      {"bigint",
+       velox::ROW({{"a", velox::BIGINT()}}),
+       vm_->rowVector(
+           {"a"},
+           {vm_->flatVector<int64_t>(
+               1000, [](velox::vector_size_t i) { return i % 8; })})},
+      {"varchar",
+       velox::ROW({{"a", velox::VARCHAR()}}),
+       vm_->rowVector(
+           {"a"},
+           {vm_->flatVector<velox::StringView>(
+               1000,
+               [&](velox::vector_size_t i) {
+                 return velox::StringView{stringData[i % stringData.size()]};
+               })})},
+  };
+
+  for (const auto& c : cases) {
+    SCOPED_TRACE(c.label);
+
+    const SerializerOptions opts{
+        .version = SerializationVersion::kSerialization,
+        .cacheEncodingLayout = true,
+        .compressionOptions = CompressionOptions{},
+    };
+    Serializer serializer{opts, c.type, pool_.get()};
+    const auto blob =
+        serializer.serialize(c.data, OrderedRanges::of(0, c.data->size()));
+
+    const auto& tree = serializer.getCachedEncodingLayout();
+    ASSERT_TRUE(tree.has_value());
+    ASSERT_EQ(tree.value().schemaKind(), Kind::Row);
+    ASSERT_EQ(tree.value().childrenCount(), 1u);
+    ASSERT_NE(
+        tree.value().child(0).encodingLayout(
+            EncodingLayoutTree::StreamIdentifiers::Scalar::ScalarStream),
+        nullptr);
+
+    const SerializerOptions replayOpts{
+        .version = SerializationVersion::kSerialization,
+        .encodingLayoutTree = tree.value(),
+        .compressionOptions = CompressionOptions{},
+    };
+    Serializer replaySerializer{replayOpts, c.type, pool_.get()};
+    const auto replayBlob = replaySerializer.serialize(
+        c.data, OrderedRanges::of(0, c.data->size()));
+
+    EXPECT_EQ(blob, replayBlob);
+  }
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/writer/EncodingLayoutStreamContext.h
+++ b/dwio/nimble/writer/EncodingLayoutStreamContext.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+
+#include "dwio/nimble/encodings/common/EncodingLayout.h"
+#include "dwio/nimble/velox/SchemaBuilder.h"
+
+namespace facebook::nimble {
+
+class EncodingLayoutStreamContext : public StreamContext {
+ public:
+  const EncodingLayout* encoding() const {
+    return encoding_.has_value() ? &*encoding_ : nullptr;
+  }
+
+  void setEncoding(EncodingLayout value) {
+    encoding_.emplace(std::move(value));
+  }
+
+ private:
+  std::optional<EncodingLayout> encoding_;
+};
+
+inline EncodingLayoutStreamContext& encodingLayoutContext(
+    const StreamDescriptorBuilder& descriptor) {
+  auto* ctx = descriptor.context<EncodingLayoutStreamContext>();
+  if (ctx != nullptr) {
+    return *ctx;
+  }
+  descriptor.setContext(std::make_unique<EncodingLayoutStreamContext>());
+  return *descriptor.context<EncodingLayoutStreamContext>();
+}
+
+} // namespace facebook::nimble


### PR DESCRIPTION
Summary:

Add `Serializer::getEncodingLayoutTree()` so callers can retrieve the `EncodingLayoutTree` selected during the most recent `serialize()` call. The returned tree can be fed to a subsequent `Serializer` for the same schema via `SerializerOptions::encodingLayoutTree` to replay via `ReplayedEncodingSelectionPolicy` and skip the encoding-selection cascade (`Statistics::create` + per-candidate `estimateSize`). `encodingLayoutTree` was previously write-only at construction time — the only way to obtain a tree was to reverse-engineer the output bytes.

Mechanism: `SerializerImpl::StreamDataWriter` accepts an out-parameter `std::unordered_map<uint32_t, EncodingLayout>*`. Each fresh (non-replayed) encode calls `EncodingLayoutCapture::capture(encoded, options)` and stores the result keyed by stream offset. After `serialize()` finishes, `Serializer::assembleEncodingLayoutTree` walks `schemaBuilder().root()` and folds the per-stream layouts into an `EncodingLayoutTree` keyed by `StreamIdentifier`. Streams that replayed a pre-supplied layout are looked up via the existing `streamEncodingLayouts_` map so the returned tree is complete.

Capture is always on. The per-stream `EncodingLayoutCapture::capture` call is cheap next to the encoding work — one pass over the just-produced bytes, no reparse.

Differential Revision: D114630642


