### PR TITLE
perf: Add nested ALP encoding streams

### DIFF
--- a/dwio/nimble/encodings/ALPEncoding.h
+++ b/dwio/nimble/encodings/ALPEncoding.h
@@ -50,8 +50,11 @@
 ///   1-5 bytes: exceptionCount (varint, present only when has exceptions)
 ///   1-5 bytes: encodedValuesSize (varint uint32, size of nested encoding)
 ///   N bytes: nested encoding of ZigZag-coded signed encoded values
-///   exceptionCount * 4 bytes: exception positions (uint32 each)
-///   exceptionCount * sizeof(physicalType) bytes: exception values
+///   If has exceptions:
+///     1-5 bytes: exceptionPositionsSize (varint uint32)
+///     N bytes: nested encoding of uint32 exception positions
+///     1-5 bytes: exceptionValuesSize (varint uint32)
+///     N bytes: nested encoding of original logical exception values
 
 namespace facebook::nimble {
 
@@ -137,13 +140,33 @@ class ALPEncoding final
         noStringBufferFactory);
     pos += encodedValuesSize;
 
-    exceptionPositions_ = pos;
-    pos += exceptionCount_ * sizeof(uint32_t);
-    exceptionValues_ = pos;
-
     encodedBuffer_.resize(this->rowCount());
     encodedValuesEncoding_->materialize(
         this->rowCount(), encodedBuffer_.data());
