### PR TITLE
fix(nimble): Compose caller rowRanges with the kTablet header window

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -625,24 +625,27 @@ void Deserializer::appendBatch(
     decodeRun(run, output);
   }
 
-  // Base range from the batch: parser's rowRange (kTablet header) or
-  // full-batch default if the header didn't encode one.
+  // Rows this batch exposes: the parser's rowRange (kTablet header) or the
+  // whole batch if the header didn't encode one.
   nimble::RowRange range =
       parser_->rowRange().value_or(nimble::RowRange{0, rowCount});
-  // Caller override wins if provided.
+  // A caller range narrows within what the batch exposes rather than
+  // replacing it, so it is relative to `range.startRow`. For a kTablet
+  // batch windowed to [500, 600), caller [0, 50) selects [500, 550). For
+  // every other version `range` starts at 0, so the two coincide.
   if (rowRange.has_value()) {
     NIMBLE_USER_CHECK(
-        !requiresBarrier,
-        "override rowRange not supported for null-barrier batches");
+        !requiresBarrier, "rowRange not supported for null-barrier batches");
     NIMBLE_USER_CHECK_LE(
         rowRange->startRow,
         rowRange->endRow,
-        "override rowRange startRow must be <= endRow");
+        "rowRange startRow must be <= endRow");
     NIMBLE_USER_CHECK_LE(
         rowRange->endRow,
-        rowCount,
-        "override rowRange endRow exceeds batch rowCount");
-    range = *rowRange;
+        range.numRows(),
+        "rowRange endRow exceeds the rows this batch exposes");
+    range = nimble::RowRange{
+        range.startRow + rowRange->startRow, range.startRow + rowRange->endRow};
   }
 
   appendStreamSegments(rowCount, /*startRow=*/run.rows, requiresBarrier);

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -92,19 +92,31 @@ class Deserializer {
 
   /// Decodes each batch in `data`, appending only the rows in
   /// `rowRanges[i]` for `data[i]`. The output is the concatenation of the
-  /// selected rows across batches, in order. Caller-supplied ranges take
-  /// precedence over any rowRange encoded in the batch header.
+  /// selected rows across batches, in order.
+  ///
+  /// `rowRanges[i]` is relative to the rows the batch already exposes, not
+  /// to the batch's physical row numbering. A kTablet batch whose header
+  /// carries a rowRange exposes only that window, so a caller range narrows
+  /// it further rather than replacing it: header `[500, 600)` combined with
+  /// caller `[0, 50)` selects physical rows `[500, 550)`. For every other
+  /// version the batch exposes all `rowCount` rows, so `rowRanges[i]` is
+  /// simply the physical range.
   ///
   /// Equivalent output to
   ///   for each i: deserialize(data[i]).slice(rowRanges[i].startRow,
   ///                                          rowRanges[i].numRows())
   /// concatenated, but rows outside each range are never materialized —
-  /// they are skipped via the FieldReader's `skip()` primitive.
+  /// they are skipped via the FieldReader's `skip()` primitive. Note this
+  /// equivalence holds under the relative interpretation: the single-batch
+  /// `deserialize` already applies the header window, so slicing its output
+  /// is the same as narrowing within that window.
   ///
   /// Preconditions:
   ///   * `data` is non-empty and `data.size() == rowRanges.size()`.
   ///   * For each `i`: `rowRanges[i].startRow <= rowRanges[i].endRow` and
-  ///     `rowRanges[i].endRow <= data[i]`'s batch rowCount.
+  ///     `rowRanges[i].endRow <= ` the number of rows `data[i]` exposes
+  ///     (the header rowRange's `numRows()` for kTablet, the batch rowCount
+  ///     otherwise).
   ///   * No batch carries the null-barrier flag.
   void deserialize(
       const std::vector<std::string_view>& data,
@@ -146,9 +158,9 @@ class Deserializer {
 
   // Shared body of all public `deserialize` overloads. Loops over `data`,
   // calls `appendBatch` per batch, then `decodeRun`. Pass an empty
-  // `rowRanges` to let each batch's rowRange be inferred from the header;
-  // pass a `data.size()`-sized `rowRanges` to override the inferred range
-  // per batch (`rowRanges[i]` for `data[i]`).
+  // `rowRanges` to decode whatever range each batch exposes (its header
+  // rowRange, or the whole batch); pass a `data.size()`-sized `rowRanges`
+  // to narrow within that range per batch (`rowRanges[i]` for `data[i]`).
   void deserializeImpl(
       folly::Range<const std::string_view*> data,
       folly::Range<const nimble::RowRange*> rowRanges,
@@ -205,10 +217,11 @@ class Deserializer {
   // Queues `batch`'s streams onto the pending decode run and records the
   // batch's effective rowRange in `runRanges_` (run-local coordinates).
   //
-  // `rowRange` overrides the range that would otherwise be inferred from
-  // the batch header (kTablet header rowRange, or full-batch for other
-  // versions). When set, requires
-  // `rowRange->startRow <= rowRange->endRow <= batch rowCount` and a
+  // `rowRange` narrows within the range the batch already exposes (the
+  // kTablet header rowRange, or the full batch for other versions) and is
+  // relative to that range's start, so it cannot widen the window or
+  // address rows outside it. When set, requires
+  // `rowRange->startRow <= rowRange->endRow <= exposed numRows()` and a
   // non-null-barrier batch.
   //
   // If the batch requires a null barrier, `decodeRun` fires before and

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -334,6 +334,78 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     return deserializeProjectedBatches(projector, batches);
   }
 
+  // Stripe rows the `makeWindowedSlice` key bounds select.
+  static constexpr uint32_t kWindowStart = 30;
+  static constexpr uint32_t kWindowEnd = 60;
+  static constexpr uint32_t kWindowRows = kWindowEnd - kWindowStart;
+
+  // A projected slice whose header window is [kWindowStart, kWindowEnd).
+  // Owns the projector and the projector result because the slice borrows
+  // from both.
+  struct WindowedSlice {
+    std::unique_ptr<NimbleIndexProjector> projector;
+    NimbleIndexProjector::Result result;
+    // The full stripe's `value` column, for building expectations.
+    std::vector<int32_t> values;
+
+    const folly::IOBuf& slice() const {
+      return result.responses[0].slices[0];
+    }
+  };
+
+  // Writes a 100-row stripe keyed on `key`, projects `value`, and returns
+  // the single slice the key bounds window to [kWindowStart, kWindowEnd).
+  WindowedSlice makeWindowedSlice() {
+    auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+    constexpr int kStripeRows = 100;
+    std::vector<int64_t> keys(kStripeRows);
+    std::vector<int32_t> values(kStripeRows);
+    for (int i = 0; i < kStripeRows; ++i) {
+      keys[i] = i;
+      values[i] = i * 10;
+    }
+    auto batch = vectorMaker_->rowVector(
+        {"key", "value"},
+        {vectorMaker_->flatVector<int64_t>(keys),
+         vectorMaker_->flatVector<int32_t>(values)});
+    writeData({batch}, {"key"});
+    std::vector<Subfield> subfields;
+    subfields.emplace_back("value");
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, kWindowStart, kWindowEnd);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    auto result = projector->project(request, {});
+    return {std::move(projector), std::move(result), std::move(values)};
+  }
+
+  // Asserts the slice really carries the expected header window, so the
+  // composition tests cannot pass vacuously on an unwindowed slice.
+  void expectWindow(const WindowedSlice& windowed) {
+    ASSERT_EQ(windowed.result.responses[0].slices.size(), 1);
+    const auto window = readEmbeddedRowRange(windowed.slice());
+    ASSERT_EQ(window.startRow, kWindowStart);
+    ASSERT_EQ(window.endRow, kWindowEnd);
+  }
+
+  // Same, but narrows within the slice's header window using the per-batch
+  // rowRanges overload. `rowRanges` are relative to that window.
+  VectorPtr deserializeProjectedSlice(
+      const NimbleIndexProjector& projector,
+      const folly::IOBuf& slice,
+      const std::vector<RowRange>& rowRanges) {
+    auto coalesced = coalesceChunkSlice(slice);
+    std::vector<std::string_view> batches{std::string_view(
+        reinterpret_cast<const char*>(coalesced.data()), coalesced.length())};
+    DeserializerOptions deserOptions;
+    deserOptions.hasHeader = true;
+    Deserializer deserializer(
+        projector.projectedNimbleType(), leafPool_.get(), deserOptions);
+    VectorPtr output;
+    deserializer.deserialize(batches, rowRanges, output);
+    return output;
+  }
+
   // Compares decoded output rows with an expected vector. The Deserializer
   // honors the header's row range via skip+next at decode time, so output
   // contains exactly the requested rows starting at index 0.
@@ -1630,6 +1702,68 @@ TEST_P(NimbleIndexProjectorTest, deserializerRangeFullStripe) {
 }
 
 #undef RUN_DESERIALIZER_RANGE_TEST
+
+// A caller rowRange composes with the header window instead of replacing it:
+// it is relative to the window start, so it can only narrow.
+TEST_P(NimbleIndexProjectorTest, deserializerRowRangeNarrowsHeaderWindow) {
+  auto windowed = makeWindowedSlice();
+  ASSERT_NO_FATAL_FAILURE(expectWindow(windowed));
+
+  // [0, 10) is relative to the window, so it selects stripe rows [30, 40)
+  // (values 300..390). Replacing the window would have yielded [0, 10).
+  std::vector<int32_t> expectedValues(
+      windowed.values.begin() + kWindowStart,
+      windowed.values.begin() + kWindowStart + 10);
+  auto expected = vectorMaker_->rowVector(
+      {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues)});
+  expectVectorRows(
+      deserializeProjectedSlice(
+          *windowed.projector, windowed.slice(), {RowRange{0, 10}}),
+      expected);
+}
+
+// The full window is addressable; one row past it is not.
+TEST_P(NimbleIndexProjectorTest, deserializerRowRangeAcceptsWholeWindow) {
+  auto windowed = makeWindowedSlice();
+  ASSERT_NO_FATAL_FAILURE(expectWindow(windowed));
+
+  std::vector<int32_t> expectedValues(
+      windowed.values.begin() + kWindowStart,
+      windowed.values.begin() + kWindowEnd);
+  auto expected = vectorMaker_->rowVector(
+      {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues)});
+  expectVectorRows(
+      deserializeProjectedSlice(
+          *windowed.projector, windowed.slice(), {RowRange{0, kWindowRows}}),
+      expected);
+}
+
+// The window, not the stripe, bounds a caller rowRange. Every one of these
+// fits inside the 100-row stripe, so validating against the batch rowCount
+// (the pre-composition contract) would have accepted them all and silently
+// returned rows outside the window the slice was scoped to.
+TEST_P(NimbleIndexProjectorTest, deserializerRowRangeRejectsRangePastWindow) {
+  auto windowed = makeWindowedSlice();
+  ASSERT_NO_FATAL_FAILURE(expectWindow(windowed));
+
+  const std::vector<RowRange> pastWindow{
+      // One row too many, starting at the window start.
+      RowRange{0, kWindowRows + 1},
+      // Starts inside the window but runs past its end.
+      RowRange{kWindowRows - 5, kWindowRows + 5},
+      // Starts at the first row past the window.
+      RowRange{kWindowRows, kWindowRows + 1},
+      // Entirely beyond the window.
+      RowRange{kWindowRows + 10, kWindowRows + 20},
+  };
+  for (const auto& range : pastWindow) {
+    SCOPED_TRACE(range.toString());
+    NIMBLE_ASSERT_THROW(
+        deserializeProjectedSlice(
+            *windowed.projector, windowed.slice(), {range}),
+        "rowRange endRow exceeds the rows this batch exposes");
+  }
+}
 
 TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchWithRowRange) {
   // Each input batch's embedded row range is applied per-segment by the


### PR DESCRIPTION
Summary:
`Deserializer::deserialize(data, rowRanges, output)` treated a caller-supplied
`rowRanges[i]` as a *replacement* for the row range in the batch header, not a
narrowing of it. For a kTablet slice windowed to stripe rows `[500, 600)`, a
caller passing `[0, 50)` got stripe rows `[0, 50)` — rows outside the window the
slice was scoped to.

That is the wrong contract. A caller holding a windowed slice should not be able
to address rows outside it; the window is what the query selected. Make the
caller range relative to the window so it can only narrow:

```
range = parser_->rowRange().value_or({0, rowCount});   // rows the batch exposes
if (rowRange) {
  NIMBLE_USER_CHECK_LE(rowRange->endRow, range.numRows(), ...);  // was: rowCount
  range = {range.startRow + rowRange->startRow,
           range.startRow + rowRange->endRow};          // was: range = *rowRange
}
```

Header `[500, 600)` + caller `[0, 50)` now selects `[500, 550)`.

**Why this is safe to change now.** The 3-arg `rowRanges` overload has zero
production callers in fbsource — the only call sites are 7 in
`DeserializerSkipTest.cpp`. Verified three ways: a regex sweep for
`deserialize(...rowRanges...)`, a caller audit, and the observation that only 12
files repo-wide reference `RowRange.h`, none of them a production consumer of
this overload. There are also no wrappers forwarding caller ranges into it.

**Why the blast radius is smaller than it looks.** For every non-kTablet version
`parser_->rowRange()` is `nullopt`, so the base range is `{0, rowCount}` and
composing is arithmetically identical to replacing. The two contracts diverge
only for kTablet batches carrying a non-zero-start window. `DeserializerSkipTest`
is entirely kSerialization, so all 7 call sites and their ~15 tests are unaffected
by construction, not by luck.

**`deserializeImpl` and the other overloads are untouched.** It is private, has no
`friend`s, and has exactly two call sites: the private `folly::Range` overload
passes `{}`, and the public 3-arg overload passes the caller's ranges. On the `{}`
path `rowRange` stays `nullopt`, so the modified branch never executes and the
header window is used verbatim — which is what every production kTablet consumer
(`rocks/nimble`, Rodos, ZippyDB, the rexdb benchmarks, `NimbleFigtableIterator`)
relies on via the 1-arg/2-arg overloads.

The tightened bound matters as much as the composition: validating against
`range.numRows()` instead of `rowCount` turns "silently read rows outside your
window" into a loud `NimbleUserError`, so any future caller written against the
old absolute-coordinate assumption fails immediately rather than returning wrong
rows.

Comments updated to match: the public overload's contract block, the
`deserializeImpl` and `appendBatch` declaration comments, and the inline comment
at the composition site.

Reviewed By: xiaoxmeng

Differential Revision: D114950491


