### PR TITLE
feat(nimble): Support rowRanges on null-barrier batches

### DIFF
--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -634,8 +634,6 @@ void Deserializer::appendBatch(
   // batch windowed to [500, 600), caller [0, 50) selects [500, 550). For
   // every other version `range` starts at 0, so the two coincide.
   if (rowRange.has_value()) {
-    NIMBLE_USER_CHECK(
-        !requiresBarrier, "rowRange not supported for null-barrier batches");
     NIMBLE_USER_CHECK_LE(
         rowRange->startRow,
         rowRange->endRow,

--- a/dwio/nimble/serializer/Deserializer.cpp
+++ b/dwio/nimble/serializer/Deserializer.cpp
@@ -625,24 +625,27 @@ void Deserializer::appendBatch(
     decodeRun(run, output);
   }
 
-  // Base range from the batch: parser's rowRange (kTablet header) or
-  // full-batch default if the header didn't encode one.
+  // Rows this batch exposes: the parser's rowRange (kTablet header) or the
+  // whole batch if the header didn't encode one.
   nimble::RowRange range =
       parser_->rowRange().value_or(nimble::RowRange{0, rowCount});
-  // Caller override wins if provided.
+  // A caller range narrows within what the batch exposes rather than
+  // replacing it, so it is relative to `range.startRow`. For a kTablet
+  // batch windowed to [500, 600), caller [0, 50) selects [500, 550). For
+  // every other version `range` starts at 0, so the two coincide.
   if (rowRange.has_value()) {
     NIMBLE_USER_CHECK(
-        !requiresBarrier,
-        "override rowRange not supported for null-barrier batches");
+        !requiresBarrier, "rowRange not supported for null-barrier batches");
     NIMBLE_USER_CHECK_LE(
         rowRange->startRow,
         rowRange->endRow,
-        "override rowRange startRow must be <= endRow");
+        "rowRange startRow must be <= endRow");
     NIMBLE_USER_CHECK_LE(
         rowRange->endRow,
-        rowCount,
-        "override rowRange endRow exceeds batch rowCount");
-    range = *rowRange;
+        range.numRows(),
+        "rowRange endRow exceeds the rows this batch exposes");
+    range = nimble::RowRange{
+        range.startRow + rowRange->startRow, range.startRow + rowRange->endRow};
   }
 
   appendStreamSegments(rowCount, /*startRow=*/run.rows, requiresBarrier);

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -92,19 +92,31 @@ class Deserializer {
 
   /// Decodes each batch in `data`, appending only the rows in
   /// `rowRanges[i]` for `data[i]`. The output is the concatenation of the
-  /// selected rows across batches, in order. Caller-supplied ranges take
-  /// precedence over any rowRange encoded in the batch header.
+  /// selected rows across batches, in order.
+  ///
+  /// `rowRanges[i]` is relative to the rows the batch already exposes, not
+  /// to the batch's physical row numbering. A kTablet batch whose header
+  /// carries a rowRange exposes only that window, so a caller range narrows
+  /// it further rather than replacing it: header `[500, 600)` combined with
+  /// caller `[0, 50)` selects physical rows `[500, 550)`. For every other
+  /// version the batch exposes all `rowCount` rows, so `rowRanges[i]` is
+  /// simply the physical range.
   ///
   /// Equivalent output to
   ///   for each i: deserialize(data[i]).slice(rowRanges[i].startRow,
   ///                                          rowRanges[i].numRows())
   /// concatenated, but rows outside each range are never materialized —
-  /// they are skipped via the FieldReader's `skip()` primitive.
+  /// they are skipped via the FieldReader's `skip()` primitive. Note this
+  /// equivalence holds under the relative interpretation: the single-batch
+  /// `deserialize` already applies the header window, so slicing its output
+  /// is the same as narrowing within that window.
   ///
   /// Preconditions:
   ///   * `data` is non-empty and `data.size() == rowRanges.size()`.
   ///   * For each `i`: `rowRanges[i].startRow <= rowRanges[i].endRow` and
-  ///     `rowRanges[i].endRow <= data[i]`'s batch rowCount.
+  ///     `rowRanges[i].endRow <= ` the number of rows `data[i]` exposes
+  ///     (the header rowRange's `numRows()` for kTablet, the batch rowCount
+  ///     otherwise).
   ///   * No batch carries the null-barrier flag.
   void deserialize(
       const std::vector<std::string_view>& data,
@@ -146,9 +158,9 @@ class Deserializer {
 
   // Shared body of all public `deserialize` overloads. Loops over `data`,
   // calls `appendBatch` per batch, then `decodeRun`. Pass an empty
-  // `rowRanges` to let each batch's rowRange be inferred from the header;
-  // pass a `data.size()`-sized `rowRanges` to override the inferred range
-  // per batch (`rowRanges[i]` for `data[i]`).
+  // `rowRanges` to decode whatever range each batch exposes (its header
+  // rowRange, or the whole batch); pass a `data.size()`-sized `rowRanges`
+  // to narrow within that range per batch (`rowRanges[i]` for `data[i]`).
   void deserializeImpl(
       folly::Range<const std::string_view*> data,
       folly::Range<const nimble::RowRange*> rowRanges,
@@ -205,10 +217,11 @@ class Deserializer {
   // Queues `batch`'s streams onto the pending decode run and records the
   // batch's effective rowRange in `runRanges_` (run-local coordinates).
   //
-  // `rowRange` overrides the range that would otherwise be inferred from
-  // the batch header (kTablet header rowRange, or full-batch for other
-  // versions). When set, requires
-  // `rowRange->startRow <= rowRange->endRow <= batch rowCount` and a
+  // `rowRange` narrows within the range the batch already exposes (the
+  // kTablet header rowRange, or the full batch for other versions) and is
+  // relative to that range's start, so it cannot widen the window or
+  // address rows outside it. When set, requires
+  // `rowRange->startRow <= rowRange->endRow <= exposed numRows()` and a
   // non-null-barrier batch.
   //
   // If the batch requires a null barrier, `decodeRun` fires before and

--- a/dwio/nimble/serializer/Deserializer.h
+++ b/dwio/nimble/serializer/Deserializer.h
@@ -117,7 +117,6 @@ class Deserializer {
   ///     `rowRanges[i].endRow <= ` the number of rows `data[i]` exposes
   ///     (the header rowRange's `numRows()` for kTablet, the batch rowCount
   ///     otherwise).
-  ///   * No batch carries the null-barrier flag.
   void deserialize(
       const std::vector<std::string_view>& data,
       const std::vector<nimble::RowRange>& rowRanges,
@@ -221,11 +220,12 @@ class Deserializer {
   // kTablet header rowRange, or the full batch for other versions) and is
   // relative to that range's start, so it cannot widen the window or
   // address rows outside it. When set, requires
-  // `rowRange->startRow <= rowRange->endRow <= exposed numRows()` and a
-  // non-null-barrier batch.
+  // `rowRange->startRow <= rowRange->endRow <= exposed numRows()`.
   //
   // If the batch requires a null barrier, `decodeRun` fires before and
-  // after queuing so the barrier batch decodes standalone.
+  // after queuing so the barrier batch decodes standalone. A rowRange
+  // applies there too: a barrier batch is a one-batch run, which is exactly
+  // the unit the range narrows.
   void appendBatch(
       std::string_view batch,
       std::optional<nimble::RowRange> rowRange,

--- a/dwio/nimble/serializer/tests/DeserializerSkipTest.cpp
+++ b/dwio/nimble/serializer/tests/DeserializerSkipTest.cpp
@@ -95,6 +95,124 @@ class DeserializerSkipTest : public ::testing::Test {
     return {std::move(serialized), std::move(schema)};
   }
 
+  // ROW(a INTEGER, s ROW(b INTEGER)). Rows listed in `nestedNullRows` get a
+  // null `s`, so s's Row null stream is written with real nulls and the
+  // batch's null-barrier flag is set. A nullable *scalar* column would not
+  // do it: the flag only tracks structural (Row/FlatMap) null streams.
+  static velox::TypePtr barrierType() {
+    return velox::ROW(
+        {{"a", velox::INTEGER()},
+         {"s", velox::ROW({{"b", velox::INTEGER()}})}});
+  }
+
+  velox::VectorPtr makeBarrierBatch(
+      int32_t base,
+      velox::vector_size_t rows,
+      const std::vector<velox::vector_size_t>& nestedNullRows) {
+    auto type = barrierType();
+    auto a = velox::BaseVector::create(velox::INTEGER(), rows, pool_.get());
+    auto b = velox::BaseVector::create(velox::INTEGER(), rows, pool_.get());
+    for (velox::vector_size_t i = 0; i < rows; ++i) {
+      a->asFlatVector<int32_t>()->set(i, base + i);
+      b->asFlatVector<int32_t>()->set(i, (base + i) * 10);
+    }
+    auto nested = std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type->childAt(1),
+        nullptr,
+        rows,
+        std::vector<velox::VectorPtr>{b});
+    for (auto row : nestedNullRows) {
+      nested->setNull(row, true);
+    }
+    return std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        rows,
+        std::vector<velox::VectorPtr>{a, nested});
+  }
+
+  // ROW(a INTEGER, s ROW(b INTEGER), m MAP(VARCHAR, DOUBLE)) with `m` written
+  // as a FlatMap. Nulls on `s` supply the barrier flag, independently of the
+  // FlatMap, so `m` can still have an all-present key. That combination is
+  // what reaches the barrier-only in-map path: an all-present key has its
+  // in-map stream omitted, and on a barrier batch `appendStreamSegments`
+  // records it with the no-arg `addPresentInMapBatch()` sentinel.
+  static velox::TypePtr flatMapBarrierType() {
+    return velox::ROW(
+        {{"a", velox::INTEGER()},
+         {"s", velox::ROW({{"b", velox::INTEGER()}})},
+         {"m", velox::MAP(velox::VARCHAR(), velox::DOUBLE())}});
+  }
+
+  velox::VectorPtr makeFlatMapBarrierBatch(
+      const std::vector<std::vector<std::string>>& keysByRow,
+      const std::vector<velox::vector_size_t>& nestedNullRows) {
+    auto type = flatMapBarrierType();
+    const auto rows = static_cast<velox::vector_size_t>(keysByRow.size());
+    velox::vector_size_t totalEntries = 0;
+    for (const auto& keys : keysByRow) {
+      totalEntries += static_cast<velox::vector_size_t>(keys.size());
+    }
+
+    auto a = velox::BaseVector::create(velox::INTEGER(), rows, pool_.get());
+    auto b = velox::BaseVector::create(velox::INTEGER(), rows, pool_.get());
+    for (velox::vector_size_t i = 0; i < rows; ++i) {
+      a->asFlatVector<int32_t>()->set(i, i);
+      b->asFlatVector<int32_t>()->set(i, i * 10);
+    }
+    auto nested = std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type->childAt(1),
+        nullptr,
+        rows,
+        std::vector<velox::VectorPtr>{b});
+    for (auto row : nestedNullRows) {
+      nested->setNull(row, true);
+    }
+
+    auto mapKeys =
+        velox::BaseVector::create(velox::VARCHAR(), totalEntries, pool_.get());
+    auto mapValues =
+        velox::BaseVector::create(velox::DOUBLE(), totalEntries, pool_.get());
+    velox::vector_size_t idx = 0;
+    for (velox::vector_size_t row = 0; row < rows; ++row) {
+      for (const auto& key : keysByRow[row]) {
+        mapKeys->asFlatVector<velox::StringView>()->set(
+            idx, velox::StringView(key));
+        mapValues->asFlatVector<double>()->set(idx, row * 10.0 + idx);
+        ++idx;
+      }
+    }
+    auto mapVector = std::make_shared<velox::MapVector>(
+        pool_.get(),
+        type->childAt(2),
+        nullptr,
+        rows,
+        velox::allocateOffsets(rows, pool_.get()),
+        velox::allocateSizes(rows, pool_.get()),
+        mapKeys,
+        mapValues);
+    auto* rawOffsets =
+        mapVector->mutableOffsets(rows)->asMutable<velox::vector_size_t>();
+    auto* rawSizes =
+        mapVector->mutableSizes(rows)->asMutable<velox::vector_size_t>();
+    velox::vector_size_t offset = 0;
+    for (velox::vector_size_t i = 0; i < rows; ++i) {
+      rawOffsets[i] = offset;
+      rawSizes[i] = static_cast<velox::vector_size_t>(keysByRow[i].size());
+      offset += rawSizes[i];
+    }
+
+    return std::make_shared<velox::RowVector>(
+        pool_.get(),
+        type,
+        nullptr,
+        rows,
+        std::vector<velox::VectorPtr>{a, nested, mapVector});
+  }
+
   // Round-trip check: `deserialize(data, rowRanges)` for rowRanges derived
   // from a run-level [skipRows, skipRows+decodeRows) window must equal
   // `deserialize(data)` sliced by the same window.
@@ -731,6 +849,120 @@ TEST_F(DeserializerSkipTest, mapIntIntSingleBatch) {
 
 // Bad per-batch rowRange: startRow > endRow. Would underflow the uint32
 // numRows() computation and confuse `planReaderOps` if not rejected.
+// Guards every barrier test below by confirming `makeBarrierBatch` produces
+// what it claims: nulls in the nested Row set the header's barrier flag, and
+// the same schema without nulls leaves it clear. If this helper ever stopped
+// producing barrier batches, those tests would silently run on ordinary
+// batches and still pass.
+TEST_F(DeserializerSkipTest, barrierFlagSetOnlyWhenNestedRowHasNulls) {
+  auto readBarrierFlag = [&](const std::string& blob) {
+    DeserializerOptions dsOpts{.hasHeader = true};
+    serde::StreamDataParser parser{pool_.get(), dsOpts};
+    parser.initialize(blob);
+    return parser.requiresNullBarrier();
+  };
+
+  auto [withNulls, schema1] =
+      serialize(barrierType(), {makeBarrierBatch(0, 10, {3, 7})});
+  EXPECT_TRUE(readBarrierFlag(withNulls[0]));
+
+  auto [noNulls, schema2] =
+      serialize(barrierType(), {makeBarrierBatch(0, 10, {})});
+  EXPECT_FALSE(readBarrierFlag(noNulls[0]));
+}
+
+// A null-barrier batch decodes standalone, which is exactly the unit a
+// rowRange applies to. Uses the file's equivalence property:
+// deserialize(data, ranges) == deserialize(data) sliced by the same window.
+TEST_F(DeserializerSkipTest, barrierSingleBatchWithRowRange) {
+  auto [serialized, schema] =
+      serialize(barrierType(), {makeBarrierBatch(0, 10, {3, 7})});
+  checkSkip(schema, serialized, /*skipRows=*/2, /*decodeRows=*/5);
+}
+
+// A barrier batch sandwiched between ordinary ones: the run is flushed before
+// and after it, so the ranges must still line up across all three.
+TEST_F(DeserializerSkipTest, barrierBatchAmongNonBarrierBatches) {
+  auto [serialized, schema] = serialize(
+      barrierType(),
+      {makeBarrierBatch(0, 5, {}),
+       makeBarrierBatch(5, 5, {1, 3}),
+       makeBarrierBatch(10, 5, {})});
+  checkSkip(schema, serialized, /*skipRows=*/3, /*decodeRows=*/9);
+}
+
+// Every batch flagged: each becomes its own run.
+TEST_F(DeserializerSkipTest, barrierEveryBatch) {
+  auto [serialized, schema] = serialize(
+      barrierType(),
+      {makeBarrierBatch(0, 5, {2}),
+       makeBarrierBatch(5, 5, {1}),
+       makeBarrierBatch(10, 5, {4})});
+  checkSkip(schema, serialized, /*skipRows=*/4, /*decodeRows=*/7);
+}
+
+// Range boundaries against a barrier batch: whole batch, empty, and a window
+// that ends exactly on the batch boundary.
+TEST_F(DeserializerSkipTest, barrierBatchRangeBoundaries) {
+  auto [serialized, schema] = serialize(
+      barrierType(),
+      {makeBarrierBatch(0, 6, {0, 5}), makeBarrierBatch(6, 6, {2})});
+  checkSkip(schema, serialized, /*skipRows=*/0, /*decodeRows=*/12);
+  checkSkip(schema, serialized, /*skipRows=*/0, /*decodeRows=*/6);
+  checkSkip(schema, serialized, /*skipRows=*/6, /*decodeRows=*/6);
+  checkSkip(schema, serialized, /*skipRows=*/5, /*decodeRows=*/2);
+  checkSkip(schema, serialized, /*skipRows=*/3, /*decodeRows=*/0);
+}
+
+// The barrier-only in-map path. Key "a" is in every row, so its in-map stream
+// is omitted and the reader reconstructs it; on a barrier batch that goes
+// through the `addPresentInMapBatch()` sentinel (endRow = kPresentInMapEndRow),
+// which was written assuming the whole batch is read. A rowRange makes the
+// reader skip instead, exercising the sentinel's clamping in skipInMap and
+// fillInMapGap. Key "b" is on even rows only, so its in-map stream is really
+// written and both in-map shapes are covered in one batch.
+TEST_F(DeserializerSkipTest, barrierFlatMapInMapWithRowRange) {
+  std::vector<std::vector<std::string>> keysByRow;
+  for (int i = 0; i < 8; ++i) {
+    std::vector<std::string> keys{"a"};
+    if (i % 2 == 0) {
+      keys.emplace_back("b");
+    }
+    keysByRow.push_back(std::move(keys));
+  }
+  auto [serialized, schema] = serialize(
+      flatMapBarrierType(),
+      {makeFlatMapBarrierBatch(keysByRow, /*nestedNullRows=*/{2, 5})},
+      /*flatMapColumns=*/{{"m", {}}});
+
+  checkSkip(schema, serialized, /*skipRows=*/0, /*decodeRows=*/8);
+  checkSkip(schema, serialized, /*skipRows=*/1, /*decodeRows=*/5);
+  checkSkip(schema, serialized, /*skipRows=*/3, /*decodeRows=*/2);
+  checkSkip(schema, serialized, /*skipRows=*/5, /*decodeRows=*/3);
+}
+
+// Same shape across several barrier batches, so the sentinel is re-created per
+// batch and the reader is reset between runs.
+TEST_F(DeserializerSkipTest, barrierFlatMapInMapMultipleBatches) {
+  auto makeBatch = [&](int rows) {
+    std::vector<std::vector<std::string>> keysByRow;
+    for (int i = 0; i < rows; ++i) {
+      std::vector<std::string> keys{"a"};
+      if (i % 3 == 0) {
+        keys.emplace_back("b");
+      }
+      keysByRow.push_back(std::move(keys));
+    }
+    return makeFlatMapBarrierBatch(keysByRow, /*nestedNullRows=*/{1});
+  };
+  auto [serialized, schema] = serialize(
+      flatMapBarrierType(),
+      {makeBatch(6), makeBatch(6), makeBatch(6)},
+      /*flatMapColumns=*/{{"m", {}}});
+
+  checkSkip(schema, serialized, /*skipRows=*/2, /*decodeRows=*/11);
+}
+
 TEST_F(DeserializerSkipTest, rejectRowRangeStartRowAfterEndRow) {
   auto type = velox::ROW({{"a", velox::INTEGER()}});
   auto batch = vm_->rowVector(

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -1703,6 +1703,63 @@ TEST_P(NimbleIndexProjectorTest, deserializerRangeFullStripe) {
 
 #undef RUN_DESERIALIZER_RANGE_TEST
 
+// Barrier + windowed kTablet + caller rowRange together. The projector marks a
+// slice `requiresNullBarrier` whenever a Row/FlatMap null stream is physically
+// present, so this combination is production-shaped rather than synthetic.
+TEST_P(NimbleIndexProjectorTest, deserializerRowRangeOnBarrierWindowedSlice) {
+  auto nestedType = ROW({"b"}, {INTEGER()});
+  auto rowType = ROW({"key", "s"}, {BIGINT(), nestedType});
+  constexpr int kStripeRows = 100;
+  std::vector<int64_t> keys(kStripeRows);
+  std::vector<int32_t> bs(kStripeRows);
+  for (int i = 0; i < kStripeRows; ++i) {
+    keys[i] = i;
+    bs[i] = i * 10;
+  }
+  auto nested = std::make_shared<RowVector>(
+      leafPool_.get(),
+      nestedType,
+      nullptr,
+      kStripeRows,
+      std::vector<VectorPtr>{vectorMaker_->flatVector<int32_t>(bs)});
+  // Real nulls inside the projected window make the slice a barrier.
+  for (int row : {32, 41, 55}) {
+    nested->setNull(row, true);
+  }
+  auto batch = std::make_shared<RowVector>(
+      leafPool_.get(),
+      rowType,
+      nullptr,
+      kStripeRows,
+      std::vector<VectorPtr>{vectorMaker_->flatVector<int64_t>(keys), nested});
+  writeData({batch}, {"key"});
+
+  std::vector<Subfield> subfields;
+  subfields.emplace_back("s");
+  auto projector = createProjector(subfields);
+  auto bounds = makeRangeLookup(rowType, {"key"}, kWindowStart, kWindowEnd);
+  NimbleIndexProjector::Request request;
+  request.keyBounds = {bounds};
+  auto result = projector->project(request, {});
+  ASSERT_EQ(result.responses[0].slices.size(), 1);
+  const auto& slice = result.responses[0].slices[0];
+  const auto header = readEmbeddedTabletChunkHeader(slice);
+  ASSERT_EQ(header.rowRange.startRow, kWindowStart);
+  ASSERT_EQ(header.rowRange.endRow, kWindowEnd);
+  // Without this the test would silently cover only the ordinary path.
+  ASSERT_TRUE(header.requiresNullBarrier);
+
+  // Caller [0, 10) narrows the [30, 60) window to stripe rows [30, 40), which
+  // spans the null at row 32. Compare against the unranged decode sliced the
+  // same way, so nulls and values are both checked.
+  auto full = deserializeProjectedSlice(*projector, slice);
+  ASSERT_EQ(full->size(), kWindowRows);
+  auto expected = full->slice(0, 10);
+  expectVectorRows(
+      deserializeProjectedSlice(*projector, slice, {RowRange{0, 10}}),
+      expected);
+}
+
 // A caller rowRange composes with the header window instead of replacing it:
 // it is relative to the window start, so it can only narrow.
 TEST_P(NimbleIndexProjectorTest, deserializerRowRangeNarrowsHeaderWindow) {

--- a/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
+++ b/dwio/nimble/velox/index/tests/NimbleIndexProjectorTest.cpp
@@ -334,6 +334,78 @@ class NimbleIndexProjectorTest : public ::testing::TestWithParam<TestParam> {
     return deserializeProjectedBatches(projector, batches);
   }
 
+  // Stripe rows the `makeWindowedSlice` key bounds select.
+  static constexpr uint32_t kWindowStart = 30;
+  static constexpr uint32_t kWindowEnd = 60;
+  static constexpr uint32_t kWindowRows = kWindowEnd - kWindowStart;
+
+  // A projected slice whose header window is [kWindowStart, kWindowEnd).
+  // Owns the projector and the projector result because the slice borrows
+  // from both.
+  struct WindowedSlice {
+    std::unique_ptr<NimbleIndexProjector> projector;
+    NimbleIndexProjector::Result result;
+    // The full stripe's `value` column, for building expectations.
+    std::vector<int32_t> values;
+
+    const folly::IOBuf& slice() const {
+      return result.responses[0].slices[0];
+    }
+  };
+
+  // Writes a 100-row stripe keyed on `key`, projects `value`, and returns
+  // the single slice the key bounds window to [kWindowStart, kWindowEnd).
+  WindowedSlice makeWindowedSlice() {
+    auto rowType = ROW({"key", "value"}, {BIGINT(), INTEGER()});
+    constexpr int kStripeRows = 100;
+    std::vector<int64_t> keys(kStripeRows);
+    std::vector<int32_t> values(kStripeRows);
+    for (int i = 0; i < kStripeRows; ++i) {
+      keys[i] = i;
+      values[i] = i * 10;
+    }
+    auto batch = vectorMaker_->rowVector(
+        {"key", "value"},
+        {vectorMaker_->flatVector<int64_t>(keys),
+         vectorMaker_->flatVector<int32_t>(values)});
+    writeData({batch}, {"key"});
+    std::vector<Subfield> subfields;
+    subfields.emplace_back("value");
+    auto projector = createProjector(subfields);
+    auto bounds = makeRangeLookup(rowType, {"key"}, kWindowStart, kWindowEnd);
+    NimbleIndexProjector::Request request;
+    request.keyBounds = {bounds};
+    auto result = projector->project(request, {});
+    return {std::move(projector), std::move(result), std::move(values)};
+  }
+
+  // Asserts the slice really carries the expected header window, so the
+  // composition tests cannot pass vacuously on an unwindowed slice.
+  void expectWindow(const WindowedSlice& windowed) {
+    ASSERT_EQ(windowed.result.responses[0].slices.size(), 1);
+    const auto window = readEmbeddedRowRange(windowed.slice());
+    ASSERT_EQ(window.startRow, kWindowStart);
+    ASSERT_EQ(window.endRow, kWindowEnd);
+  }
+
+  // Same, but narrows within the slice's header window using the per-batch
+  // rowRanges overload. `rowRanges` are relative to that window.
+  VectorPtr deserializeProjectedSlice(
+      const NimbleIndexProjector& projector,
+      const folly::IOBuf& slice,
+      const std::vector<RowRange>& rowRanges) {
+    auto coalesced = coalesceChunkSlice(slice);
+    std::vector<std::string_view> batches{std::string_view(
+        reinterpret_cast<const char*>(coalesced.data()), coalesced.length())};
+    DeserializerOptions deserOptions;
+    deserOptions.hasHeader = true;
+    Deserializer deserializer(
+        projector.projectedNimbleType(), leafPool_.get(), deserOptions);
+    VectorPtr output;
+    deserializer.deserialize(batches, rowRanges, output);
+    return output;
+  }
+
   // Compares decoded output rows with an expected vector. The Deserializer
   // honors the header's row range via skip+next at decode time, so output
   // contains exactly the requested rows starting at index 0.
@@ -1630,6 +1702,68 @@ TEST_P(NimbleIndexProjectorTest, deserializerRangeFullStripe) {
 }
 
 #undef RUN_DESERIALIZER_RANGE_TEST
+
+// A caller rowRange composes with the header window instead of replacing it:
+// it is relative to the window start, so it can only narrow.
+TEST_P(NimbleIndexProjectorTest, deserializerRowRangeNarrowsHeaderWindow) {
+  auto windowed = makeWindowedSlice();
+  ASSERT_NO_FATAL_FAILURE(expectWindow(windowed));
+
+  // [0, 10) is relative to the window, so it selects stripe rows [30, 40)
+  // (values 300..390). Replacing the window would have yielded [0, 10).
+  std::vector<int32_t> expectedValues(
+      windowed.values.begin() + kWindowStart,
+      windowed.values.begin() + kWindowStart + 10);
+  auto expected = vectorMaker_->rowVector(
+      {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues)});
+  expectVectorRows(
+      deserializeProjectedSlice(
+          *windowed.projector, windowed.slice(), {RowRange{0, 10}}),
+      expected);
+}
+
+// The full window is addressable; one row past it is not.
+TEST_P(NimbleIndexProjectorTest, deserializerRowRangeAcceptsWholeWindow) {
+  auto windowed = makeWindowedSlice();
+  ASSERT_NO_FATAL_FAILURE(expectWindow(windowed));
+
+  std::vector<int32_t> expectedValues(
+      windowed.values.begin() + kWindowStart,
+      windowed.values.begin() + kWindowEnd);
+  auto expected = vectorMaker_->rowVector(
+      {"value"}, {vectorMaker_->flatVector<int32_t>(expectedValues)});
+  expectVectorRows(
+      deserializeProjectedSlice(
+          *windowed.projector, windowed.slice(), {RowRange{0, kWindowRows}}),
+      expected);
+}
+
+// The window, not the stripe, bounds a caller rowRange. Every one of these
+// fits inside the 100-row stripe, so validating against the batch rowCount
+// (the pre-composition contract) would have accepted them all and silently
+// returned rows outside the window the slice was scoped to.
+TEST_P(NimbleIndexProjectorTest, deserializerRowRangeRejectsRangePastWindow) {
+  auto windowed = makeWindowedSlice();
+  ASSERT_NO_FATAL_FAILURE(expectWindow(windowed));
+
+  const std::vector<RowRange> pastWindow{
+      // One row too many, starting at the window start.
+      RowRange{0, kWindowRows + 1},
+      // Starts inside the window but runs past its end.
+      RowRange{kWindowRows - 5, kWindowRows + 5},
+      // Starts at the first row past the window.
+      RowRange{kWindowRows, kWindowRows + 1},
+      // Entirely beyond the window.
+      RowRange{kWindowRows + 10, kWindowRows + 20},
+  };
+  for (const auto& range : pastWindow) {
+    SCOPED_TRACE(range.toString());
+    NIMBLE_ASSERT_THROW(
+        deserializeProjectedSlice(
+            *windowed.projector, windowed.slice(), {range}),
+        "rowRange endRow exceeds the rows this batch exposes");
+  }
+}
 
 TEST_P(NimbleIndexProjectorTest, deserializerMultiBatchWithRowRange) {
   // Each input batch's embedded row range is applied per-segment by the


### PR DESCRIPTION
Summary:
`deserialize(data, rowRanges, output)` rejected any batch carrying the
null-barrier flag:

```cpp
NIMBLE_USER_CHECK(!requiresBarrier, "rowRange not supported for null-barrier batches");
```

It turns out to be a guard rather than a real limitation. Removing it is the
whole production change — no decode logic needed to move.

**Why it already works.** A barrier batch is decoded standalone: `appendBatch`
flushes the pending run before queuing it and again immediately after. That
makes it a one-batch run with `run.rows == 0`, which is exactly the unit a
rowRange narrows, so `runRanges_`, `buildDecodeOps` and `decodeRun` need no
changes.

The one place a barrier changes decoder bookkeeping is FlatMap in-map. On the
barrier path `appendStreamSegments` records all-present keys with the no-arg
`addPresentInMapBatch()` sentinel (`endRow = kPresentInMapEndRow`) rather than an
explicit extent, because the read's length is not known at queue time. That was
written assuming the whole batch is read, and a rowRange makes the reader skip
instead. It holds up: `fillInMapGap` already clamps `presentStartRow` to
`max(segment.startRow, rowOffset)` and caps at the gap end, and
`advanceInMapPresentSegmentIndex` correctly never retires a sentinel. Verified by
test rather than by reading (see below).

Also dropped the now-false "No batch carries the null-barrier flag" precondition
from the public contract, and refreshed the `appendBatch` comment.

Reviewed By: xiaoxmeng

Differential Revision: D114957960