+
+    if (exceptionCount_ > 0) {
+      const uint32_t exceptionPositionsSize = varint::readVarint32(&pos);
+      auto exceptionPositionsEncoding = encodingFactory.create(
+          *this->pool_,
+          std::string_view(pos, exceptionPositionsSize),
+          noStringBufferFactory);
+      pos += exceptionPositionsSize;
+
+      const uint32_t exceptionValuesSize = varint::readVarint32(&pos);
+      auto exceptionValuesEncoding = encodingFactory.create(
+          *this->pool_,
+          std::string_view(pos, exceptionValuesSize),
+          noStringBufferFactory);
+      pos += exceptionValuesSize;
+
+      exceptionPositionsBuffer_.resize(exceptionCount_);
+      exceptionPositionsEncoding->materialize(
+          exceptionCount_, exceptionPositionsBuffer_.data());
+
+      exceptionValuesBuffer_.resize(exceptionCount_);
+      exceptionValuesEncoding->materialize(
+          exceptionCount_, exceptionValuesBuffer_.data());
+    }
   }
 
   void reset() final {
@@ -212,18 +235,19 @@ class ALPEncoding final
     const uint32_t rowCount = values.size();
     auto* pool = &buffer.getMemoryPool();
 
-    Vector<cppDataType> logicalValues(pool, rowCount);
+    ScopedVector<cppDataType> logicalValues{rowCount, pool, options.bufferPool};
     for (uint32_t i = 0; i < rowCount; ++i) {
       logicalValues[i] = detail::alp::toLogical<cppDataType>(values[i]);
     }
 
+    ScopedVector<uint64_t> encodedValues{rowCount, pool, options.bufferPool};
+    ScopedVector<uint32_t> exceptionPositions{
+        /*size=*/0, pool, options.bufferPool};
+    ScopedVector<physicalType> exceptionValues{
+        /*size=*/0, pool, options.bufferPool};
     const auto [exponent, factor] = findBestExponentFactor(
         std::span<const cppDataType>{
             logicalValues.data(), logicalValues.size()});
-
-    Vector<uint64_t> encodedValues(pool, rowCount);
-    Vector<uint32_t> exceptionPositions(pool);
-    Vector<physicalType> exceptionValues(pool);
 
     for (uint32_t i = 0; i < rowCount; ++i) {
       if (!canRepresentExactly(logicalValues[i], values[i], exponent, factor)) {
@@ -245,19 +269,36 @@ class ALPEncoding final
     std::string_view serializedEncoded =
         selection.template encodeNested<uint64_t>(
             EncodingIdentifiers::ALP::EncodedValues,
-            {encodedValues},
+            {encodedValues.data(), encodedValues.size()},
             scopedBuffer.get(),
             options);
 
-    const uint32_t exceptionPositionsSize = exceptionCount * sizeof(uint32_t);
-    const uint32_t exceptionValuesSize = exceptionCount * sizeof(physicalType);
+    std::string_view serializedExceptionPositions;
+    std::string_view serializedExceptionValues;
+    if (exceptionCount > 0) {
+      serializedExceptionPositions = selection.template encodeNested<uint32_t>(
+          EncodingIdentifiers::ALP::ExceptionPositions,
+          {exceptionPositions.data(), exceptionPositions.size()},
+          scopedBuffer.get(),
+          options);
+      serializedExceptionValues = selection.template encodeNested<physicalType>(
+          EncodingIdentifiers::ALP::ExceptionValues,
+          {exceptionValues.data(), exceptionValues.size()},
+          scopedBuffer.get(),
+          options);
+    }
+
     const uint32_t metadataSize = kHeaderSize +
         (exceptionCount > 0 ? varint::varintSize(exceptionCount) : 0) +
-        varint::varintSize(serializedEncoded.size());
+        varint::varintSize(serializedEncoded.size()) +
+        (exceptionCount > 0
+             ? varint::varintSize(serializedExceptionPositions.size()) +
+                 varint::varintSize(serializedExceptionValues.size())
+             : 0);
     const uint32_t encodingSize =
         Encoding::serializePrefixSize(rowCount, options.useVarintRowCount) +
-        metadataSize + serializedEncoded.size() + exceptionPositionsSize +
-        exceptionValuesSize;
+        metadataSize + serializedEncoded.size() +
+        serializedExceptionPositions.size() + serializedExceptionValues.size();
 
     char* reserved = buffer.reserve(encodingSize);
     char* pos = reserved;
@@ -281,10 +322,10 @@ class ALPEncoding final
     encoding::writeBytes(serializedEncoded, pos);
 
     if (exceptionCount > 0) {
-      std::memcpy(pos, exceptionPositions.data(), exceptionPositionsSize);
-      pos += exceptionPositionsSize;
-      std::memcpy(pos, exceptionValues.data(), exceptionValuesSize);
-      pos += exceptionValuesSize;
+      varint::writeVarint(serializedExceptionPositions.size(), &pos);
+      encoding::writeBytes(serializedExceptionPositions, pos);
+      varint::writeVarint(serializedExceptionValues.size(), &pos);
+      encoding::writeBytes(serializedExceptionValues, pos);
     }
 
     NIMBLE_CHECK_EQ(encodingSize, pos - reserved, "Encoding size mismatch.");
@@ -312,10 +353,6 @@ class ALPEncoding final
     const std::string_view encodedValues{pos, encodedValuesSize};
     pos += encodedValuesSize;
 
-    const auto* exceptionPositions = reinterpret_cast<const uint32_t*>(pos);
-    pos += exceptionCount * sizeof(uint32_t);
-    const auto* exceptionValues = reinterpret_cast<const physicalType*>(pos);
-
     auto* pool = &buffer.getMemoryPool();
     ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
     const auto slicedEncodedValues = EncodingFactory::slice(
@@ -327,36 +364,29 @@ class ALPEncoding final
     const auto slicedEncodedValuesSize =
         static_cast<uint32_t>(slicedEncodedValues.size());
 
-    const auto* exceptionEnd = exceptionPositions + exceptionCount;
-    const auto* first =
-        std::lower_bound(exceptionPositions, exceptionEnd, offset);
-    const auto* last = std::lower_bound(first, exceptionEnd, offset + length);
-    const auto slicedExceptionCount = static_cast<uint32_t>(last - first);
-    ScopedVector<uint32_t> slicedExceptionPositions{
-        slicedExceptionCount, pool, options.bufferPool};
-    ScopedVector<physicalType> slicedExceptionValues{
-        slicedExceptionCount, pool, options.bufferPool};
-    uint32_t exceptionIndex{0};
-    for (const auto* it = first; it != last; ++it) {
-      slicedExceptionPositions[exceptionIndex] = *it - offset;
-      slicedExceptionValues[exceptionIndex] =
-          exceptionValues[it - exceptionPositions];
-      ++exceptionIndex;
-    }
-    NIMBLE_CHECK_EQ(exceptionIndex, slicedExceptionCount);
+    const auto slicedExceptionStreams = sliceExceptionStreams(
+        pos,
+        exceptionCount,
+        offset,
+        length,
+        buffer,
+        scopedBuffer.get(),
+        options);
 
-    const uint32_t exceptionPositionsSize =
-        slicedExceptionCount * sizeof(uint32_t);
-    const uint32_t exceptionValuesSize =
-        slicedExceptionCount * sizeof(physicalType);
     const uint32_t metadataSize = kHeaderSize +
-        (slicedExceptionCount > 0 ? varint::varintSize(slicedExceptionCount)
-                                  : 0) +
-        varint::varintSize(slicedEncodedValuesSize);
+        (slicedExceptionStreams.count > 0
+             ? varint::varintSize(slicedExceptionStreams.count)
+             : 0) +
+        varint::varintSize(slicedEncodedValuesSize) +
+        (slicedExceptionStreams.count > 0
+             ? varint::varintSize(slicedExceptionStreams.positions.size()) +
+                 varint::varintSize(slicedExceptionStreams.values.size())
+             : 0);
     const uint32_t encodingSize =
         Encoding::serializePrefixSize(length, options.useVarintRowCount) +
-        metadataSize + slicedEncodedValuesSize + exceptionPositionsSize +
-        exceptionValuesSize;
+        metadataSize + slicedEncodedValuesSize +
+        slicedExceptionStreams.positions.size() +
+        slicedExceptionStreams.values.size();
 
     char* reserved = buffer.reserve(encodingSize);
     char* writePos = reserved;
@@ -370,19 +400,18 @@ class ALPEncoding final
         detail::alp::Header{
             .exponent = header.exponent,
             .factor = header.factor,
-            .hasExceptions = slicedExceptionCount > 0},
+            .hasExceptions = slicedExceptionStreams.count > 0},
         writePos);
-    if (slicedExceptionCount > 0) {
-      varint::writeVarint(slicedExceptionCount, &writePos);
+    if (slicedExceptionStreams.count > 0) {
+      varint::writeVarint(slicedExceptionStreams.count, &writePos);
     }
     varint::writeVarint(slicedEncodedValuesSize, &writePos);
     encoding::writeBytes(slicedEncodedValues, writePos);
-    if (slicedExceptionCount > 0) {
-      std::memcpy(
-          writePos, slicedExceptionPositions.data(), exceptionPositionsSize);
-      writePos += exceptionPositionsSize;
-      std::memcpy(writePos, slicedExceptionValues.data(), exceptionValuesSize);
-      writePos += exceptionValuesSize;
+    if (slicedExceptionStreams.count > 0) {
+      varint::writeVarint(slicedExceptionStreams.positions.size(), &writePos);
+      encoding::writeBytes(slicedExceptionStreams.positions, writePos);
+      varint::writeVarint(slicedExceptionStreams.values.size(), &writePos);
+      encoding::writeBytes(slicedExceptionStreams.values, writePos);
     }
 
     NIMBLE_CHECK_EQ(
@@ -437,6 +466,10 @@ class ALPEncoding final
 
     std::vector<uint64_t> encodedValues;
     encodedValues.reserve(sampleSize);
+    std::vector<uint32_t> exceptionPositions;
+    exceptionPositions.reserve(sampleSize);
+    std::vector<physicalType> exceptionValues;
+    exceptionValues.reserve(sampleSize);
     uint64_t sampleExceptionCount{0};
     for (auto i = 0; i < sampleSize; ++i) {
       if (!canRepresentExactly(
@@ -445,6 +478,9 @@ class ALPEncoding final
               exponent,
               factor)) {
         encodedValues.push_back(0);
+        exceptionPositions.push_back(
+            sampledValueIndex(i, rowCount, sampleSize));
+        exceptionValues.push_back(sampledValues[static_cast<size_t>(i)]);
         ++sampleExceptionCount;
         continue;
       }
@@ -464,11 +500,31 @@ class ALPEncoding final
         TrivialEncoding<uint64_t>::estimateSize(rowCount));
     const uint64_t exceptionCount =
         (sampleExceptionCount * rowCount + sampleSize - 1) / sampleSize;
-    const uint64_t exceptionPositionsSize = exceptionCount * sizeof(uint32_t);
-    const uint64_t exceptionValuesSize = exceptionCount * sizeof(physicalType);
+    uint64_t exceptionPositionsSize{0};
+    uint64_t exceptionValuesSize{0};
+    if (exceptionCount > 0) {
+      const auto positionStats = Statistics<uint32_t>::create(
+          std::span<const uint32_t>{
+              exceptionPositions.data(), exceptionPositions.size()});
+      exceptionPositionsSize = std::min(
+          TrivialEncoding<uint32_t>::estimateSize(exceptionCount),
+          FixedBitWidthEncoding<uint32_t>::estimateSize(
+              exceptionCount, positionStats, options));
+
+      const auto valueStats = Statistics<physicalType>::create(
+          std::span<const physicalType>{
+              exceptionValues.data(), exceptionValues.size()});
+      exceptionValuesSize = std::min(
+          TrivialEncoding<physicalType>::estimateSize(exceptionCount),
+          FixedBitWidthEncoding<physicalType>::estimateSize(
+              exceptionCount, valueStats, options));
+    }
     const uint64_t metadataSize = kHeaderSize +
         (exceptionCount > 0 ? varint::varintSize(exceptionCount) : 0) +
-        varint::varintSize(nestedEncodedValuesSize);
+        varint::varintSize(nestedEncodedValuesSize) +
+        (exceptionCount > 0 ? varint::varintSize(exceptionPositionsSize) +
+                 varint::varintSize(exceptionValuesSize)
+                            : 0);
     return Encoding::serializePrefixSize(
                static_cast<uint32_t>(rowCount), options.useVarintRowCount) +
         metadataSize + nestedEncodedValuesSize + exceptionPositionsSize +
@@ -487,6 +543,101 @@ class ALPEncoding final
     return sampleIndex * rowCount / sampleSize;
   }
 
+ private:
+  struct SlicedExceptionStreams {
+    uint32_t count{0};
+    std::string_view positions;
+    std::string_view values;
+  };
+
+  static SlicedExceptionStreams sliceExceptionStreams(
+      const char*& pos,
+      uint32_t exceptionCount,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      Buffer& scopedBuffer,
+      const Encoding::Options& options) {
+    if (exceptionCount == 0) {
+      return {};
+    }
+
+    auto* pool = &buffer.getMemoryPool();
+    ScopedVector<uint32_t> exceptionPositions{
+        exceptionCount, pool, options.bufferPool};
+
+    const uint32_t exceptionPositionsSize = varint::readVarint32(&pos);
+    const std::string_view exceptionPositionsEncoded{
+        pos, exceptionPositionsSize};
+    auto exceptionPositionsEncoding = EncodingFactory(options).create(
+        buffer.getMemoryPool(),
+        exceptionPositionsEncoded,
+        [](uint32_t) -> void* { return nullptr; });
+    pos += exceptionPositionsSize;
+    exceptionPositionsEncoding->materialize(
+        exceptionCount, exceptionPositions.data());
+
+    const uint32_t exceptionValuesSize = varint::readVarint32(&pos);
+    const std::string_view exceptionValuesEncoded{pos, exceptionValuesSize};
+    pos += exceptionValuesSize;
+
+    const auto* exceptionPositionsBegin = exceptionPositions.data();
+    const auto* exceptionPositionsEnd =
+        exceptionPositionsBegin + exceptionCount;
+    const uint32_t firstExceptionIndex = static_cast<uint32_t>(
+        std::lower_bound(
+            exceptionPositionsBegin, exceptionPositionsEnd, offset) -
+        exceptionPositionsBegin);
+    const uint32_t lastExceptionIndex = static_cast<uint32_t>(
+        std::lower_bound(
+            exceptionPositionsBegin + firstExceptionIndex,
+            exceptionPositionsEnd,
+            offset + length) -
+        exceptionPositionsBegin);
+    const auto slicedExceptionCount = lastExceptionIndex - firstExceptionIndex;
+    if (slicedExceptionCount == 0) {
+      return {};
+    }
+
+    ScopedVector<uint32_t> slicedExceptionPositions{
+        slicedExceptionCount, pool, options.bufferPool};
+    uint32_t exceptionIndex{0};
+    for (uint32_t i = firstExceptionIndex; i < lastExceptionIndex; ++i) {
+      slicedExceptionPositions[exceptionIndex] = exceptionPositions[i] - offset;
+      ++exceptionIndex;
+    }
+    NIMBLE_CHECK_EQ(exceptionIndex, slicedExceptionCount);
+
+    auto slicedExceptionPositionsEncoded =
+        EncodingFactory::encodeWithCapturedLayout<uint32_t>(
+            exceptionPositionsEncoded,
+            {slicedExceptionPositions.data(), slicedExceptionCount},
+            scopedBuffer,
+            options,
+            "ALP exception positions layout");
+    NIMBLE_CHECK_LE(
+        slicedExceptionPositionsEncoded.size(),
+        std::numeric_limits<uint32_t>::max(),
+        "ALP sliced exception positions are too large.");
+
+    auto slicedExceptionValuesEncoded = EncodingFactory::slice(
+        exceptionValuesEncoded,
+        firstExceptionIndex,
+        slicedExceptionCount,
+        scopedBuffer,
+        options);
+    NIMBLE_CHECK_LE(
+        slicedExceptionValuesEncoded.size(),
+        std::numeric_limits<uint32_t>::max(),
+        "ALP sliced exception values are too large.");
+
+    return {
+        .count = slicedExceptionCount,
+        .positions = slicedExceptionPositionsEncoded,
+        .values = slicedExceptionValuesEncoded};
+  }
+
+ public:
   // Pre-computed powers of 10 for double precision.
   static constexpr std::array<double, 24> kPow10Double{
       1e0,  1e1,  1e2,  1e3,  1e4,  1e5,  1e6,  1e7,  1e8,  1e9,  1e10, 1e11,
@@ -599,10 +750,11 @@ class ALPEncoding final
 
   void
   patchExceptions(uint32_t startRow, uint32_t rowCount, physicalType* output) {
-    const auto* exVals =
-        reinterpret_cast<const physicalType*>(exceptionValues_);
-    const auto* exBegin =
-        reinterpret_cast<const uint32_t*>(exceptionPositions_);
+    if (exceptionCount_ == 0) {
+      return;
+    }
+    const auto* exVals = exceptionValuesBuffer_.data();
+    const auto* exBegin = exceptionPositionsBuffer_.data();
     const auto* exEnd = exBegin + exceptionCount_;
     const auto* first = std::lower_bound(exBegin, exEnd, startRow);
     const auto* last = std::lower_bound(first, exEnd, startRow + rowCount);
@@ -613,10 +765,11 @@ class ALPEncoding final
   }
 
   const physicalType* findException(uint32_t row) const {
-    const auto* exVals =
-        reinterpret_cast<const physicalType*>(exceptionValues_);
-    const auto* exBegin =
-        reinterpret_cast<const uint32_t*>(exceptionPositions_);
+    if (exceptionCount_ == 0) {
+      return nullptr;
+    }
+    const auto* exVals = exceptionValuesBuffer_.data();
+    const auto* exBegin = exceptionPositionsBuffer_.data();
     const auto* exEnd = exBegin + exceptionCount_;
     const auto* it = std::lower_bound(exBegin, exEnd, row);
     if (it == exEnd || *it != row) {
@@ -629,9 +782,9 @@ class ALPEncoding final
   uint8_t factor_;
   uint32_t exceptionCount_;
   std::unique_ptr<Encoding> encodedValuesEncoding_;
-  const char* exceptionPositions_;
-  const char* exceptionValues_;
   std::vector<uint64_t> encodedBuffer_;
+  std::vector<uint32_t> exceptionPositionsBuffer_;
+  std::vector<physicalType> exceptionValuesBuffer_;
   uint32_t pos_;
 };
 

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -208,9 +208,14 @@ EncodingLayout EncodingLayoutCapture::capture(
       }
       const uint32_t encodedValuesBytes = varint::readVarint32(&pos);
 
-      children.reserve(1);
-      children.emplace_back(
-          EncodingLayoutCapture::capture({pos, encodedValuesBytes}, options));
+      children.reserve(header.hasExceptions ? 3 : 1);
+      captureChild(children, pos, encodedValuesBytes, options);
+      if (header.hasExceptions) {
+        const auto positionsBytes = varint::readVarint32(&pos);
+        captureChild(children, pos, positionsBytes, options);
+        const auto valuesBytes = varint::readVarint32(&pos);
+        captureChild(children, pos, valuesBytes, options);
+      }
       break;
     }
     case EncodingType::PFOR: {

--- a/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -60,6 +60,8 @@ struct EncodingIdentifiers {
 
   struct ALP {
     static constexpr NestedEncodingIdentifier EncodedValues = 0;
+    static constexpr NestedEncodingIdentifier ExceptionPositions = 1;
+    static constexpr NestedEncodingIdentifier ExceptionValues = 2;
   };
 
   struct FrequencyPartition {

--- a/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/ALPEncodingTest.cpp
@@ -21,11 +21,13 @@
 #include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/common/tests/NimbleCompare.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "dwio/nimble/tools/EncodingUtilities.h"
 #include "fmt/core.h"
 
+#include <array>
 #include <limits>
 #include <random>
 #include <string_view>
@@ -73,12 +75,30 @@ nimble::EncodingLayout fixedBitWidthLayout() {
       nimble::CompressionType::Uncompressed};
 }
 
+nimble::EncodingLayout trivialLayout() {
+  return nimble::EncodingLayout{
+      nimble::EncodingType::Trivial, {}, nimble::CompressionType::Uncompressed};
+}
+
+nimble::EncodingLayout varintLayout() {
+  return nimble::EncodingLayout{
+      nimble::EncodingType::Varint, {}, nimble::CompressionType::Uncompressed};
+}
+
 nimble::EncodingLayout alpWithFixedBitWidthPayloadLayout() {
   return nimble::EncodingLayout{
       nimble::EncodingType::ALP,
       {},
       nimble::CompressionType::Uncompressed,
-      {fixedBitWidthLayout()}};
+      {fixedBitWidthLayout(), varintLayout(), trivialLayout()}};
+}
+
+nimble::EncodingLayout alpWithFixedBitWidthExceptionStreamsLayout() {
+  return nimble::EncodingLayout{
+      nimble::EncodingType::ALP,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {fixedBitWidthLayout(), fixedBitWidthLayout(), fixedBitWidthLayout()}};
 }
 
 nimble::EncodingLayout dictionaryWithAlpAlphabetLayout() {
@@ -110,6 +130,62 @@ TEST(ALPSizeEstimationTest, invalidSampleRejected) {
       nimble::ALPEncoding<float>::estimateSizeFromSample(
           /*rowCount=*/1, sample),
       "ALP sample size cannot exceed the input row count.");
+}
+
+template <typename D>
+void expectEstimateUsesPackedExceptionValues() {
+  using PhysicalType = typename nimble::TypeTraits<D>::physicalType;
+  constexpr uint32_t kRowCount{256};
+  const nimble::Encoding::Options options{.fixedBitWidthUseExactBits = true};
+
+  const PhysicalType exceptionValue =
+      nimble::detail::alp::toPhysical<D>(std::numeric_limits<D>::infinity());
+  std::vector<PhysicalType> values(kRowCount, exceptionValue);
+
+  const auto estimate = nimble::ALPEncoding<D>::estimateSizeFromSample(
+      kRowCount,
+      std::span<const PhysicalType>{values.data(), values.size()},
+      options);
+  ASSERT_TRUE(estimate.has_value());
+
+  std::vector<uint64_t> encodedValues(kRowCount, 0);
+  const auto encodedStats = nimble::Statistics<uint64_t>::create(
+      std::span<const uint64_t>{encodedValues.data(), encodedValues.size()});
+  const auto encodedValuesSize = std::min(
+      nimble::FixedBitWidthEncoding<uint64_t>::estimateSize(
+          kRowCount, encodedStats, options),
+      nimble::TrivialEncoding<uint64_t>::estimateSize(kRowCount));
+
+  std::vector<uint32_t> exceptionPositions;
+  exceptionPositions.reserve(kRowCount);
+  for (uint32_t i = 0; i < kRowCount; ++i) {
+    exceptionPositions.push_back(i);
+  }
+  const auto positionStats = nimble::Statistics<uint32_t>::create(
+      std::span<const uint32_t>{
+          exceptionPositions.data(), exceptionPositions.size()});
+  const auto exceptionPositionsSize = std::min(
+      nimble::TrivialEncoding<uint32_t>::estimateSize(kRowCount),
+      nimble::FixedBitWidthEncoding<uint32_t>::estimateSize(
+          kRowCount, positionStats, options));
+
+  const auto trivialExceptionValuesSize =
+      nimble::TrivialEncoding<PhysicalType>::estimateSize(kRowCount);
+  const uint64_t trivialExceptionValuesBound =
+      nimble::EncodingPrefix::serializedSize(
+          kRowCount, options.useVarintRowCount) +
+      3 + nimble::varint::varintSize(kRowCount) +
+      nimble::varint::varintSize(encodedValuesSize) +
+      nimble::varint::varintSize(exceptionPositionsSize) +
+      nimble::varint::varintSize(trivialExceptionValuesSize) +
+      encodedValuesSize + exceptionPositionsSize + trivialExceptionValuesSize;
+
+  EXPECT_LT(estimate.value(), trivialExceptionValuesBound);
+}
+
+TEST(ALPSizeEstimationTest, packsExceptionValuesWhenEstimating) {
+  expectEstimateUsesPackedExceptionValues<float>();
+  expectEstimateUsesPackedExceptionValues<double>();
 }
 
 TEST(ALPEncodingHeaderTest, compactControlWordRoundTrip) {
@@ -328,9 +404,18 @@ TYPED_TEST(ALPEncodingTest, headerMetadataUsesVarints) {
       nimble::varint::varintSize(encodedValuesSize));
   pos += encodedValuesSize;
 
-  const auto* exceptionPositionStart = pos;
-  EXPECT_EQ(nimble::encoding::readUint32(pos), 150);
-  EXPECT_EQ(pos - exceptionPositionStart, sizeof(uint32_t));
+  const auto exceptionPositionsSize = nimble::varint::readVarint32(&pos);
+  const auto exceptionPositions = std::string_view{pos, exceptionPositionsSize};
+  EXPECT_EQ(
+      nimble::EncodingPrefix::encodingType(exceptionPositions),
+      nimble::EncodingType::Varint);
+  pos += exceptionPositionsSize;
+
+  const auto exceptionValuesSize = nimble::varint::readVarint32(&pos);
+  const auto exceptionValues = std::string_view{pos, exceptionValuesSize};
+  EXPECT_EQ(
+      nimble::EncodingPrefix::encodingType(exceptionValues),
+      nimble::EncodingType::Trivial);
 
   std::vector<velox::BufferPtr> stringBuffers;
   auto encoding =
@@ -341,6 +426,34 @@ TYPED_TEST(ALPEncodingTest, headerMetadataUsesVarints) {
     SCOPED_TRACE(i);
     EXPECT_TRUE(nimble::NimbleCompare<D>::equals(result[i], values[i]));
   }
+}
+
+TYPED_TEST(ALPEncodingTest, traverseEncodingsVisitsExceptionStreams) {
+  using D = typename TypeParam::data_type;
+  using PhysicalType = typename nimble::TypeTraits<D>::physicalType;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = false, .fixedBitWidthUseExactBits = true};
+
+  nimble::Vector<D> values{this->pool_.get(), 200};
+  values.fill(D{1.25});
+  values[150] = std::numeric_limits<D>::infinity();
+  const auto serialized = encodeWithLayout<D>(
+      *this->buffer_, values, alpWithFixedBitWidthPayloadLayout(), options);
+
+  expectEncodingLayout(
+      serialized,
+      {
+          {nimble::EncodingType::ALP, nimble::TypeTraits<D>::dataType, ""},
+          {nimble::EncodingType::FixedBitWidth,
+           nimble::DataType::Uint64,
+           "EncodedValues"},
+          {nimble::EncodingType::Varint,
+           nimble::DataType::Uint32,
+           "ExceptionPositions"},
+          {nimble::EncodingType::Trivial,
+           nimble::TypeTraits<PhysicalType>::dataType,
+           "ExceptionValues"},
+      });
 }
 
 TYPED_TEST(ALPEncodingTest, slice) {
@@ -446,9 +559,22 @@ TYPED_TEST(ALPEncodingTest, sliceRebasesExceptions) {
   EXPECT_EQ(nimble::varint::readVarint32(&pos), 2);
   const auto encodedValuesSize = nimble::varint::readVarint32(&pos);
   pos += encodedValuesSize;
+
+  const auto exceptionPositionsSize = nimble::varint::readVarint32(&pos);
+  std::vector<velox::BufferPtr> positionStringBuffers;
+  auto exceptionPositionsEncoding = createEncoding(
+      this->pool_.get(),
+      {pos, exceptionPositionsSize},
+      options,
+      positionStringBuffers);
+  nimble::Vector<uint32_t> exceptionPositions{this->pool_.get(), 2};
+  exceptionPositionsEncoding->materialize(2, exceptionPositions.data());
   // Source exceptions at rows 17 and 31 become slice-local rows 1 and 15.
-  EXPECT_EQ(nimble::encoding::readUint32(pos), 1);
-  EXPECT_EQ(nimble::encoding::readUint32(pos), 15);
+  const std::vector<uint32_t> expectedPositions{1, 15};
+  EXPECT_EQ(
+      std::vector<uint32_t>(
+          exceptionPositions.begin(), exceptionPositions.end()),
+      expectedPositions);
 
   std::vector<velox::BufferPtr> stringBuffers;
   auto encoding =
@@ -460,6 +586,56 @@ TYPED_TEST(ALPEncodingTest, sliceRebasesExceptions) {
     EXPECT_TRUE(
         nimble::NimbleCompare<DataType>::equals(
             result[i], values[kOffset + i]));
+  }
+}
+
+TYPED_TEST(ALPEncodingTest, slicePreservesExceptionStreamLayouts) {
+  using DataType = typename TypeParam::data_type;
+  using PhysicalType = typename nimble::TypeTraits<DataType>::physicalType;
+  const nimble::Encoding::Options options{
+      .useVarintRowCount = false, .fixedBitWidthUseExactBits = true};
+
+  nimble::Vector<DataType> values{this->pool_.get(), 128};
+  values.fill(DataType{1.25});
+  values[17] = -std::numeric_limits<DataType>::infinity();
+  values[31] = std::numeric_limits<DataType>::quiet_NaN();
+
+  const auto serialized = encodeWithLayout<DataType>(
+      *this->buffer_,
+      values,
+      alpWithFixedBitWidthExceptionStreamsLayout(),
+      options);
+
+  nimble::Buffer sliceBuffer{*this->pool_};
+  const auto sliced = nimble::EncodingFactory::slice(
+      serialized, /*offset=*/16, /*length=*/32, sliceBuffer, options);
+
+  expectEncodingLayout(
+      sliced,
+      {
+          {nimble::EncodingType::ALP,
+           nimble::TypeTraits<DataType>::dataType,
+           ""},
+          {nimble::EncodingType::FixedBitWidth,
+           nimble::DataType::Uint64,
+           "EncodedValues"},
+          {nimble::EncodingType::FixedBitWidth,
+           nimble::DataType::Uint32,
+           "ExceptionPositions"},
+          {nimble::EncodingType::FixedBitWidth,
+           nimble::TypeTraits<PhysicalType>::dataType,
+           "ExceptionValues"},
+      });
+
+  std::vector<velox::BufferPtr> stringBuffers;
+  auto encoding =
+      createEncoding(this->pool_.get(), sliced, options, stringBuffers);
+  nimble::Vector<DataType> result{this->pool_.get(), 32};
+  encoding->materialize(32, result.data());
+  for (uint32_t i = 0; i < result.size(); ++i) {
+    SCOPED_TRACE(fmt::format("i={}", i));
+    EXPECT_TRUE(
+        nimble::NimbleCompare<DataType>::equals(result[i], values[16 + i]));
   }
 }
 

--- a/dwio/nimble/encodings/views/ALPEncodingView.h
+++ b/dwio/nimble/encodings/views/ALPEncodingView.h
@@ -16,8 +16,10 @@
 #pragma once
 
 #include <algorithm>
+#include <optional>
 
 #include "dwio/nimble/encodings/ALPEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/views/EncodingViewFactory.h"
 #include "velox/common/encode/Coding.h"
@@ -51,15 +53,33 @@ class ALPEncodingView final : public TypedEncodingView<T> {
     NIMBLE_CHECK_NOT_NULL(encodedValues_);
     pos += encodedValuesSize;
 
-    exceptionPositions_ = reinterpret_cast<const uint32_t*>(pos);
-    pos += exceptionCount_ * sizeof(uint32_t);
-    exceptionValues_ = reinterpret_cast<const physicalType*>(pos);
+    if (exceptionCount_ == 0) {
+      return;
+    }
+
+    auto noStringBufferFactory = [](uint32_t) -> void* { return nullptr; };
+    const EncodingFactory encodingFactory{options};
+
+    const auto exceptionPositionsSize = varint::readVarint32(&pos);
+    auto exceptionPositionsEncoding = encodingFactory.create(
+        *this->pool_, {pos, exceptionPositionsSize}, noStringBufferFactory);
+    pos += exceptionPositionsSize;
+
+    const auto exceptionValuesSize = varint::readVarint32(&pos);
+    exceptionValues_ = detail::createTypedEncodingView<physicalType>(
+        {pos, exceptionValuesSize}, this->pool_, options);
+    NIMBLE_CHECK_NOT_NULL(exceptionValues_);
+
+    exceptionPositionsBuffer_.emplace(
+        exceptionCount_, this->pool_, options.bufferPool);
+    exceptionPositionsEncoding->materialize(
+        exceptionCount_, exceptionPositionsBuffer_->data());
   }
 
  private:
   T readTypedAt(uint32_t index) const final {
     NIMBLE_CHECK_LT(index, this->rowCount_);
-    if (const auto* exception = findException(index)) {
+    if (const auto exception = findException(index)) {
       return detail::castFromPhysicalType<T>(*exception);
     }
 
@@ -70,13 +90,25 @@ class ALPEncodingView final : public TypedEncodingView<T> {
   void readPhysical(uint32_t offset, uint32_t length, physicalType* output)
       const final {
     this->checkReadRange(offset, length);
+    if (exceptionCount_ == 0) {
+      for (uint32_t i = 0; i < length; ++i) {
+        output[i] = detail::alp::toPhysical<T>(decodeValue(
+            velox::ZigZag::decode(encodedValues_->readAt(offset + i))));
+      }
+      return;
+    }
+
+    const auto* exceptionPositionsBegin = exceptionPositionsBuffer_->data();
+    const auto* exceptionPositionsEnd =
+        exceptionPositionsBegin + exceptionCount_;
     const auto* exceptionPosition = std::lower_bound(
-        exceptionPositions_, exceptionPositions_ + exceptionCount_, offset);
+        exceptionPositionsBegin, exceptionPositionsEnd, offset);
     for (uint32_t i = 0; i < length; ++i) {
       const auto row = offset + i;
-      if (exceptionPosition != exceptionPositions_ + exceptionCount_ &&
+      if (exceptionPosition != exceptionPositionsEnd &&
           *exceptionPosition == row) {
-        output[i] = exceptionValues_[exceptionPosition - exceptionPositions_];
+        const auto exceptionIndex = exceptionPosition - exceptionPositionsBegin;
+        output[i] = exceptionValues_->readAt(exceptionIndex);
         ++exceptionPosition;
       } else {
         output[i] = detail::alp::toPhysical<T>(
@@ -85,14 +117,18 @@ class ALPEncodingView final : public TypedEncodingView<T> {
     }
   }
 
-  const physicalType* findException(uint32_t index) const {
-    const auto* begin = exceptionPositions_;
+  std::optional<physicalType> findException(uint32_t index) const {
+    if (exceptionCount_ == 0) {
+      return std::nullopt;
+    }
+
+    const auto* begin = exceptionPositionsBuffer_->data();
     const auto* end = begin + exceptionCount_;
     const auto* it = std::lower_bound(begin, end, index);
     if (it == end || *it != index) {
-      return nullptr;
+      return std::nullopt;
     }
-    return exceptionValues_ + (it - begin);
+    return exceptionValues_->readAt(it - begin);
   }
 
   T decodeValue(int64_t encoded) const {
@@ -105,8 +141,8 @@ class ALPEncodingView final : public TypedEncodingView<T> {
   uint8_t factor_{0};
   uint32_t exceptionCount_{0};
   std::unique_ptr<TypedEncodingView<uint64_t>> encodedValues_;
-  const uint32_t* exceptionPositions_{nullptr};
-  const physicalType* exceptionValues_{nullptr};
+  std::unique_ptr<TypedEncodingView<physicalType>> exceptionValues_;
+  std::optional<ScopedVector<uint32_t>> exceptionPositionsBuffer_;
 };
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -143,8 +143,9 @@ void traverseEncodings(
     case EncodingType::ALP: {
       const char* pos = stream.data() + dataOffset;
       const auto header = detail::alp::readHeader(pos);
+      uint32_t exceptionCount = 0;
       if (header.hasExceptions) {
-        varint::readVarint32(&pos); // exceptionCount
+        exceptionCount = varint::readVarint32(&pos);
       }
       const uint32_t encodedValuesSize = varint::readVarint32(&pos);
       traverseEncodings(
@@ -154,6 +155,26 @@ void traverseEncodings(
           "EncodedValues",
           useVarintRowCount,
           visitor);
+      pos += encodedValuesSize;
+      if (exceptionCount > 0) {
+        const uint32_t exceptionPositionsSize = varint::readVarint32(&pos);
+        traverseEncodings(
+            {pos, exceptionPositionsSize},
+            level + 1,
+            1,
+            "ExceptionPositions",
+            useVarintRowCount,
+            visitor);
+        pos += exceptionPositionsSize;
+        const uint32_t exceptionValuesSize = varint::readVarint32(&pos);
+        traverseEncodings(
+            {pos, exceptionValuesSize},
+            level + 1,
+            2,
+            "ExceptionValues",
+            useVarintRowCount,
+            visitor);
+      }
       break;
     }
     case EncodingType::BlockBitPacking: {


### PR DESCRIPTION
Summary:
Add nested ALP exception streams so exception positions and exception values are always serialized as normal Nimble child encodings when exceptions are present, with varint sizes in the ALP payload. Positions use Varint and values use Trivial over the physical float/double representation.

The encoded values stream remains the existing global ALP nested stream. This diff does not add block-local ALP parameter or value stream variants.

Differential Revision: D114963871


