### PR TITLE
feat: Add shared dictionary builder and encoding (#1076)

### DIFF
--- a/dwio/nimble/common/Types.cpp
+++ b/dwio/nimble/common/Types.cpp
@@ -46,6 +46,7 @@ constexpr auto kEncodingTypes =
         {EncodingType::Fsst, "Fsst"},
         {EncodingType::Huffman, "Huffman"},
         {EncodingType::DeltaBlock, "DeltaBlock"},
+        {EncodingType::SharedDictionary, "SharedDictionary"},
     });
 
 constexpr auto kCompressionTypes =

--- a/dwio/nimble/common/Types.h
+++ b/dwio/nimble/common/Types.h
@@ -156,6 +156,10 @@ enum class EncodingType {
   // EXPERIMENTAL: Not production-ready. Do not enable for production tables
   // without consulting the Nimble team (oncall: dwios).
   DeltaBlock = 21,
+  // Stores indices into an integer alphabet owned by a stripe, file, or
+  // external provider. The alphabet is resolved independently from the
+  // encoded index stream.
+  SharedDictionary = 22,
 };
 std::string toString(EncodingType encodingType);
 /// Returns the encoding type for 'name'. Throws if 'name' is unknown.

--- a/dwio/nimble/encodings/EncodingSliceFactory.cpp
+++ b/dwio/nimble/encodings/EncodingSliceFactory.cpp
@@ -33,6 +33,7 @@
 #include "dwio/nimble/encodings/NullableEncoding.h"
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -188,6 +189,20 @@ std::string_view sliceDictionary(
       DictionaryEncoding<T>::slice(encoded, offset, length, buffer, options));
 }
 
+std::string_view sliceSharedDictionary(
+    std::string_view encoded,
+    DataType dataType,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  NIMBLE_RETURN_BY_INTEGER_DATA_TYPE(
+      dataType,
+      T,
+      SharedDictionaryEncoding<T>::slice(
+          encoded, offset, length, buffer, options));
+}
+
 std::string_view sliceFixedBitWidth(
     std::string_view encoded,
     DataType dataType,
@@ -300,7 +315,8 @@ std::string_view EncodingSliceFactory::slice(
   NIMBLE_CHECK_LE(offset, rowCount);
   NIMBLE_CHECK_LE(length, rowCount - offset);
   NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
-  if (offset == 0 && length == rowCount) {
+  if (offset == 0 && length == rowCount &&
+      encodingType != EncodingType::SharedDictionary) {
     return encoded;
   }
 
@@ -314,6 +330,9 @@ std::string_view EncodingSliceFactory::slice(
       return sliceRLE(encoded, dataType, offset, length, buffer, options);
     case EncodingType::Dictionary:
       return sliceDictionary(
+          encoded, dataType, offset, length, buffer, options);
+    case EncodingType::SharedDictionary:
+      return sliceSharedDictionary(
           encoded, dataType, offset, length, buffer, options);
     case EncodingType::FixedBitWidth:
       return sliceFixedBitWidth(

--- a/dwio/nimble/encodings/SharedDictionaryBuilder.h
+++ b/dwio/nimble/encodings/SharedDictionaryBuilder.h
@@ -20,7 +20,6 @@
 #include <optional>
 #include <span>
 #include <string>
-#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -29,7 +28,9 @@
 #include "absl/container/flat_hash_map.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/SharedDictionaryTypes.h"
 
+#include "velox/common/Casts.h"
 #include "velox/common/memory/Memory.h"
 
 namespace facebook::nimble {
@@ -57,10 +58,10 @@ class SharedDictionaryBuilder {
   /// Identifies how a writer-side shared dictionary builder owns or resolves
   /// its alphabet.
   enum class Kind : uint8_t {
-    /// Builds an alphabet from input batches and commits accepted entries.
+    /// Builds an alphabet by inserting missing values during lookup.
     Streaming = 0,
-    /// Uses a prebuilt file-scope alphabet materialized by the writer.
-    PrebuiltFile = 1,
+    /// Uses a fixed alphabet supplied at construction time.
+    Fixed = 1,
     /// Uses an externally supplied value-to-index map without file alphabet
     /// data.
     External = 2,
@@ -68,22 +69,21 @@ class SharedDictionaryBuilder {
 
   virtual ~SharedDictionaryBuilder() = default;
 
-  /// Mapping produced by prepare() before alphabet changes are committed.
-  /// Writers use this to encode and estimate a candidate shared stream, then
-  /// either commit it when shared dictionary wins or drop the mapping when
-  /// direct encoding wins.
+  /// Mapping produced by lookup().
+  /// Streaming builders insert missing entries during lookup and report those
+  /// entries here so callers can estimate alphabet cost.
   class Mapping {
    public:
     explicit Mapping(velox::memory::MemoryPool* pool) : indices_{pool} {}
 
-    /// Returns one dictionary index for each input value passed to prepare().
+    /// Returns one dictionary index for each input value passed to lookup().
     std::span<const uint32_t> indices() const {
       return indices_;
     }
 
-    /// Returns the number of new alphabet entries staged by prepare().
-    uint32_t newEntryCount() const {
-      return static_cast<uint32_t>(newEntries_.size());
+    /// Returns distinct values inserted by lookup() for streaming builders.
+    std::span<const T> newEntries() const {
+      return newEntries_;
     }
 
    private:
@@ -93,106 +93,73 @@ class SharedDictionaryBuilder {
 
     // One dictionary index per input value.
     Vector<uint32_t> indices_;
-    // Distinct values the streaming builder appends on commit().
+    // Distinct values inserted into a streaming dictionary by lookup().
     std::vector<T> newEntries_;
   };
 
-  /// Maps values to dictionary indices and starts a pending mapping. New
-  /// entries are staged in the returned mapping so that their indices are
-  /// available for candidate encoding, but become durable only after commit().
-  /// Returns nullopt when a fixed alphabet cannot map one of the values.
-  std::optional<Mapping> prepare(std::span<const T> values) {
-    checkState(State::Ready, "prepare");
-    auto mapping = prepareImpl(values);
-    if (mapping.has_value()) {
-      state_ = State::Prepared;
-    }
-    return mapping;
-  }
-
   virtual Kind kind() const = 0;
-
-  /// Returns the builder kind as a stable debug string.
-  std::string kindString() const {
-    return kindString(kind());
-  }
 
   /// Returns a stable debug string for a builder kind.
   static std::string kindString(Kind kind) {
     switch (kind) {
       case Kind::Streaming:
         return "Streaming";
-      case Kind::PrebuiltFile:
-        return "PrebuiltFile";
+      case Kind::Fixed:
+        return "Fixed";
       case Kind::External:
         return "External";
     }
     return fmt::format("Unknown: {}", static_cast<int>(kind));
   }
 
-  /// Makes staged alphabet growth durable after shared encoding is selected.
-  void commit(const Mapping& mapping) {
-    checkState(State::Prepared, "commit");
-    commitImpl(mapping);
-    state_ = State::Ready;
+  /// Returns the lifetime and lookup namespace for this dictionary.
+  SharedDictionaryScope scope() const {
+    return scope_;
+  }
+
+  /// Returns the dictionary id within scope().
+  uint32_t dictionaryId() const {
+    return dictionaryId_;
+  }
+
+  /// Maps values to dictionary indices. Streaming builders insert missing
+  /// values immediately; fixed/external builders return nullopt when a value
+  /// is not present.
+  std::optional<Mapping> lookup(std::span<const T> values) {
+    return lookupImpl(values);
   }
 
   /// Clears stripe-owned alphabet state before values from the next stripe are
-  /// prepared, dropping any pending mapping. Fixed file/external builders do
-  /// not reset because their dictionaries are prebuilt.
+  /// looked up. Fixed file/external builders do not reset because their
+  /// dictionaries are prebuilt.
   void reset() {
-    checkState(State::Prepared, "reset");
     resetImpl();
-    state_ = State::Ready;
   }
 
   /// Returns the alphabet entries when the writer owns and serializes them.
   virtual std::span<const T> alphabet() const = 0;
 
  protected:
-  enum class State : uint8_t {
-    Ready = 0,
-    Prepared = 1,
-  };
-
-  explicit SharedDictionaryBuilder(velox::memory::MemoryPool* pool)
-      : pool_{pool} {
-    NIMBLE_CHECK_NOT_NULL(pool_, "Shared dictionary builder requires a pool.");
-  }
+  SharedDictionaryBuilder(
+      SharedDictionaryScope scope,
+      uint32_t dictionaryId,
+      velox::memory::MemoryPool* pool)
+      : scope_{scope},
+        dictionaryId_{dictionaryId},
+        pool_{velox::checkedNotNull(pool)} {}
 
   velox::memory::MemoryPool* pool() const {
     return pool_;
   }
 
-  virtual std::optional<Mapping> prepareImpl(
-      std::span<const T> values) const = 0;
-
-  virtual void commitImpl(const Mapping& mapping) = 0;
+  virtual std::optional<Mapping> lookupImpl(std::span<const T> values) = 0;
 
   virtual void resetImpl() = 0;
 
  private:
-  static std::string stateString(State state) {
-    switch (state) {
-      case State::Ready:
-        return "Ready";
-      case State::Prepared:
-        return "Prepared";
-    }
-    return fmt::format("Unknown: {}", static_cast<int>(state));
-  }
-
-  void checkState(State expected, std::string_view operation) const {
-    NIMBLE_CHECK(
-        state_ == expected,
-        "{} shared dictionary builder cannot {} while {}.",
-        kindString(),
-        operation,
-        stateString(state_));
-  }
-
+  const SharedDictionaryScope scope_;
+  const uint32_t dictionaryId_;
   velox::memory::MemoryPool* const pool_;
-  State state_{State::Ready};
 };
 
 /// Streaming dictionary builder for stripe/file-owned alphabets.
@@ -203,8 +170,16 @@ class StreamingSharedDictionaryBuilder final
   using Mapping = typename SharedDictionaryBuilder<T>::Mapping;
   using Kind = typename SharedDictionaryBuilder<T>::Kind;
 
-  explicit StreamingSharedDictionaryBuilder(velox::memory::MemoryPool* pool)
-      : SharedDictionaryBuilder<T>{pool} {}
+  StreamingSharedDictionaryBuilder(
+      SharedDictionaryScope scope,
+      uint32_t dictionaryId,
+      velox::memory::MemoryPool* pool)
+      : SharedDictionaryBuilder<T>{scope, dictionaryId, pool} {
+    NIMBLE_CHECK_NE(
+        scope,
+        SharedDictionaryScope::External,
+        "Streaming shared dictionary builder cannot use external scope.");
+  }
 
   Kind kind() const final {
     return Kind::Streaming;
@@ -215,12 +190,11 @@ class StreamingSharedDictionaryBuilder final
   }
 
  protected:
-  std::optional<Mapping> prepareImpl(std::span<const T> values) const final {
+  std::optional<Mapping> lookupImpl(std::span<const T> values) final {
     Mapping mapping{this->pool()};
     mapping.indices_.reserve(values.size());
     mapping.newEntries_.reserve(values.size());
 
-    DictionaryIndexType<T> pendingEntries;
     for (const auto& value : values) {
       const auto it = alphabetMapping_.find(value);
       if (it != alphabetMapping_.end()) {
@@ -228,37 +202,20 @@ class StreamingSharedDictionaryBuilder final
         continue;
       }
 
-      const auto pending = pendingEntries.find(value);
-      if (pending != pendingEntries.end()) {
-        mapping.indices_.push_back(pending->second);
-        continue;
-      }
-
-      const auto index = alphabet().size() + mapping.newEntries_.size();
+      const auto index = alphabet_.size();
       NIMBLE_USER_CHECK_LT(
           index,
           kMaxDictionaryEntryCount,
           "Shared dictionary size exceeds maximum.");
       const auto dictionaryIndex = static_cast<uint32_t>(index);
-      pendingEntries.emplace(value, dictionaryIndex);
+      const auto [_, inserted] =
+          alphabetMapping_.emplace(value, dictionaryIndex);
+      NIMBLE_CHECK(inserted, "Shared dictionary mapping insertion failed.");
+      alphabet_.push_back(value);
       mapping.newEntries_.push_back(value);
       mapping.indices_.push_back(dictionaryIndex);
     }
     return mapping;
-  }
-
-  void commitImpl(const Mapping& mapping) final {
-    alphabet_.reserve(alphabet_.size() + mapping.newEntries_.size());
-    for (const auto& value : mapping.newEntries_) {
-      NIMBLE_CHECK_LT(
-          alphabet_.size(),
-          kMaxDictionaryEntryCount,
-          "Shared dictionary size exceeds maximum.");
-      const auto index = static_cast<uint32_t>(alphabet_.size());
-      const auto [_, inserted] = alphabetMapping_.emplace(value, index);
-      NIMBLE_CHECK(inserted, "Shared dictionary mapping was committed twice.");
-      alphabet_.push_back(value);
-    }
   }
 
   void resetImpl() final {
@@ -271,9 +228,9 @@ class StreamingSharedDictionaryBuilder final
   DictionaryIndexType<T> alphabetMapping_;
 };
 
-/// Fixed dictionary builder backed by a prebuilt file-scope alphabet. The
-/// caller keeps the alphabet alive and unchanged for the builder's lifetime;
-/// the builder only stores a view so the prebuilt alphabet is not copied again.
+/// Fixed dictionary builder backed by a prebuilt alphabet. The caller keeps the
+/// alphabet alive and unchanged for the builder's lifetime; the builder only
+/// stores a view so the prebuilt alphabet is not copied again.
 template <typename T>
 class FixedSharedDictionaryBuilder final : public SharedDictionaryBuilder<T> {
  public:
@@ -281,14 +238,21 @@ class FixedSharedDictionaryBuilder final : public SharedDictionaryBuilder<T> {
   using Kind = typename SharedDictionaryBuilder<T>::Kind;
 
   FixedSharedDictionaryBuilder(
-      velox::memory::MemoryPool* pool,
-      std::span<const T> alphabet)
-      : SharedDictionaryBuilder<T>{pool}, alphabet_{alphabet} {
-    buildDictionaryMap();
+      std::span<const T> alphabet,
+      SharedDictionaryScope scope,
+      uint32_t dictionaryId,
+      velox::memory::MemoryPool* pool)
+      : SharedDictionaryBuilder<T>{scope, dictionaryId, pool},
+        alphabet_{alphabet},
+        dictionaryIndex_{buildDictionaryIndex(alphabet)} {
+    NIMBLE_CHECK_NE(
+        scope,
+        SharedDictionaryScope::External,
+        "Fixed shared dictionary builder cannot use external scope.");
   }
 
   Kind kind() const final {
-    return Kind::PrebuiltFile;
+    return Kind::Fixed;
   }
 
   std::span<const T> alphabet() const final {
@@ -296,13 +260,13 @@ class FixedSharedDictionaryBuilder final : public SharedDictionaryBuilder<T> {
   }
 
  protected:
-  std::optional<Mapping> prepareImpl(std::span<const T> values) const final {
+  std::optional<Mapping> lookupImpl(std::span<const T> values) final {
     Mapping mapping{this->pool()};
     mapping.indices_.reserve(values.size());
 
     for (const auto& value : values) {
-      const auto it = alphabetMapping_.find(value);
-      if (it == alphabetMapping_.end()) {
+      const auto it = dictionaryIndex_.find(value);
+      if (it == dictionaryIndex_.end()) {
         return std::nullopt;
       }
       mapping.indices_.push_back(it->second);
@@ -310,39 +274,30 @@ class FixedSharedDictionaryBuilder final : public SharedDictionaryBuilder<T> {
     return mapping;
   }
 
-  void commitImpl(const Mapping& mapping) final {
-    NIMBLE_CHECK_EQ(
-        mapping.newEntryCount(),
-        0,
-        "{} shared dictionary builder should not stage new entries.",
-        this->kindString());
-  }
-
   void resetImpl() final {
     NIMBLE_UNSUPPORTED(
-        "{} shared dictionary builder does not support reset().",
-        this->kindString());
+        "{} shared dictionary builder does not support reset().", this->kind());
   }
 
  private:
-  void buildDictionaryMap() {
-    NIMBLE_CHECK(
-        alphabetMapping_.empty(),
-        "Shared dictionary mapping should be empty before build.");
+  static DictionaryIndexType<T> buildDictionaryIndex(
+      std::span<const T> alphabet) {
     NIMBLE_USER_CHECK_LE(
-        alphabet_.size(),
+        alphabet.size(),
         kMaxDictionaryEntryCount,
-        "Prebuilt file shared dictionary size exceeds maximum.");
-    alphabetMapping_.reserve(alphabet_.size());
-    for (uint32_t i = 0; i < alphabet_.size(); ++i) {
-      const auto [_, inserted] = alphabetMapping_.emplace(alphabet_[i], i);
+        "Fixed shared dictionary size exceeds maximum.");
+    DictionaryIndexType<T> dictionaryIndex;
+    dictionaryIndex.reserve(alphabet.size());
+    for (uint32_t i = 0; i < alphabet.size(); ++i) {
+      const auto [_, inserted] = dictionaryIndex.emplace(alphabet[i], i);
       NIMBLE_USER_CHECK(
-          inserted, "Prebuilt file shared dictionary has duplicate values.");
+          inserted, "Fixed shared dictionary has duplicate values.");
     }
+    return dictionaryIndex;
   }
 
   const std::span<const T> alphabet_;
-  DictionaryIndexType<T> alphabetMapping_;
+  const DictionaryIndexType<T> dictionaryIndex_;
 };
 
 /// Lookup-only builder for externally owned dictionaries. It maps values to
@@ -357,8 +312,10 @@ class ExternalSharedDictionaryBuilder final
 
   ExternalSharedDictionaryBuilder(
       DictionaryIndexType<T> dictionaryIndex,
+      uint32_t dictionaryId,
       velox::memory::MemoryPool* pool)
-      : SharedDictionaryBuilder<T>{pool},
+      : SharedDictionaryBuilder<
+            T>{SharedDictionaryScope::External, dictionaryId, pool},
         dictionaryIndex_{std::move(dictionaryIndex)} {}
 
   Kind kind() const final {
@@ -368,11 +325,11 @@ class ExternalSharedDictionaryBuilder final
   std::span<const T> alphabet() const final {
     NIMBLE_UNSUPPORTED(
         "{} shared dictionary builder does not expose an alphabet.",
-        this->kindString());
+        this->kind());
   }
 
  protected:
-  std::optional<Mapping> prepareImpl(std::span<const T> values) const final {
+  std::optional<Mapping> lookupImpl(std::span<const T> values) final {
     Mapping mapping{this->pool()};
     mapping.indices_.reserve(values.size());
 
@@ -386,18 +343,9 @@ class ExternalSharedDictionaryBuilder final
     return mapping;
   }
 
-  void commitImpl(const Mapping& mapping) final {
-    NIMBLE_CHECK_EQ(
-        mapping.newEntryCount(),
-        0,
-        "{} shared dictionary builder should not stage new entries.",
-        this->kindString());
-  }
-
   void resetImpl() final {
     NIMBLE_UNSUPPORTED(
-        "{} shared dictionary builder does not support reset().",
-        this->kindString());
+        "{} shared dictionary builder does not support reset().", this->kind());
   }
 
  private:

--- a/dwio/nimble/encodings/SharedDictionaryEncoding.h
+++ b/dwio/nimble/encodings/SharedDictionaryEncoding.h
@@ -1,0 +1,567 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/SharedDictionaryTypes.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/selection/EncodingSelection.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "velox/buffer/Buffer.h"
+
+namespace facebook::nimble {
+
+namespace detail {
+
+template <typename T>
+class SharedDictionarySliceSelectionPolicy final
+    : public EncodingSelectionPolicy<T> {
+ public:
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  SharedDictionarySliceSelectionPolicy(
+      EncodingType encodingType,
+      std::optional<EncodingType> alphabetEncodingType,
+      std::optional<EncodingType> indicesEncodingType)
+      : encodingType_{encodingType},
+        alphabetEncodingType_{alphabetEncodingType},
+        indicesEncodingType_{indicesEncodingType} {}
+
+  EncodingSelectionResult select(
+      std::span<const physicalType> /* values */,
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */) final {
+    return {.encodingType = encodingType_};
+  }
+
+  EncodingSelectionResult selectNullable(
+      std::span<const physicalType> /* values */,
+      std::span<const bool> /* nulls */,
+      const Statistics<physicalType>& /* statistics */,
+      const Encoding::Options& /* options */) final {
+    NIMBLE_UNREACHABLE(
+        "Shared dictionary slice selection does not support nullable values.");
+  }
+
+ private:
+  std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier,
+      DataType nestedDataType) final {
+    if (parentEncodingType == EncodingType::Dictionary &&
+        nestedEncodingIdentifier == EncodingIdentifiers::Dictionary::Alphabet &&
+        alphabetEncodingType_.has_value()) {
+      UNIQUE_PTR_FACTORY(
+          nestedDataType,
+          SharedDictionarySliceSelectionPolicy,
+          *alphabetEncodingType_,
+          std::nullopt,
+          std::nullopt);
+    }
+    if (parentEncodingType == EncodingType::Dictionary &&
+        nestedEncodingIdentifier == EncodingIdentifiers::Dictionary::Indices &&
+        indicesEncodingType_.has_value()) {
+      UNIQUE_PTR_FACTORY(
+          nestedDataType,
+          SharedDictionarySliceSelectionPolicy,
+          *indicesEncodingType_,
+          std::nullopt,
+          std::nullopt);
+    }
+
+    auto nestedEncodingReadFactors =
+        ManualEncodingSelectionPolicyFactory::defaultEncodingReadFactors();
+    nestedEncodingReadFactors.erase(
+        std::remove_if(
+            nestedEncodingReadFactors.begin(),
+            nestedEncodingReadFactors.end(),
+            [parentEncodingType](const auto& entry) {
+              return entry.first == parentEncodingType;
+            }),
+        nestedEncodingReadFactors.end());
+    UNIQUE_PTR_FACTORY(
+        nestedDataType,
+        ManualEncodingSelectionPolicy,
+        std::move(nestedEncodingReadFactors),
+        std::nullopt,
+        nestedEncodingIdentifier);
+  }
+
+  const EncodingType encodingType_;
+  const std::optional<EncodingType> alphabetEncodingType_;
+  const std::optional<EncodingType> indicesEncodingType_;
+};
+
+inline void materializeLocalDictionaryIndices(
+    std::span<const uint32_t> sortedUniqueSharedIndices,
+    std::span<const uint32_t> slicedSharedIndices,
+    std::span<uint32_t> localIndices) {
+  NIMBLE_DCHECK_GT(sortedUniqueSharedIndices.size(), 1);
+  NIMBLE_DCHECK_EQ(localIndices.size(), slicedSharedIndices.size());
+
+  for (size_t i{0}; i < slicedSharedIndices.size(); ++i) {
+    const auto it = std::lower_bound(
+        sortedUniqueSharedIndices.begin(),
+        sortedUniqueSharedIndices.end(),
+        slicedSharedIndices[i]);
+    NIMBLE_DCHECK(
+        it != sortedUniqueSharedIndices.end() && *it == slicedSharedIndices[i],
+        "Shared dictionary slice index missing from local dictionary.");
+    localIndices[i] = static_cast<uint32_t>(
+        std::distance(sortedUniqueSharedIndices.begin(), it));
+  }
+}
+
+} // namespace detail
+
+/// The layout for a shared dictionary encoding is:
+/// Encoding prefix, one-byte scope, varint dictionary ID, encoded indices.
+template <typename T>
+class SharedDictionaryEncoding
+    : public TypedEncoding<T, typename TypeTraits<T>::physicalType> {
+ public:
+  using physicalType = typename TypeTraits<T>::physicalType;
+
+  SharedDictionaryEncoding(
+      velox::memory::MemoryPool& pool,
+      std::string_view data,
+      std::function<void*(uint32_t)> stringBufferFactory,
+      const Encoding::Options& options = {});
+
+  ~SharedDictionaryEncoding() override {
+    this->releaseBuffer(indicesBuffer_);
+  }
+
+  SharedDictionaryEncoding(const SharedDictionaryEncoding&) = delete;
+  SharedDictionaryEncoding& operator=(const SharedDictionaryEncoding&) = delete;
+  SharedDictionaryEncoding(SharedDictionaryEncoding&&) = delete;
+  SharedDictionaryEncoding& operator=(SharedDictionaryEncoding&&) = delete;
+
+  void reset() final {
+    indicesEncoding_->reset();
+  }
+
+  void skip(uint32_t rowCount) final {
+    indicesEncoding_->skip(rowCount);
+  }
+
+  void materialize(uint32_t rowCount, void* buffer) final;
+
+  template <typename V>
+  void readWithVisitor(V& visitor, ReadWithVisitorParams& params);
+
+  void materializeIndices(uint32_t rowCount, uint32_t* buffer) override {
+    indicesEncoding_->materialize(rowCount, buffer);
+  }
+
+  bool dictionaryEnabled() const override {
+    // TODO: Enable dictionary preservation after SharedDictionary implements
+    // readIndicesWithVisitor().
+    return false;
+  }
+
+  uint32_t dictionarySize() const override {
+    return alphabet_->entryCount();
+  }
+
+  SharedDictionaryScope scope() const {
+    return scope_;
+  }
+
+  uint32_t dictionaryId() const {
+    return dictionaryId_;
+  }
+
+  static std::string_view encode(
+      EncodingSelection<physicalType>& selection,
+      std::span<const physicalType> values,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  static std::string_view slice(
+      std::string_view encoded,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  std::string debugString(int offset) const final;
+
+ private:
+  static constexpr uint32_t kScopeSize = sizeof(uint8_t);
+
+  static std::string_view encodeIndices(
+      EncodingSelection<physicalType>& selection,
+      std::span<const uint32_t> indices,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  static std::string_view encodeMaterializedDictionarySlice(
+      const SharedDictionaryAlphabet& alphabet,
+      std::string_view encodedIndices,
+      uint32_t offset,
+      uint32_t length,
+      Buffer& buffer,
+      const Encoding::Options& options = {});
+
+  uint32_t* ensureIndexBuffer(uint32_t numElements) {
+    const auto bytes = numElements * sizeof(uint32_t);
+    if (indicesBuffer_ == nullptr || indicesBuffer_->capacity() < bytes) {
+      if (indicesBuffer_ != nullptr) {
+        this->releaseBuffer(indicesBuffer_);
+      }
+      indicesBuffer_ = this->getBuffer(bytes);
+    }
+    return indicesBuffer_->asMutable<uint32_t>();
+  }
+
+  SharedDictionaryScope scope_;
+  uint32_t dictionaryId_;
+  std::shared_ptr<const SharedDictionaryAlphabet> alphabet_;
+  std::unique_ptr<Encoding> indicesEncoding_;
+  velox::BufferPtr indicesBuffer_;
+};
+
+template <typename T>
+SharedDictionaryEncoding<T>::SharedDictionaryEncoding(
+    velox::memory::MemoryPool& pool,
+    std::string_view data,
+    std::function<void*(uint32_t)> stringBufferFactory,
+    const Encoding::Options& options)
+    : TypedEncoding<T, physicalType>{pool, data, options} {
+  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  NIMBLE_CHECK_NOT_NULL(options.sharedDictionaryResolver);
+
+  const char* pos = data.data() + this->dataOffset();
+  scope_ = readSharedDictionaryScope(data, pos);
+  dictionaryId_ = readSharedDictionaryId(data, pos);
+  const auto indicesOffset = static_cast<size_t>(pos - data.data());
+  NIMBLE_CHECK_LT(
+      indicesOffset,
+      data.size(),
+      "Shared dictionary encoding is missing its indices.");
+  alphabet_ = options.sharedDictionaryResolver->resolve(
+      scope_, dictionaryId_, TypeTraits<T>::dataType);
+  NIMBLE_CHECK_NOT_NULL(alphabet_);
+  NIMBLE_CHECK_EQ(
+      alphabet_->dataType(),
+      TypeTraits<T>::dataType,
+      "Shared dictionary {} has unexpected type.",
+      dictionaryId_);
+
+  indicesEncoding_ = EncodingFactory().create(
+      *this->pool_,
+      {pos, data.size() - indicesOffset},
+      std::move(stringBufferFactory),
+      options);
+  NIMBLE_CHECK_EQ(
+      indicesEncoding_->dataType(),
+      DataType::Uint32,
+      "Shared dictionary indices have unexpected type.");
+  NIMBLE_CHECK_EQ(
+      indicesEncoding_->rowCount(),
+      this->rowCount(),
+      "Shared dictionary index count differs from row count.");
+}
+
+template <typename T>
+void SharedDictionaryEncoding<T>::materialize(uint32_t rowCount, void* buffer) {
+  auto* indices = ensureIndexBuffer(rowCount);
+  indicesEncoding_->materialize(rowCount, indices);
+  alphabet_->template materialize<T>(
+      std::span<const uint32_t>{indices, rowCount},
+      static_cast<physicalType*>(buffer));
+}
+
+template <typename T>
+template <typename V>
+void SharedDictionaryEncoding<T>::readWithVisitor(
+    V& visitor,
+    ReadWithVisitorParams& params) {
+  if constexpr (sizeof(T) < sizeof(uint32_t)) {
+    // Nested index decoders may use the reader values buffer before the hook
+    // copies indices out, so it must fit uint32_t indices rather than T values.
+    visitor.reader().template ensureValuesCapacity<uint32_t>(
+        visitor.numRows(), /*preserveValues=*/true);
+  }
+  const auto startRowIndex = visitor.rowIndex();
+  const auto numIndices = visitor.numRows() - startRowIndex;
+  auto* indices = ensureIndexBuffer(numIndices);
+  velox::common::AlwaysTrue indicesFilter;
+  detail::DictionaryIndicesHook indicesHook(indices, startRowIndex);
+  auto indicesVisitor = DecoderVisitor<
+      int32_t,
+      velox::common::AlwaysTrue,
+      velox::dwio::common::ExtractToHook<detail::DictionaryIndicesHook>,
+      V::dense>(
+      indicesFilter,
+      &visitor.reader(),
+      velox::RowSet(visitor.rows(), visitor.numRows()),
+      velox::dwio::common::ExtractToHook<detail::DictionaryIndicesHook>(
+          &indicesHook));
+  indicesVisitor.setRowIndex(startRowIndex);
+  callReadWithVisitor(*indicesEncoding_, indicesVisitor, params);
+  detail::readWithVisitorSlow(visitor, params, nullptr, [&] {
+    return alphabet_->template physicalValueAt<T>(
+        indices[visitor.rowIndex() - startRowIndex]);
+  });
+}
+
+template <typename T>
+std::string_view SharedDictionaryEncoding<T>::encode(
+    EncodingSelection<physicalType>& selection,
+    std::span<const physicalType> values,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  const auto sharedDictionaryInput = selection.sharedDictionaryInput();
+  NIMBLE_CHECK(
+      sharedDictionaryInput.has_value(),
+      "Shared dictionary encoding requires input from selection.");
+  NIMBLE_CHECK_EQ(
+      sharedDictionaryInput->indices.size(),
+      values.size(),
+      "Shared dictionary index count differs from value count.");
+  NIMBLE_CHECK_NE(
+      sharedDictionaryInput->dictionaryId,
+      kInvalidSharedDictionaryId,
+      "Shared dictionary encoding requires a valid dictionary id.");
+
+  ScopedEncodingBuffer scopedBuffer{
+      &buffer.getMemoryPool(), options.encodingBufferPool};
+  const auto encodedIndices = encodeIndices(
+      selection, sharedDictionaryInput->indices, scopedBuffer.get(), options);
+
+  const auto rowCount =
+      static_cast<uint32_t>(sharedDictionaryInput->indices.size());
+  const auto dictionaryId = sharedDictionaryInput->dictionaryId;
+  const uint64_t encodingSize =
+      static_cast<uint64_t>(
+          Encoding::serializePrefixSize(rowCount, options.useVarintRowCount)) +
+      kScopeSize + varint::varintSize(dictionaryId) + encodedIndices.size();
+  char* reserved = buffer.reserve(encodingSize);
+  char* pos = reserved;
+  Encoding::serializePrefix(
+      EncodingType::SharedDictionary,
+      TypeTraits<T>::dataType,
+      rowCount,
+      options.useVarintRowCount,
+      pos);
+  encoding::write<uint8_t>(
+      static_cast<uint8_t>(sharedDictionaryInput->scope), pos);
+  varint::writeVarint(dictionaryId, &pos);
+  encoding::writeBytes(encodedIndices, pos);
+  NIMBLE_DCHECK_EQ(
+      static_cast<uint64_t>(pos - reserved),
+      encodingSize,
+      "Encoding size mismatch.");
+
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string_view SharedDictionaryEncoding<T>::encodeIndices(
+    EncodingSelection<physicalType>& selection,
+    std::span<const uint32_t> indices,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  NIMBLE_CHECK_LE(
+      indices.size(),
+      kMaxSharedDictionarySize,
+      "Shared dictionary index count exceeds maximum.");
+  return selection.template encodeNested<uint32_t>(
+      EncodingIdentifiers::SharedDictionary::Indices, indices, buffer, options);
+}
+
+template <typename T>
+std::string_view SharedDictionaryEncoding<T>::slice(
+    std::string_view encoded,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  static_assert(isIntegralType<T>() && !std::is_same_v<T, bool>);
+  const auto sourceRowCount =
+      EncodingPrefix::readRowCount(encoded, options.useVarintRowCount);
+  NIMBLE_CHECK_LE(offset, sourceRowCount);
+  NIMBLE_CHECK_LE(length, sourceRowCount - offset);
+  NIMBLE_CHECK_GT(length, 0, "Cannot slice zero rows.");
+
+  NIMBLE_CHECK_NOT_NULL(options.sharedDictionaryResolver);
+  const char* pos = encoded.data() +
+      EncodingPrefix::prefixSize(encoded, options.useVarintRowCount);
+  const auto scope = readSharedDictionaryScope(encoded, pos);
+  const auto dictionaryId = readSharedDictionaryId(encoded, pos);
+  const auto indicesOffset = static_cast<size_t>(pos - encoded.data());
+  NIMBLE_CHECK_LT(
+      indicesOffset,
+      encoded.size(),
+      "Shared dictionary encoding is missing its indices.");
+  const std::string_view encodedIndices{pos, encoded.size() - indicesOffset};
+
+  const auto alphabet = options.sharedDictionaryResolver->resolve(
+      scope, dictionaryId, TypeTraits<T>::dataType);
+  NIMBLE_CHECK_NOT_NULL(alphabet);
+  NIMBLE_CHECK_EQ(
+      alphabet->dataType(),
+      TypeTraits<T>::dataType,
+      "Shared dictionary {} has unexpected type.",
+      dictionaryId);
+
+  return encodeMaterializedDictionarySlice(
+      *alphabet, encodedIndices, offset, length, buffer, options);
+}
+
+template <typename T>
+std::string_view SharedDictionaryEncoding<T>::encodeMaterializedDictionarySlice(
+    const SharedDictionaryAlphabet& alphabet,
+    std::string_view encodedIndices,
+    uint32_t offset,
+    uint32_t length,
+    Buffer& buffer,
+    const Encoding::Options& options) {
+  auto* pool = &buffer.getMemoryPool();
+  ScopedEncodingBuffer scopedBuffer{pool, options.encodingBufferPool};
+  ScopedVector<uint32_t> slicedIndices{length, pool, options.bufferPool};
+  auto indicesEncoding = EncodingFactory{options}.create(
+      *pool, encodedIndices, [&scopedBuffer](uint32_t size) -> void* {
+        return scopedBuffer.get().reserve(size);
+      });
+  indicesEncoding->skip(offset);
+  indicesEncoding->materialize(length, slicedIndices.data());
+
+  ScopedVector<uint32_t> uniqueIndices{length, pool, options.bufferPool};
+  std::copy(slicedIndices.begin(), slicedIndices.end(), uniqueIndices.begin());
+  std::sort(uniqueIndices.begin(), uniqueIndices.end());
+  uniqueIndices.resize(
+      static_cast<uint64_t>(
+          std::unique(uniqueIndices.begin(), uniqueIndices.end()) -
+          uniqueIndices.begin()));
+
+  ScopedVector<physicalType> values{
+      uniqueIndices.size(), pool, options.bufferPool};
+  alphabet.template materialize<T>(
+      std::span<const uint32_t>{uniqueIndices.data(), uniqueIndices.size()},
+      values.data());
+
+  if (uniqueIndices.size() == 1) {
+    const uint64_t encodingSize =
+        EncodingPrefix::serializedSize(length, options.useVarintRowCount) +
+        sizeof(physicalType);
+    char* reserved = buffer.reserve(encodingSize);
+    char* writePos = reserved;
+    EncodingPrefix::serialize(
+        EncodingType::Constant,
+        TypeTraits<T>::dataType,
+        length,
+        options.useVarintRowCount,
+        writePos);
+    encoding::write<physicalType>(values[0], writePos);
+    NIMBLE_DCHECK_EQ(
+        static_cast<uint64_t>(writePos - reserved),
+        encodingSize,
+        "Encoding size mismatch.");
+    return {reserved, encodingSize};
+  }
+
+  ScopedVector<uint32_t> localIndices{length, pool, options.bufferPool};
+  detail::materializeLocalDictionaryIndices(
+      uniqueIndices, slicedIndices, localIndices);
+
+  // TODO: When the slice references most of the shared alphabet, consider
+  // preserving the shared dictionary form by slicing the shared alphabet or
+  // carrying the full shared alphabet instead of rebuilding a local dictionary.
+  auto policy =
+      std::make_unique<detail::SharedDictionarySliceSelectionPolicy<T>>(
+          EncodingType::Dictionary,
+          alphabet.encodingType(),
+          EncodingPrefix::encodingType(encodedIndices));
+  EncodingSelection<physicalType> selection{
+      {.encodingType = EncodingType::Dictionary},
+      Statistics<physicalType>::create(
+          std::span<const physicalType>{values.data(), values.size()}),
+      std::move(policy)};
+  const auto serializedAlphabet = selection.template encodeNested<physicalType>(
+      EncodingIdentifiers::Dictionary::Alphabet,
+      std::span<const physicalType>{values.data(), values.size()},
+      scopedBuffer.get(),
+      options);
+  const auto serializedIndices = selection.template encodeNested<uint32_t>(
+      EncodingIdentifiers::Dictionary::Indices,
+      std::span<const uint32_t>{localIndices.data(), localIndices.size()},
+      scopedBuffer.get(),
+      options);
+
+  NIMBLE_CHECK_LE(
+      serializedAlphabet.size(),
+      std::numeric_limits<uint32_t>::max(),
+      "Shared dictionary slice alphabet encoding exceeds maximum size.");
+  const uint64_t encodingSize =
+      EncodingPrefix::serializedSize(length, options.useVarintRowCount) +
+      sizeof(uint32_t) + serializedAlphabet.size() + serializedIndices.size();
+  char* reserved = buffer.reserve(encodingSize);
+  char* writePos = reserved;
+  EncodingPrefix::serialize(
+      EncodingType::Dictionary,
+      TypeTraits<T>::dataType,
+      length,
+      options.useVarintRowCount,
+      writePos);
+  encoding::writeUint32(
+      static_cast<uint32_t>(serializedAlphabet.size()), writePos);
+  encoding::writeBytes(serializedAlphabet, writePos);
+  encoding::writeBytes(serializedIndices, writePos);
+  NIMBLE_DCHECK_EQ(
+      static_cast<uint64_t>(writePos - reserved),
+      encodingSize,
+      "Encoding size mismatch.");
+  return {reserved, encodingSize};
+}
+
+template <typename T>
+std::string SharedDictionaryEncoding<T>::debugString(int offset) const {
+  return fmt::format(
+      "{}\n{}scope={} dictionaryId={} entries={}\n{}indices child:\n{}",
+      Encoding::debugString(offset),
+      std::string(offset + 2, ' '),
+      scope_,
+      dictionaryId_,
+      dictionarySize(),
+      std::string(offset, ' '),
+      indicesEncoding_->debugString(offset + 2));
+}
+
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/SharedDictionaryTypes.cpp
+++ b/dwio/nimble/encodings/SharedDictionaryTypes.cpp
@@ -16,6 +16,9 @@
 
 #include "dwio/nimble/encodings/SharedDictionaryTypes.h"
 
+#include <algorithm>
+
+#include "dwio/nimble/common/Varint.h"
 #include "velox/common/EnumDefine.h"
 
 namespace facebook::nimble {
@@ -30,30 +33,49 @@ const auto& sharedDictionaryScopeNames() {
       };
   return kNames;
 }
+
+size_t checkedSharedDictionaryOffset(std::string_view data, const char* pos) {
+  NIMBLE_CHECK(
+      pos >= data.data() && pos <= data.data() + data.size(),
+      "Shared dictionary cursor is outside the encoding.");
+  return static_cast<size_t>(pos - data.data());
+}
 } // namespace
 
 VELOX_DEFINE_ENUM_NAME(SharedDictionaryScope, sharedDictionaryScopeNames)
 
+SharedDictionaryScope readSharedDictionaryScope(
+    std::string_view data,
+    const char*& pos) {
+  const auto offset = checkedSharedDictionaryOffset(data, pos);
+  NIMBLE_CHECK_LT(
+      offset, data.size(), "Shared dictionary encoding is missing its scope.");
+  return toSharedDictionaryScope(static_cast<uint8_t>(*pos++));
+}
+
+uint32_t readSharedDictionaryId(std::string_view data, const char*& pos) {
+  const auto offset = checkedSharedDictionaryOffset(data, pos);
+  NIMBLE_CHECK_LT(
+      offset, data.size(), "Truncated shared dictionary ID varint.");
+
+  const auto remaining = data.size() - offset;
+  const auto bytesToCheck = std::min<size_t>(
+      remaining, varint::maxVarintSizeForBitWidth(/*bitWidth=*/32));
+  for (size_t i = 0; i < bytesToCheck; ++i) {
+    if ((static_cast<uint8_t>(pos[i]) & 0x80) == 0) {
+      return varint::readVarint32(&pos);
+    }
+  }
+
+  NIMBLE_CHECK_GE(
+      remaining,
+      varint::maxVarintSizeForBitWidth(/*bitWidth=*/32),
+      "Truncated shared dictionary ID varint.");
+  NIMBLE_UNSUPPORTED("Shared dictionary ID varint is too long.");
+}
+
 SharedDictionaryAlphabet::SharedDictionaryAlphabet(DataType dataType)
     : dataType_{dataType} {}
-
-SharedDictionaryAlphabet::DecodedChunk SharedDictionaryAlphabet::decodedChunk(
-    uint32_t begin,
-    uint32_t count,
-    const void* entries,
-    std::shared_ptr<const void> owner) {
-  return DecodedChunk{
-      .begin = begin,
-      .count = count,
-      .entries = entries,
-      .owner = std::move(owner)};
-}
-
-SharedDictionaryAlphabet::EncodedChunk SharedDictionaryAlphabet::encodedChunk(
-    uint32_t begin,
-    std::shared_ptr<const EncodingView> view) {
-  return EncodedChunk{.begin = begin, .view = std::move(view)};
-}
 
 DataType SharedDictionaryAlphabet::dataType() const {
   return dataType_;
@@ -63,67 +85,12 @@ uint32_t SharedDictionaryAlphabet::entryCount() const {
   return entryCount_;
 }
 
-uint32_t SharedDictionaryAlphabet::validateDecodedChunks(
-    const std::vector<DecodedChunk>& chunks) {
-  uint32_t nextBegin{0};
-  for (const auto& chunk : chunks) {
-    NIMBLE_CHECK_EQ(
-        chunk.begin,
-        nextBegin,
-        "Shared dictionary alphabet chunks must be contiguous.");
-    NIMBLE_CHECK_NOT_NULL(chunk.entries);
-    NIMBLE_CHECK_NOT_NULL(chunk.owner);
-    NIMBLE_CHECK_LE(
-        chunk.count,
-        kMaxSharedDictionaryEntryCount - nextBegin,
-        "Shared dictionary alphabet chunk count overflows.");
-    nextBegin += chunk.count;
-  }
-  return nextBegin;
-}
-
-uint32_t SharedDictionaryAlphabet::validateEncodedChunks(
-    DataType dataType,
-    const std::vector<EncodedChunk>& chunks) {
-  uint32_t nextBegin{0};
-  for (const auto& chunk : chunks) {
-    NIMBLE_CHECK_EQ(
-        chunk.begin,
-        nextBegin,
-        "Shared dictionary alphabet chunks must be contiguous.");
-    NIMBLE_CHECK_NOT_NULL(chunk.view);
-    NIMBLE_CHECK_EQ(
-        chunk.view->dataType(),
-        dataType,
-        "Shared dictionary encoded chunk has unexpected type.");
-    const auto rowCount = chunk.view->rowCount();
-    NIMBLE_CHECK_LE(
-        rowCount,
-        kMaxSharedDictionaryEntryCount - nextBegin,
-        "Shared dictionary alphabet chunk count overflows.");
-    nextBegin += rowCount;
-  }
-  return nextBegin;
+std::optional<EncodingType> SharedDictionaryAlphabet::encodingType() const {
+  return encodingTypeImpl();
 }
 
 void SharedDictionaryAlphabet::setEntryCount(uint32_t entryCount) {
   entryCount_ = entryCount;
-}
-
-std::shared_ptr<const SharedDictionaryAlphabet>
-SharedDictionaryAlphabet::createDecoded(
-    DataType dataType,
-    std::vector<DecodedChunk> chunks) {
-  return std::make_shared<DecodedSharedDictionaryAlphabet>(
-      dataType, std::move(chunks));
-}
-
-std::shared_ptr<const SharedDictionaryAlphabet>
-SharedDictionaryAlphabet::createEncoded(
-    DataType dataType,
-    std::vector<EncodedChunk> chunks) {
-  return std::make_shared<EncodedSharedDictionaryAlphabet>(
-      dataType, std::move(chunks));
 }
 
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/SharedDictionaryTypes.h
+++ b/dwio/nimble/encodings/SharedDictionaryTypes.h
@@ -15,8 +15,7 @@
  */
 #pragma once
 
-#include <algorithm>
-#include <iterator>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <optional>
@@ -24,24 +23,20 @@
 #include <string>
 #include <string_view>
 #include <type_traits>
-#include <utility>
-#include <vector>
 
 #include <fmt/core.h>
 
-#include "dwio/nimble/common/DataTypeDispatch.h"
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/encodings/common/EncodingType.h"
-#include "dwio/nimble/encodings/views/EncodingViewFactory.h"
 #include "velox/common/EnumDeclare.h"
 
 namespace facebook::nimble {
 
-/// Identifies where an alphabet is stored or resolved, and the namespace used
-/// by SharedDictionaryConfig::dictionaryId. The scope controls both dictionary
-/// lifetime and whether the reader loads an in-stripe auxiliary stream, the
-/// file catalog, or an external catalog.
+/// Identifies where an alphabet is stored or resolved, and the dictionary id
+/// namespace to use. The scope controls both dictionary lifetime and whether
+/// the reader loads an in-stripe auxiliary stream, the file catalog, or an
+/// external catalog.
 enum class SharedDictionaryScope : uint8_t {
   /// Alphabet is stored as an auxiliary stream in the current stripe, and its
   /// dictionary id is local to that stripe.
@@ -57,11 +52,6 @@ enum class SharedDictionaryScope : uint8_t {
 
 VELOX_DECLARE_ENUM_NAME(SharedDictionaryScope);
 
-inline std::string_view sharedDictionaryScopeString(
-    SharedDictionaryScope scope) {
-  return SharedDictionaryScopeName::toName(scope);
-}
-
 inline SharedDictionaryScope toSharedDictionaryScope(uint8_t value) {
   const auto scope = static_cast<SharedDictionaryScope>(value);
   switch (scope) {
@@ -74,77 +64,36 @@ inline SharedDictionaryScope toSharedDictionaryScope(uint8_t value) {
       "Unsupported shared dictionary scope {}.", static_cast<int>(value));
 }
 
-inline constexpr uint32_t kMaxSharedDictionaryEntryCount =
+inline constexpr uint32_t kMaxSharedDictionarySize =
     std::numeric_limits<uint32_t>::max();
 
 inline constexpr uint32_t kInvalidSharedDictionaryId =
     std::numeric_limits<uint32_t>::max();
 
-/// Enables a shared dictionary for one logical scalar stream.
-struct SharedDictionaryConfig {
+SharedDictionaryScope readSharedDictionaryScope(
+    std::string_view data,
+    const char*& pos);
+
+uint32_t readSharedDictionaryId(std::string_view data, const char*& pos);
+
+/// SharedDictionary-specific input selected for one encoded value stream.
+struct SharedDictionaryEncodingInput {
   SharedDictionaryScope scope{SharedDictionaryScope::Stripe};
-
-  /// Identifies the dictionary within its scope:
-  /// - Stripe: auxiliary stream id in the current stripe that stores the
-  ///   alphabet.
-  /// - File: entry id in the file shared dictionary catalog.
-  /// - External: id passed through to the external resolver.
-  /// The sentinel default catches accidental use before the writer assigns an
-  /// id in the selected scope.
   uint32_t dictionaryId{kInvalidSharedDictionaryId};
-
-  /// Uses an externally determined alphabet from the configured resolver
-  /// instead of growing it while encoding values. External-scope dictionaries
-  /// always use a prebuilt alphabet; file-scope dictionaries use one when this
-  /// is set. Forced alphabetEncoding is only allowed when the alphabet is
-  /// prebuilt.
-  bool usesPrebuiltAlphabet{false};
-
-  /// Overrides the encoding used for the stored dictionary alphabet. Empty uses
-  /// regular encoding selection.
-  std::optional<EncodingType> alphabetEncoding;
+  std::span<const uint32_t> indices;
 };
 
 /// Provides indexed access to one immutable shared dictionary alphabet.
 class SharedDictionaryAlphabet {
  public:
-  struct DecodedChunk {
-    uint32_t begin{};
-    uint32_t count{};
-    const void* entries{};
-    /// Keeps entries alive for this chunk.
-    std::shared_ptr<const void> owner;
-  };
-
-  struct EncodedChunk {
-    uint32_t begin{};
-    /// Random-access view over the encoded alphabet chunk.
-    std::shared_ptr<const EncodingView> view;
-  };
-
   virtual ~SharedDictionaryAlphabet() = default;
-
-  static DecodedChunk decodedChunk(
-      uint32_t begin,
-      uint32_t count,
-      const void* entries,
-      std::shared_ptr<const void> owner);
-
-  static EncodedChunk encodedChunk(
-      uint32_t begin,
-      std::shared_ptr<const EncodingView> view);
-
-  static std::shared_ptr<const SharedDictionaryAlphabet> createDecoded(
-      DataType dataType,
-      std::vector<DecodedChunk> chunks);
-
-  static std::shared_ptr<const SharedDictionaryAlphabet> createEncoded(
-      DataType dataType,
-      std::vector<EncodedChunk> chunks);
 
   DataType dataType() const;
 
   uint32_t entryCount() const;
+
+  /// Returns the original Nimble encoding type for the alphabet when known.
+  std::optional<EncodingType> encodingType() const;
 
   template <typename T>
   typename TypeTraits<T>::physicalType physicalValueAt(uint32_t index) const {
@@ -177,13 +126,6 @@ class SharedDictionaryAlphabet {
  protected:
   explicit SharedDictionaryAlphabet(DataType dataType);
 
-  static uint32_t validateDecodedChunks(
-      const std::vector<DecodedChunk>& chunks);
-
-  static uint32_t validateEncodedChunks(
-      DataType dataType,
-      const std::vector<EncodedChunk>& chunks);
-
   void setEntryCount(uint32_t entryCount);
 
  private:
@@ -192,168 +134,18 @@ class SharedDictionaryAlphabet {
   virtual void materializeImpl(std::span<const uint32_t> indices, void* output)
       const = 0;
 
+  virtual std::optional<EncodingType> encodingTypeImpl() const = 0;
+
   const DataType dataType_;
   uint32_t entryCount_{0};
 };
 
-/// Owns an immutable, decoded shared dictionary alphabet split into chunks.
-class DecodedSharedDictionaryAlphabet final : public SharedDictionaryAlphabet {
- public:
-  using Chunk = SharedDictionaryAlphabet::DecodedChunk;
-
-  DecodedSharedDictionaryAlphabet(DataType dataType, std::vector<Chunk> chunks)
-      : SharedDictionaryAlphabet{dataType}, chunks_{std::move(chunks)} {
-    setEntryCount(validateDecodedChunks(chunks_));
-  }
-
- private:
-  template <typename T>
-  void getPhysicalValueTyped(uint32_t index, void* output) const {
-    const auto& chunk = chunkForIndex(index);
-    *static_cast<typename TypeTraits<T>::physicalType*>(output) =
-        static_cast<const typename TypeTraits<T>::physicalType*>(
-            chunk.entries)[index - chunk.begin];
-  }
-
-  template <typename T>
-  void materializeTyped(
-      std::span<const uint32_t> indices,
-      typename TypeTraits<T>::physicalType* output) const {
-    if (chunks_.size() == 1) {
-      const auto* entries =
-          static_cast<const typename TypeTraits<T>::physicalType*>(
-              chunks_[0].entries);
-      for (size_t i = 0; i < indices.size(); ++i) {
-        NIMBLE_CHECK_LT(
-            indices[i],
-            entryCount(),
-            "Shared dictionary index exceeds alphabet size.");
-        output[i] = entries[indices[i]];
-      }
-      return;
-    }
-    for (size_t i = 0; i < indices.size(); ++i) {
-      const auto& chunk = chunkForIndex(indices[i]);
-      output[i] = static_cast<const typename TypeTraits<T>::physicalType*>(
-          chunk.entries)[indices[i] - chunk.begin];
-    }
-  }
-
-  void physicalValueAtImpl(uint32_t index, void* output) const final {
-    NIMBLE_RETURN_BY_DATA_TYPE_OR(
-        dataType(),
-        T,
-        (getPhysicalValueTyped<T>(index, output), void()),
-        NIMBLE_UNSUPPORTED(
-            "{} is not supported by shared dictionary alphabets.", dataType()));
-  }
-
-  void materializeImpl(std::span<const uint32_t> indices, void* output)
-      const final {
-    NIMBLE_RETURN_BY_DATA_TYPE_OR(
-        dataType(),
-        T,
-        (materializeTyped<T>(
-             indices,
-             static_cast<typename TypeTraits<T>::physicalType*>(output)),
-         void()),
-        NIMBLE_UNSUPPORTED(
-            "{} is not supported by shared dictionary alphabets.", dataType()));
-  }
-
-  const Chunk& chunkForIndex(uint32_t index) const {
-    NIMBLE_CHECK_LT(
-        index, entryCount(), "Shared dictionary index exceeds alphabet size.");
-    if (chunks_.size() == 1) {
-      return chunks_.front();
-    }
-    const auto it = std::upper_bound(
-        chunks_.begin(),
-        chunks_.end(),
-        index,
-        [](uint32_t value, const Chunk& chunk) { return value < chunk.begin; });
-    NIMBLE_CHECK(it != chunks_.begin());
-    return *std::prev(it);
-  }
-
-  const std::vector<Chunk> chunks_;
-};
-
-/// Owns immutable, encoded shared dictionary alphabet chunks in memory.
-class EncodedSharedDictionaryAlphabet final : public SharedDictionaryAlphabet {
- public:
-  using Chunk = SharedDictionaryAlphabet::EncodedChunk;
-
-  EncodedSharedDictionaryAlphabet(DataType dataType, std::vector<Chunk> chunks)
-      : SharedDictionaryAlphabet{dataType}, chunks_{std::move(chunks)} {
-    setEntryCount(validateEncodedChunks(dataType, chunks_));
-  }
-
- private:
-  void readPhysicalValue(uint32_t index, void* output) const {
-    const auto chunkIndex = chunkIndexForIndex(index);
-    const auto& chunk = chunks_[chunkIndex];
-    chunk.view->readAt(index - chunk.begin, output);
-  }
-
-  template <typename T>
-  void materializeTyped(
-      std::span<const uint32_t> indices,
-      typename TypeTraits<T>::physicalType* output) const {
-    if (chunks_.size() == 1) {
-      const auto& chunk = chunks_.front();
-      for (size_t i = 0; i < indices.size(); ++i) {
-        NIMBLE_CHECK_LT(
-            indices[i],
-            entryCount(),
-            "Shared dictionary index exceeds alphabet size.");
-        chunk.view->readAt(indices[i], output + i);
-      }
-      return;
-    }
-    for (size_t i = 0; i < indices.size(); ++i) {
-      const auto chunkIndex = chunkIndexForIndex(indices[i]);
-      const auto& chunk = chunks_[chunkIndex];
-      chunk.view->readAt(indices[i] - chunk.begin, output + i);
-    }
-  }
-
-  void physicalValueAtImpl(uint32_t index, void* output) const final {
-    readPhysicalValue(index, output);
-  }
-
-  void materializeImpl(std::span<const uint32_t> indices, void* output)
-      const final {
-    NIMBLE_RETURN_BY_DATA_TYPE_OR(
-        dataType(),
-        T,
-        (materializeTyped<T>(
-             indices,
-             static_cast<typename TypeTraits<T>::physicalType*>(output)),
-         void()),
-        NIMBLE_UNSUPPORTED(
-            "{} is not supported by shared dictionary alphabets.", dataType()));
-  }
-
-  size_t chunkIndexForIndex(uint32_t index) const {
-    NIMBLE_CHECK_LT(
-        index, entryCount(), "Shared dictionary index exceeds alphabet size.");
-    if (chunks_.size() == 1) {
-      return 0;
-    }
-    const auto it = std::upper_bound(
-        chunks_.begin(),
-        chunks_.end(),
-        index,
-        [](uint32_t value, const Chunk& chunk) { return value < chunk.begin; });
-    NIMBLE_CHECK(it != chunks_.begin());
-    return static_cast<size_t>(std::distance(chunks_.begin(), std::prev(it)));
-  }
-
-  const std::vector<Chunk> chunks_;
-};
-
-/// Resolves a dictionary ID within the current reader's decode context.
+/// Resolves a dictionary ID within the current reader or writer context.
+///
+/// File-scope writers use the resolved alphabet as logical dictionary values
+/// and serialize it through Nimble encoding for the file catalog. They do not
+/// accept or reuse resolver-provided encoded bytes. External-scope dictionaries
+/// are resolver-owned and are not serialized into the Nimble file.
 class SharedDictionaryResolver {
  public:
   virtual ~SharedDictionaryResolver() = default;

--- a/dwio/nimble/encodings/common/Encoding.h
+++ b/dwio/nimble/encodings/common/Encoding.h
@@ -28,6 +28,7 @@
 #include "velox/dwio/common/ColumnVisitors.h"
 #include "velox/dwio/common/DecoderUtil.h"
 
+#include <memory>
 #include <string_view>
 #include <type_traits>
 
@@ -73,6 +74,7 @@ struct DecodingStats;
 namespace facebook::nimble {
 
 class EncodingBufferPool;
+class SharedDictionaryResolver;
 
 template <typename T, typename Filter, typename ExtractValues, bool kIsDense>
 using DecoderVisitor =
@@ -157,6 +159,10 @@ class Encoding {
 
     /// Per-column decoding statistics for timing decompression.
     velox::dwio::common::DecodingStats* decodingStats = nullptr;
+
+    /// Resolves alphabets referenced by SharedDictionary encodings. The
+    /// resolver is bound to the current file and stripe decode context.
+    std::shared_ptr<const SharedDictionaryResolver> sharedDictionaryResolver;
 
     velox::io::IoCounter* decompressCounter() const {
       return decodingStats != nullptr ? &decodingStats->decompressCPUTimeNanos

--- a/dwio/nimble/encodings/common/EncodingFactory.cpp
+++ b/dwio/nimble/encodings/common/EncodingFactory.cpp
@@ -33,6 +33,7 @@
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -76,6 +77,9 @@ std::unique_ptr<Encoding> EncodingFactory::create(
     }
     case EncodingType::Dictionary: {
       RETURN_ENCODING_BY_NON_BOOL_TYPE(DictionaryEncoding, dataType);
+    }
+    case EncodingType::SharedDictionary: {
+      RETURN_ENCODING_BY_INTEGER_TYPE(SharedDictionaryEncoding, dataType);
     }
     case EncodingType::FixedBitWidth: {
       RETURN_ENCODING_BY_NUMERIC_TYPE(FixedBitWidthEncoding, dataType);
@@ -274,6 +278,15 @@ std::string_view EncodingFactory::encode(
       }
       return DictionaryEncoding<T>::encode(
           selection, castedValues, buffer, options);
+    }
+    case EncodingType::SharedDictionary: {
+      if constexpr (isIntegralType<T>() && !std::is_same_v<T, bool>) {
+        return SharedDictionaryEncoding<T>::encode(
+            selection, castedValues, buffer, options);
+      }
+      NIMBLE_INCOMPATIBLE_ENCODING(
+          "SharedDictionary encoding only supports non-bool integer data types, got {}.",
+          TypeTraits<T>::dataType);
     }
     case EncodingType::FixedBitWidth: {
       if constexpr (isNumericType<physicalType>()) {

--- a/dwio/nimble/encodings/common/EncodingLayout.cpp
+++ b/dwio/nimble/encodings/common/EncodingLayout.cpp
@@ -21,6 +21,7 @@
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/ALPEncoding.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
+#include "dwio/nimble/encodings/SharedDictionaryTypes.h"
 #include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
@@ -319,6 +320,21 @@ EncodingLayout EncodingLayoutCapture::capture(
       children.emplace_back(
           EncodingLayoutCapture::capture(
               {pos, encoding.size() - (pos - encoding.data())}, options));
+      break;
+    }
+    case EncodingType::SharedDictionary: {
+      children.reserve(1);
+      const char* pos = encoding.data() + prefixSize;
+      readSharedDictionaryScope(encoding, pos);
+      readSharedDictionaryId(encoding, pos);
+      const auto indicesOffset = static_cast<size_t>(pos - encoding.data());
+      NIMBLE_CHECK_LT(
+          indicesOffset,
+          encoding.size(),
+          "Shared dictionary encoding is missing its indices.");
+      children.emplace_back(
+          EncodingLayoutCapture::capture(
+              {pos, encoding.size() - indicesOffset}, options));
       break;
     }
     case EncodingType::RLE: {

--- a/dwio/nimble/encodings/common/EncodingUtils.h
+++ b/dwio/nimble/encodings/common/EncodingUtils.h
@@ -29,6 +29,7 @@
 #include "dwio/nimble/encodings/PFOREncoding.h"
 #include "dwio/nimble/encodings/PrefixEncoding.h"
 #include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "dwio/nimble/encodings/SimdForBitpackEncoding.h"
 #include "dwio/nimble/encodings/SparseBoolEncoding.h"
 #include "dwio/nimble/encodings/TrivialEncoding.h"
@@ -104,6 +105,13 @@ auto encodingTypeDispatchNonString(Encoding& encoding, F&& f) {
       return f(static_cast<RLEEncoding<T>&>(encoding));
     case EncodingType::Dictionary:
       return f(static_cast<DictionaryEncoding<T>&>(encoding));
+    case EncodingType::SharedDictionary:
+      if constexpr (isIntegralType<T>() && !std::is_same_v<T, bool>) {
+        return f(static_cast<SharedDictionaryEncoding<T>&>(encoding));
+      }
+      NIMBLE_UNREACHABLE(
+          "Shared dictionary only supports integer types, got {}.",
+          encoding.dataType());
     case EncodingType::FixedBitWidth:
       return f(static_cast<FixedBitWidthEncoding<T>&>(encoding));
     case EncodingType::Nullable:

--- a/dwio/nimble/encodings/selection/EncodingIdentifier.h
+++ b/dwio/nimble/encodings/selection/EncodingIdentifier.h
@@ -48,6 +48,10 @@ struct EncodingIdentifiers {
     static constexpr NestedEncodingIdentifier Indices = 0;
   };
 
+  struct SharedDictionary {
+    static constexpr NestedEncodingIdentifier Indices = 0;
+  };
+
   struct Trivial {
     static constexpr NestedEncodingIdentifier Lengths = 0;
   };

--- a/dwio/nimble/encodings/selection/EncodingSelection.h
+++ b/dwio/nimble/encodings/selection/EncodingSelection.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <span>
 #include <unordered_map>
@@ -23,6 +24,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Types.h"
 #include "dwio/nimble/compression/CompressionPolicy.h"
+#include "dwio/nimble/encodings/SharedDictionaryTypes.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/common/EncodingLayout.h"
 #include "dwio/nimble/encodings/selection/EncodingIdentifier.h"
@@ -75,6 +77,9 @@ struct EncodingSelectionResult {
   /// Encoding-specific configuration passed from the selection policy.
   /// Currently this config is manually set, not dynamically determined.
   EncodingLayout::Config encodingConfig;
+  /// SharedDictionary-specific encoding data supplied by the writer-side
+  /// selection policy.
+  std::optional<SharedDictionaryEncodingInput> sharedDictionaryInput;
   std::function<std::unique_ptr<CompressionPolicy>()> compressionPolicyFactory =
       []() { return std::make_unique<NoCompressionPolicy>(); };
 };
@@ -104,6 +109,12 @@ class EncodingSelection {
   std::unique_ptr<CompressionPolicy> compressionPolicy() const noexcept {
     auto policy = selectionResult_.compressionPolicyFactory();
     return policy;
+  }
+
+  /// Returns SharedDictionary-specific input supplied by the selection policy.
+  std::optional<SharedDictionaryEncodingInput> sharedDictionaryInput()
+      const noexcept {
+    return selectionResult_.sharedDictionaryInput;
   }
 
   template <typename NestedT>

--- a/dwio/nimble/encodings/tests/CMakeLists.txt
+++ b/dwio/nimble/encodings/tests/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 add_library(
   nimble_encodings_tests_utils
+  SharedDictionaryEncodingTestUtils.cpp
   TestUtils.cpp
   ../selection/tests/RandomEncodingSelectionPolicy.cpp
 )
@@ -56,6 +57,8 @@ add_executable(
   RLEEncodingViewTest.cpp
   RLEEncodingTest.cpp
   SentinelEncodingTest.cpp
+  SharedDictionaryBuilderTest.cpp
+  SharedDictionaryEncodingTest.cpp
   SharedDictionaryTypesTest.cpp
   SimdForBitpackEncodingViewTest.cpp
   SliceEncodingTest.cpp

--- a/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingLayoutTest.cpp
@@ -21,13 +21,18 @@
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 #include "dwio/nimble/encodings/SubIntSplitConfig.h"
 #endif
+#include "dwio/nimble/encodings/SharedDictionaryEncoding.h"
 #include "dwio/nimble/encodings/common/EncodingFactory.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+#include "dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
 #include "dwio/nimble/tools/EncodingUtilities.h"
 #include "velox/common/memory/Memory.h"
 
+#include <optional>
+#include <span>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 using namespace facebook;
 
@@ -150,7 +155,7 @@ class ForceSubIntSplitPolicy final : public nimble::EncodingSelectionPolicy<T> {
 
 } // namespace
 
-TEST(EncodingLayoutTests, Trivial) {
+TEST(EncodingLayoutTests, trivial) {
   {
     nimble::EncodingLayout expected{
         nimble::EncodingType::Trivial,
@@ -172,7 +177,7 @@ TEST(EncodingLayoutTests, Trivial) {
   }
 }
 
-TEST(EncodingLayoutTests, TrivialString) {
+TEST(EncodingLayoutTests, trivialString) {
   {
     nimble::EncodingLayout expected{
         nimble::EncodingType::Trivial,
@@ -190,7 +195,7 @@ TEST(EncodingLayoutTests, TrivialString) {
   }
 }
 
-TEST(EncodingLayoutTests, FixedBitWidth) {
+TEST(EncodingLayoutTests, fixedBitWidth) {
   {
     nimble::EncodingLayout expected{
         nimble::EncodingType::FixedBitWidth,
@@ -230,7 +235,7 @@ TEST(EncodingLayoutTests, FixedBitWidth) {
   }
 }
 
-TEST(EncodingLayoutTests, Varint) {
+TEST(EncodingLayoutTests, varint) {
   nimble::EncodingLayout expected{
       nimble::EncodingType::Varint,
       {},
@@ -241,7 +246,7 @@ TEST(EncodingLayoutTests, Varint) {
   testCapture<uint32_t>(expected, {1, 2, 3});
 }
 
-TEST(EncodingLayoutTests, Constant) {
+TEST(EncodingLayoutTests, constant) {
   nimble::EncodingLayout expected{
       nimble::EncodingType::Constant,
       {},
@@ -252,7 +257,7 @@ TEST(EncodingLayoutTests, Constant) {
   testCapture<uint32_t>(expected, {1, 1, 1});
 }
 
-TEST(EncodingLayoutTests, Pfor) {
+TEST(EncodingLayoutTests, pfor) {
   // PFOR nests two exception sub-streams (positions, residual values). Capture
   // records each present sub-stream recursively, like the compound encodings,
   // so a captured layout reproduces the full PFOR tree.
@@ -283,7 +288,7 @@ TEST(EncodingLayoutTests, Pfor) {
   EXPECT_TRUE(captured.child(1).has_value());
 }
 
-TEST(EncodingLayoutTests, for) {
+TEST(EncodingLayoutTests, forEncoding) {
   // FOR nests three frame metadata sub-streams: bit widths, references, and
   // bit offsets. Capture records each present sub-stream recursively so a
   // captured layout reproduces the full FOR tree.
@@ -347,7 +352,7 @@ TEST(EncodingLayoutTests, fsst) {
       nimble::EncodingType::Trivial);
 }
 
-TEST(EncodingLayoutTests, BlockBitPacking) {
+TEST(EncodingLayoutTests, blockBitPacking) {
   // BlockBitPacking nests three per-block metadata sub-streams (baselines, bit
   // widths, data offsets). Capture records each present sub-stream recursively,
   // like the compound encodings, so a captured layout reproduces the full tree.
@@ -378,7 +383,7 @@ TEST(EncodingLayoutTests, BlockBitPacking) {
   EXPECT_TRUE(captured.child(2).has_value());
 }
 
-TEST(EncodingLayoutTests, SparseBool) {
+TEST(EncodingLayoutTests, sparseBool) {
   nimble::EncodingLayout expected{
       nimble::EncodingType::SparseBool,
       {},
@@ -406,7 +411,7 @@ TEST(EncodingLayoutTests, SparseBool) {
       captureTest, std::array<bool, 5>{false, false, false, true, false});
 }
 
-TEST(EncodingLayoutTests, MainlyConst) {
+TEST(EncodingLayoutTests, mainlyConst) {
   nimble::EncodingLayout expected{
       nimble::EncodingType::MainlyConstant,
       {},
@@ -441,7 +446,7 @@ TEST(EncodingLayoutTests, MainlyConst) {
   testCapture<uint32_t>(captureTest, {1, 1, 1, 1, 5, 1});
 }
 
-TEST(EncodingLayoutTests, Dictionary) {
+TEST(EncodingLayoutTests, dictionary) {
   nimble::EncodingLayout expected{
       nimble::EncodingType::Dictionary,
       {},
@@ -461,7 +466,70 @@ TEST(EncodingLayoutTests, Dictionary) {
   testCapture<uint32_t>(expected, {1, 1, 1, 1, 5, 1});
 }
 
-TEST(EncodingLayoutTests, ReplayDictionaryRejectsEmpty) {
+TEST(EncodingLayoutTests, sharedDictionary) {
+  nimble::EncodingLayout expected{
+      nimble::EncodingType::SharedDictionary,
+      {},
+      nimble::CompressionType::Uncompressed,
+      {
+          nimble::EncodingLayout{
+              nimble::EncodingType::FixedBitWidth,
+              {},
+              nimble::CompressionType::Uncompressed},
+      }};
+
+  testSerialization(expected);
+
+  auto defaultPool = velox::memory::deprecatedAddDefaultLeafMemoryPool();
+  nimble::Buffer buffer{*defaultPool};
+  const std::vector<uint32_t> indices{0, 1, 0, 2, 1, 2};
+  const auto encoded = nimble::test::encodeSharedDictionary(buffer, indices);
+
+  verifyEncodingLayout(
+      expected,
+      nimble::EncodingLayoutCapture::capture(
+          encoded, nimble::Encoding::Options{}));
+
+  struct TraversedEncoding {
+    nimble::EncodingType encodingType;
+    nimble::DataType dataType;
+    uint32_t level;
+    uint32_t index;
+    std::string nestedEncodingName;
+  };
+  std::vector<TraversedEncoding> traversed;
+  nimble::tools::traverseEncodings(
+      encoded,
+      [&](nimble::EncodingType encodingType,
+          nimble::DataType dataType,
+          uint32_t level,
+          uint32_t index,
+          std::string nestedEncodingName,
+          std::unordered_map<
+              nimble::tools::EncodingPropertyType,
+              nimble::tools::EncodingProperty> /* properties */) {
+        traversed.push_back(
+            TraversedEncoding{
+                .encodingType = encodingType,
+                .dataType = dataType,
+                .level = level,
+                .index = index,
+                .nestedEncodingName = std::move(nestedEncodingName)});
+        return true;
+      });
+  ASSERT_EQ(traversed.size(), 2);
+  EXPECT_EQ(traversed[0].encodingType, nimble::EncodingType::SharedDictionary);
+  EXPECT_EQ(traversed[0].dataType, nimble::DataType::Int32);
+  EXPECT_EQ(traversed[0].level, 0);
+  EXPECT_TRUE(traversed[0].nestedEncodingName.empty());
+  EXPECT_EQ(traversed[1].encodingType, nimble::EncodingType::FixedBitWidth);
+  EXPECT_EQ(traversed[1].dataType, nimble::DataType::Uint32);
+  EXPECT_EQ(traversed[1].level, 1);
+  EXPECT_EQ(traversed[1].index, 0);
+  EXPECT_EQ(traversed[1].nestedEncodingName, "Indices");
+}
+
+TEST(EncodingLayoutTests, replayDictionaryRejectsEmpty) {
   // A replayed Dictionary layout applied to an EMPTY value stream cannot build
   // a dictionary. It must reject the stream with an incompatible-encoding error
   // -- like the other data-requiring encodings in EncodingFactory -- so the
@@ -491,7 +559,7 @@ TEST(EncodingLayoutTests, ReplayDictionaryRejectsEmpty) {
 
 TEST(
     EncodingLayoutTests,
-    ReplayMainlyConstantDictionaryRejectsEmptyOtherValues) {
+    replayMainlyConstantDictionaryRejectsEmptyOtherValues) {
   // Replay a MainlyConstant whose OtherValues stream is a nested Dictionary.
   // When every value equals the common value, OtherValues is empty, so the
   // nested Dictionary replay has nothing to encode -- the data shape that made
@@ -530,7 +598,7 @@ TEST(
       "Dictionary encoding cannot be used with 0 rows.");
 }
 
-TEST(EncodingLayoutTests, Rle) {
+TEST(EncodingLayoutTests, rle) {
   nimble::EncodingLayout expected{
       nimble::EncodingType::RLE,
       {},
@@ -550,7 +618,7 @@ TEST(EncodingLayoutTests, Rle) {
   testCapture<uint32_t>(expected, {1, 1, 1, 1, 5, 1});
 }
 
-TEST(EncodingLayoutTests, RleBool) {
+TEST(EncodingLayoutTests, rleBool) {
   nimble::EncodingLayout expected{
       nimble::EncodingType::RLE,
       {},
@@ -566,7 +634,7 @@ TEST(EncodingLayoutTests, RleBool) {
   testCapture<bool>(expected, std::array<bool, 4>{false, false, true, true});
 }
 
-TEST(EncodingLayoutTests, Nullable) {
+TEST(EncodingLayoutTests, nullable) {
   nimble::EncodingLayout expected{
       nimble::EncodingType::Nullable,
       {},
@@ -627,7 +695,7 @@ TEST(EncodingLayoutTests, Nullable) {
 
 // Verify that an EncodingLayout tree with a SubIntSplit root and two named
 // child sections can be serialized and deserialized correctly.
-TEST(EncodingLayoutTests, SubIntSplitSerialization) {
+TEST(EncodingLayoutTests, subIntSplitSerialization) {
   nimble::EncodingLayout layout{
       nimble::EncodingType::SubIntSplit,
       {},
@@ -682,7 +750,7 @@ TEST(EncodingLayoutTests, SubIntSplitSerialization) {
 
 // Verify that EncodingLayoutCapture correctly reads the SubIntSplit binary
 // format and that the captured tree round-trips through serialize/deserialize.
-TEST(EncodingLayoutTests, SubIntSplitCapture) {
+TEST(EncodingLayoutTests, subIntSplitCapture) {
   nimble::EncodingSelectionPolicyCreator encodingSelectionPolicyCreator =
       [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{}](
           nimble::DataType dataType)
@@ -725,7 +793,10 @@ TEST(EncodingLayoutTests, SubIntSplitCapture) {
 
   // The encoded stream must round-trip through the encoding factory.
   auto decoded = nimble::EncodingFactory().create(
-      *defaultPool, encoding, [](uint32_t) { return nullptr; });
+      *defaultPool,
+      encoding,
+      [](uint32_t) { return nullptr; },
+      nimble::Encoding::Options{});
   nimble::Vector<int64_t> decodedValues{defaultPool.get()};
   decodedValues.resize(data.size());
   decoded->materialize(data.size(), decodedValues.data());
@@ -781,7 +852,7 @@ TEST(EncodingLayoutTests, SubIntSplitCapture) {
   }
 }
 
-TEST(EncodingLayoutTests, SubIntSplitPreserveBoundariesReplay) {
+TEST(EncodingLayoutTests, subIntSplitPreserveBoundariesReplay) {
   nimble::EncodingSelectionPolicyCreator encodingSelectionPolicyCreator =
       [encodingFactory = nimble::ManualEncodingSelectionPolicyFactory{}](
           nimble::DataType dataType)
@@ -829,7 +900,7 @@ TEST(EncodingLayoutTests, SubIntSplitPreserveBoundariesReplay) {
 }
 #endif
 
-TEST(EncodingLayoutTests, SizeTooSmall) {
+TEST(EncodingLayoutTests, sizeTooSmall) {
   {
     nimble::EncodingLayout expected{
         nimble::EncodingType::Trivial,

--- a/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
+++ b/dwio/nimble/encodings/tests/ReadWithVisitorTest.cpp
@@ -36,6 +36,7 @@
 #include "dwio/nimble/encodings/legacy/EncodingUtils.h"
 #include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
 #include "dwio/nimble/encodings/tests/EncodingLayoutTestHelper.h"
+#include "dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
 #include "dwio/nimble/velox/ChunkedStream.h"
 #include "dwio/nimble/velox/selective/ByteColumnReader.h"
 #include "dwio/nimble/velox/selective/ColumnReader.h"
@@ -205,6 +206,42 @@ std::unique_ptr<SubIntSplitEncoding<T>> makeSubIntSplitEncoding(
   return std::make_unique<SubIntSplitEncoding<T>>(
       memPool, encoded, [](uint32_t) { return nullptr; });
 }
+
+class Int32SharedDictionaryResolver final : public SharedDictionaryResolver {
+ public:
+  Int32SharedDictionaryResolver(
+      uint32_t dictionaryId,
+      std::vector<int32_t> values)
+      : dictionaryId_{dictionaryId},
+        alphabet_{makeAlphabet(std::move(values))} {}
+
+  std::shared_ptr<const SharedDictionaryAlphabet> resolve(
+      SharedDictionaryScope scope,
+      uint32_t dictionaryId,
+      DataType dataType) const final {
+    if (scope != SharedDictionaryScope::Stripe ||
+        dictionaryId != dictionaryId_ || dataType != DataType::Int32) {
+      return nullptr;
+    }
+    return alphabet_;
+  }
+
+ private:
+  static std::shared_ptr<const SharedDictionaryAlphabet> makeAlphabet(
+      std::vector<int32_t> values) {
+    auto owner = std::make_shared<std::vector<int32_t>>(std::move(values));
+    return test::createTestSharedDictionaryAlphabet(
+        DataType::Int32,
+        {test::TestSharedDictionaryAlphabet::Chunk{
+            .begin = 0,
+            .count = static_cast<uint32_t>(owner->size()),
+            .entries = owner->data(),
+            .owner = owner}});
+  }
+
+  const uint32_t dictionaryId_;
+  const std::shared_ptr<const SharedDictionaryAlphabet> alphabet_;
+};
 
 EncodingLayout makeAlpEncodingLayout(EncodingType encodedValuesEncodingType) {
   const auto encodedValuesLayout = [&] {
@@ -1997,6 +2034,64 @@ TEST_P(ReadWithVisitorTest, encodingLevelDictionaryAlwaysTrueDense) {
   for (int i = 0; i < kRows; ++i) {
     EXPECT_EQ(values[i], (i % 5) * 10) << "row " << i;
   }
+}
+
+TEST_P(ReadWithVisitorTest, encodingLevelSharedDictionaryAlwaysTrueDense) {
+  if (!useNonLegacy()) {
+    GTEST_SKIP() << "SharedDictionaryEncoding requires non-legacy encoding";
+  }
+
+  const std::vector<int32_t> alphabet{10, 20, 30, 40};
+  const std::vector<uint32_t> indices{2, 0, 3, 1, 2};
+  const std::vector<int32_t> expected{30, 10, 40, 20, 30};
+  const auto kRows = static_cast<int>(indices.size());
+
+  auto input = makeRowVector({makeFlatVector<int32_t>(
+      kRows, [&](auto row) { return expected[row]; })});
+  auto rowType = asRowType(input->type());
+  auto ctx = makeFileContext(input);
+  auto scanSpec = std::make_shared<common::ScanSpec>("root");
+  scanSpec->addAllChildFields(*rowType);
+  scanSpec->childByName("c0")->setFilter(
+      std::make_unique<common::AlwaysTrue>());
+  auto root = buildReader(*ctx, rowType, *scanSpec);
+
+  auto* structReader =
+      dynamic_cast<dwio::common::SelectiveStructColumnReaderBase*>(root.get());
+  auto* reader = static_cast<IntegerColumnReaderTestAccessor*>(
+      dynamic_cast<IntegerColumnReader*>(structReader->children()[0]));
+  ASSERT_NE(reader, nullptr);
+
+  std::vector<vector_size_t> rowVec(kRows);
+  std::iota(rowVec.begin(), rowVec.end(), 0);
+  RowSet rows(rowVec.data(), rowVec.size());
+
+  reader->doPrepareRead<int32_t>(0, rows, nullptr);
+
+  Buffer buffer(*pool());
+  const auto encoded = test::encodeSharedDictionary(buffer, indices);
+  Encoding::Options options;
+  options.sharedDictionaryResolver =
+      std::make_shared<Int32SharedDictionaryResolver>(
+          /*dictionaryId=*/7, alphabet);
+  SharedDictionaryEncoding<int32_t> encoding{
+      *pool(), encoded, [](uint32_t) { return nullptr; }, options};
+
+  common::AlwaysTrue filter;
+  dwio::common::ExtractToReader extractValues(reader);
+  constexpr bool kIsDense = true;
+  DecoderVisitor<
+      int32_t,
+      common::AlwaysTrue,
+      dwio::common::ExtractToReader,
+      kIsDense>
+      visitor(filter, reader, rows, extractValues);
+  auto params = makeReadWithVisitorParams(visitor, rows, pool());
+
+  callReadWithVisitor(encoding, visitor, params);
+
+  EXPECT_EQ(reader->numValues(), kRows);
+  EXPECT_EQ(getValues<int32_t>(reader), expected);
 }
 
 // ---------------------------------------------------------------------------

--- a/dwio/nimble/encodings/tests/SharedDictionaryBuilderTest.cpp
+++ b/dwio/nimble/encodings/tests/SharedDictionaryBuilderTest.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "dwio/nimble/common/tests/GTestUtils.h"
-#include "dwio/nimble/velox/SharedDictionaryBuilder.h"
+#include "dwio/nimble/encodings/SharedDictionaryBuilder.h"
 #include "fmt/core.h"
 #include "velox/common/memory/Memory.h"
 
@@ -123,7 +123,8 @@ void verifyFuzzedDictionary(velox::memory::MemoryPool* pool, const char* type) {
   SCOPED_TRACE(type);
 
   const auto values = makeFuzzValues<T>();
-  StreamingSharedDictionaryBuilder<T> streamingBuilder{pool};
+  StreamingSharedDictionaryBuilder<T> streamingBuilder{
+      SharedDictionaryScope::Stripe, /*dictionaryId=*/7, pool};
   std::vector<T> expectedAlphabet;
   std::vector<uint32_t> expectedIndices;
   expectedIndices.reserve(values.size());
@@ -132,7 +133,7 @@ void verifyFuzzedDictionary(velox::memory::MemoryPool* pool, const char* type) {
     const auto chunkSize =
         std::min<size_t>((offset % 7) + 1, values.size() - offset);
     const std::span<const T> chunk{values.data() + offset, chunkSize};
-    const auto alphabetBeforePrepare = expectedAlphabet;
+    const auto alphabetBeforeLookup = expectedAlphabet;
     std::vector<uint32_t> expectedChunkIndices;
     expectedChunkIndices.reserve(chunk.size());
 
@@ -144,39 +145,40 @@ void verifyFuzzedDictionary(velox::memory::MemoryPool* pool, const char* type) {
         expectedChunkIndices.begin(),
         expectedChunkIndices.end());
 
-    auto mapping = streamingBuilder.prepare(chunk);
+    auto mapping = streamingBuilder.lookup(chunk);
     ASSERT_TRUE(mapping.has_value());
     EXPECT_EQ(toIndexVector(mapping->indices()), expectedChunkIndices);
     EXPECT_EQ(
-        mapping->newEntryCount(),
-        expectedAlphabet.size() - alphabetBeforePrepare.size());
-    EXPECT_EQ(toVector(streamingBuilder.alphabet()), alphabetBeforePrepare);
-    streamingBuilder.commit(mapping.value());
+        mapping->newEntries().size(),
+        expectedAlphabet.size() - alphabetBeforeLookup.size());
     EXPECT_EQ(toVector(streamingBuilder.alphabet()), expectedAlphabet);
 
     offset += chunkSize;
   }
   EXPECT_EQ(toVector(streamingBuilder.alphabet()), expectedAlphabet);
 
+  const std::span<const T> expectedAlphabetSpan{
+      expectedAlphabet.data(), expectedAlphabet.size()};
   FixedSharedDictionaryBuilder<T> prebuiltBuilder{
-      pool,
-      std::span<const T>{expectedAlphabet.data(), expectedAlphabet.size()}};
-  auto prebuiltMapping = prebuiltBuilder.prepare(values);
+      expectedAlphabetSpan,
+      SharedDictionaryScope::File,
+      /*dictionaryId=*/7,
+      pool};
+  auto prebuiltMapping = prebuiltBuilder.lookup(values);
   ASSERT_TRUE(prebuiltMapping.has_value());
   EXPECT_EQ(toIndexVector(prebuiltMapping->indices()), expectedIndices);
-  EXPECT_EQ(prebuiltMapping->newEntryCount(), 0);
-  prebuiltBuilder.commit(prebuiltMapping.value());
+  EXPECT_TRUE(prebuiltMapping->newEntries().empty());
   EXPECT_EQ(toVector(prebuiltBuilder.alphabet()), expectedAlphabet);
 
   ExternalSharedDictionaryBuilder<T> externalBuilder{
       buildDictionaryIndex(
           std::span<const T>{expectedAlphabet.data(), expectedAlphabet.size()}),
+      /*dictionaryId=*/7,
       pool};
-  auto externalMapping = externalBuilder.prepare(values);
+  auto externalMapping = externalBuilder.lookup(values);
   ASSERT_TRUE(externalMapping.has_value());
   EXPECT_EQ(toIndexVector(externalMapping->indices()), expectedIndices);
-  EXPECT_EQ(externalMapping->newEntryCount(), 0);
-  externalBuilder.commit(externalMapping.value());
+  EXPECT_TRUE(externalMapping->newEntries().empty());
   NIMBLE_ASSERT_THROW(
       externalBuilder.alphabet(), "does not expose an alphabet");
 }
@@ -204,43 +206,43 @@ TEST_F(SharedDictionaryBuilderTest, builderKindStringFormats) {
   using Builder = SharedDictionaryBuilder<int32_t>;
 
   EXPECT_EQ(Builder::kindString(Builder::Kind::Streaming), "Streaming");
-  EXPECT_EQ(Builder::kindString(Builder::Kind::PrebuiltFile), "PrebuiltFile");
+  EXPECT_EQ(Builder::kindString(Builder::Kind::Fixed), "Fixed");
   EXPECT_EQ(Builder::kindString(Builder::Kind::External), "External");
   EXPECT_EQ(Builder::kindString(static_cast<Builder::Kind>(42)), "Unknown: 42");
 }
 
 TEST_F(SharedDictionaryBuilderTest, alphabet) {
-  StreamingSharedDictionaryBuilder<int32_t> streamingBuilder{pool_.get()};
+  StreamingSharedDictionaryBuilder<int32_t> streamingBuilder{
+      SharedDictionaryScope::Stripe, /*dictionaryId=*/7, pool_.get()};
   EXPECT_TRUE(streamingBuilder.alphabet().empty());
 
   const std::array<int32_t, 4> streamingValues{4, 8, 4, 12};
-  auto streamingMapping = streamingBuilder.prepare(streamingValues);
+  auto streamingMapping = streamingBuilder.lookup(streamingValues);
   ASSERT_TRUE(streamingMapping.has_value());
-  EXPECT_TRUE(streamingBuilder.alphabet().empty());
-  streamingBuilder.commit(streamingMapping.value());
   EXPECT_EQ(
       toVector(streamingBuilder.alphabet()), (std::vector<int32_t>{4, 8, 12}));
 
-  const std::array<int32_t, 3> fileAlphabet{7, 11, 13};
-  FixedSharedDictionaryBuilder<int32_t> prebuiltFileBuilder{
-      pool_.get(), fileAlphabet};
+  const std::array<int32_t, 3> fixedAlphabet{7, 11, 13};
+  const std::span<const int32_t> fixedAlphabetSpan{fixedAlphabet};
+  FixedSharedDictionaryBuilder<int32_t> fixedBuilder{
+      fixedAlphabetSpan,
+      SharedDictionaryScope::File,
+      /*dictionaryId=*/7,
+      pool_.get()};
+  EXPECT_EQ(fixedBuilder.kind(), SharedDictionaryBuilder<int32_t>::Kind::Fixed);
   EXPECT_EQ(
-      prebuiltFileBuilder.kind(),
-      SharedDictionaryBuilder<int32_t>::Kind::PrebuiltFile);
-  EXPECT_EQ(
-      toVector(prebuiltFileBuilder.alphabet()),
-      (std::vector<int32_t>{7, 11, 13}));
+      toVector(fixedBuilder.alphabet()), (std::vector<int32_t>{7, 11, 13}));
 
   DictionaryIndexType<int32_t> dictionaryIndex{{7, 0}, {11, 1}, {13, 2}};
   ExternalSharedDictionaryBuilder<int32_t> externalBuilder{
-      std::move(dictionaryIndex), pool_.get()};
+      std::move(dictionaryIndex), /*dictionaryId=*/7, pool_.get()};
   EXPECT_EQ(
       externalBuilder.kind(), SharedDictionaryBuilder<int32_t>::Kind::External);
   NIMBLE_ASSERT_THROW(
       externalBuilder.alphabet(), "does not expose an alphabet");
 }
 
-TEST_F(SharedDictionaryBuilderTest, prepareAndCommitWithPrebuiltDictionary) {
+TEST_F(SharedDictionaryBuilderTest, lookupWithFixedDictionary) {
   const std::array<int32_t, 4> alphabet{7, 11, 13, 17};
   struct Scenario {
     std::vector<int32_t> values;
@@ -257,9 +259,14 @@ TEST_F(SharedDictionaryBuilderTest, prepareAndCommitWithPrebuiltDictionary) {
   for (auto i = 0; i < scenarios.size(); ++i) {
     const auto& scenario = scenarios[i];
     SCOPED_TRACE(fmt::format("scenario={}", i));
-    FixedSharedDictionaryBuilder<int32_t> builder{pool_.get(), alphabet};
+    const std::span<const int32_t> alphabetSpan{alphabet};
+    FixedSharedDictionaryBuilder<int32_t> builder{
+        alphabetSpan,
+        SharedDictionaryScope::File,
+        /*dictionaryId=*/7,
+        pool_.get()};
 
-    auto mapping = builder.prepare(scenario.values);
+    auto mapping = builder.lookup(scenario.values);
     if (!scenario.expectedIndices.has_value()) {
       EXPECT_FALSE(mapping.has_value());
       EXPECT_EQ(
@@ -270,14 +277,13 @@ TEST_F(SharedDictionaryBuilderTest, prepareAndCommitWithPrebuiltDictionary) {
     ASSERT_TRUE(mapping.has_value());
     EXPECT_EQ(
         toIndexVector(mapping->indices()), scenario.expectedIndices.value());
-    EXPECT_EQ(mapping->newEntryCount(), 0);
-    builder.commit(mapping.value());
+    EXPECT_TRUE(mapping->newEntries().empty());
     EXPECT_EQ(
         toVector(builder.alphabet()), (std::vector<int32_t>{7, 11, 13, 17}));
   }
 }
 
-TEST_F(SharedDictionaryBuilderTest, prepareAndCommitWithExternalDictionary) {
+TEST_F(SharedDictionaryBuilderTest, lookupWithExternalDictionary) {
   const std::array<int32_t, 4> alphabet{7, 11, 13, 17};
   struct Scenario {
     std::vector<int32_t> values;
@@ -295,9 +301,11 @@ TEST_F(SharedDictionaryBuilderTest, prepareAndCommitWithExternalDictionary) {
     const auto& scenario = scenarios[i];
     SCOPED_TRACE(fmt::format("scenario={}", i));
     ExternalSharedDictionaryBuilder<int32_t> builder{
-        buildDictionaryIndex(std::span<const int32_t>{alphabet}), pool_.get()};
+        buildDictionaryIndex(std::span<const int32_t>{alphabet}),
+        /*dictionaryId=*/7,
+        pool_.get()};
 
-    auto mapping = builder.prepare(scenario.values);
+    auto mapping = builder.lookup(scenario.values);
     if (!scenario.expectedIndices.has_value()) {
       EXPECT_FALSE(mapping.has_value());
       NIMBLE_ASSERT_THROW(builder.alphabet(), "does not expose an alphabet");
@@ -307,50 +315,45 @@ TEST_F(SharedDictionaryBuilderTest, prepareAndCommitWithExternalDictionary) {
     ASSERT_TRUE(mapping.has_value());
     EXPECT_EQ(
         toIndexVector(mapping->indices()), scenario.expectedIndices.value());
-    EXPECT_EQ(mapping->newEntryCount(), 0);
-    builder.commit(mapping.value());
+    EXPECT_TRUE(mapping->newEntries().empty());
     NIMBLE_ASSERT_THROW(builder.alphabet(), "does not expose an alphabet");
   }
 }
 
-TYPED_TEST(
-    SharedDictionaryBuilderTypedTest,
-    prepareAndCommitWithStreamingDictionary) {
+TYPED_TEST(SharedDictionaryBuilderTypedTest, lookupWithStreamingDictionary) {
   using T = TypeParam;
   const auto values = makeTypedValues<T>();
   const auto expected = expectedFirstSeenDictionary<T>(values);
-  StreamingSharedDictionaryBuilder<T> builder{this->pool_.get()};
+  StreamingSharedDictionaryBuilder<T> builder{
+      SharedDictionaryScope::Stripe, /*dictionaryId=*/7, this->pool_.get()};
 
-  auto mapping = builder.prepare(values);
+  auto mapping = builder.lookup(values);
   ASSERT_TRUE(mapping.has_value());
   EXPECT_EQ(toIndexVector(mapping->indices()), expected.indices);
-  EXPECT_EQ(mapping->newEntryCount(), expected.alphabet.size());
-  EXPECT_TRUE(builder.alphabet().empty());
-  builder.commit(mapping.value());
+  EXPECT_EQ(mapping->newEntries().size(), expected.alphabet.size());
   EXPECT_EQ(toVector(builder.alphabet()), expected.alphabet);
 }
 
-TYPED_TEST(
-    SharedDictionaryBuilderTypedTest,
-    prepareAndCommitWithPrebuiltDictionary) {
+TYPED_TEST(SharedDictionaryBuilderTypedTest, lookupWithFixedDictionary) {
   using T = TypeParam;
   const auto values = makeTypedValues<T>();
   const auto expected = expectedFirstSeenDictionary<T>(values);
+  const std::span<const T> alphabet{
+      expected.alphabet.data(), expected.alphabet.size()};
   FixedSharedDictionaryBuilder<T> builder{
-      this->pool_.get(),
-      std::span<const T>{expected.alphabet.data(), expected.alphabet.size()}};
+      alphabet,
+      SharedDictionaryScope::File,
+      /*dictionaryId=*/7,
+      this->pool_.get()};
 
-  auto mapping = builder.prepare(values);
+  auto mapping = builder.lookup(values);
   ASSERT_TRUE(mapping.has_value());
   EXPECT_EQ(toIndexVector(mapping->indices()), expected.indices);
-  EXPECT_EQ(mapping->newEntryCount(), 0);
-  builder.commit(mapping.value());
+  EXPECT_TRUE(mapping->newEntries().empty());
   EXPECT_EQ(toVector(builder.alphabet()), expected.alphabet);
 }
 
-TYPED_TEST(
-    SharedDictionaryBuilderTypedTest,
-    prepareAndCommitWithExternalDictionary) {
+TYPED_TEST(SharedDictionaryBuilderTypedTest, lookupWithExternalDictionary) {
   using T = TypeParam;
   const auto values = makeTypedValues<T>();
   const auto expected = expectedFirstSeenDictionary<T>(values);
@@ -358,13 +361,13 @@ TYPED_TEST(
       buildDictionaryIndex(
           std::span<const T>{
               expected.alphabet.data(), expected.alphabet.size()}),
+      /*dictionaryId=*/7,
       this->pool_.get()};
 
-  auto mapping = builder.prepare(values);
+  auto mapping = builder.lookup(values);
   ASSERT_TRUE(mapping.has_value());
   EXPECT_EQ(toIndexVector(mapping->indices()), expected.indices);
-  EXPECT_EQ(mapping->newEntryCount(), 0);
-  builder.commit(mapping.value());
+  EXPECT_TRUE(mapping->newEntries().empty());
   NIMBLE_ASSERT_THROW(builder.alphabet(), "does not expose an alphabet");
 }
 
@@ -377,9 +380,9 @@ TEST_F(SharedDictionaryBuilderTest, fuzzDifferentTypes) {
   verifyFuzzedDictionary<std::string>(pool_.get(), "std::string");
 }
 
-TEST_F(SharedDictionaryBuilderTest, prepareAndCommit) {
+TEST_F(SharedDictionaryBuilderTest, lookupAndReset) {
   enum class Action {
-    Commit,
+    Keep,
     Reset,
   };
 
@@ -387,62 +390,74 @@ TEST_F(SharedDictionaryBuilderTest, prepareAndCommit) {
     std::vector<int32_t> values;
     std::vector<uint32_t> expectedIndices;
     uint32_t expectedNewEntryCount;
-    std::vector<int32_t> expectedAlphabetBeforeAction;
+    std::vector<int32_t> expectedAlphabetAfterLookup;
     Action action;
     std::vector<int32_t> expectedAlphabetAfterAction;
   };
 
   const std::vector<std::vector<Step>> scenarios{
       {
-          {{10, 20, 10, 30}, {0, 1, 0, 2}, 3, {}, Action::Commit, {10, 20, 30}},
+          {{10, 20, 10, 30},
+           {0, 1, 0, 2},
+           3,
+           {10, 20, 30},
+           Action::Keep,
+           {10, 20, 30}},
           {{20, 40, 10, 40},
            {1, 3, 0, 3},
            1,
-           {10, 20, 30},
-           Action::Commit,
+           {10, 20, 30, 40},
+           Action::Keep,
            {10, 20, 30, 40}},
           {{50, 30, 50, 60},
            {4, 2, 4, 5},
            2,
-           {10, 20, 30, 40},
-           Action::Commit,
+           {10, 20, 30, 40, 50, 60},
+           Action::Keep,
            {10, 20, 30, 40, 50, 60}},
           {{60, 10, 40},
            {5, 0, 3},
            0,
            {10, 20, 30, 40, 50, 60},
-           Action::Commit,
+           Action::Keep,
            {10, 20, 30, 40, 50, 60}},
-          {{70, 80}, {6, 7}, 2, {10, 20, 30, 40, 50, 60}, Action::Reset, {}},
-          {{60, 90}, {0, 1}, 2, {}, Action::Commit, {60, 90}},
+          {{70, 80},
+           {6, 7},
+           2,
+           {10, 20, 30, 40, 50, 60, 70, 80},
+           Action::Reset,
+           {}},
+          {{60, 90}, {0, 1}, 2, {60, 90}, Action::Keep, {60, 90}},
       },
   };
 
   for (auto i = 0; i < scenarios.size(); ++i) {
     const auto& scenario = scenarios[i];
-    StreamingSharedDictionaryBuilder<int32_t> builder{pool_.get()};
+    StreamingSharedDictionaryBuilder<int32_t> builder{
+        SharedDictionaryScope::Stripe, /*dictionaryId=*/7, pool_.get()};
     EXPECT_EQ(
         builder.kind(), SharedDictionaryBuilder<int32_t>::Kind::Streaming);
-    EXPECT_EQ(builder.kindString(), "Streaming");
+    EXPECT_EQ(
+        SharedDictionaryBuilder<int32_t>::kindString(builder.kind()),
+        "Streaming");
 
     for (auto j = 0; j < scenario.size(); ++j) {
       const auto& step = scenario[j];
       SCOPED_TRACE(fmt::format("scenario={}, step={}", i, j));
-      auto mapping = builder.prepare(step.values);
+      auto mapping = builder.lookup(step.values);
       ASSERT_TRUE(mapping.has_value());
       EXPECT_EQ(
           std::vector<uint32_t>(
               mapping->indices().begin(), mapping->indices().end()),
           step.expectedIndices);
-      EXPECT_EQ(mapping->newEntryCount(), step.expectedNewEntryCount);
+      EXPECT_EQ(mapping->newEntries().size(), step.expectedNewEntryCount);
       EXPECT_EQ(
           std::vector<int32_t>(
               builder.alphabet().begin(), builder.alphabet().end()),
-          step.expectedAlphabetBeforeAction);
+          step.expectedAlphabetAfterLookup);
 
       switch (step.action) {
-        case Action::Commit:
-          builder.commit(mapping.value());
+        case Action::Keep:
           break;
         case Action::Reset:
           builder.reset();
@@ -456,48 +471,53 @@ TEST_F(SharedDictionaryBuilderTest, prepareAndCommit) {
   }
 }
 
-TEST_F(SharedDictionaryBuilderTest, stateMachine) {
-  StreamingSharedDictionaryBuilder<int32_t> builder{pool_.get()};
-  using Mapping = SharedDictionaryBuilder<int32_t>::Mapping;
+TEST_F(SharedDictionaryBuilderTest, lookupMutatesStreamingAlphabet) {
+  StreamingSharedDictionaryBuilder<int32_t> builder{
+      SharedDictionaryScope::Stripe, /*dictionaryId=*/7, pool_.get()};
 
-  Mapping emptyMapping{pool_.get()};
-  NIMBLE_ASSERT_THROW(
-      builder.commit(emptyMapping), "cannot commit while Ready");
-
-  const std::array<int32_t, 1> values{1};
-  auto mapping = builder.prepare(values);
+  const std::array<int32_t, 1> values{10};
+  auto mapping = builder.lookup(values);
   ASSERT_TRUE(mapping.has_value());
-  NIMBLE_ASSERT_THROW(builder.prepare(values), "cannot prepare while Prepared");
+  EXPECT_EQ(
+      std::vector<int32_t>(
+          builder.alphabet().begin(), builder.alphabet().end()),
+      (std::vector<int32_t>{10}));
 
-  builder.reset();
-  EXPECT_TRUE(builder.alphabet().empty());
-  NIMBLE_ASSERT_THROW(
-      builder.commit(mapping.value()), "cannot commit while Ready");
+  const std::array<int32_t, 1> otherValues{20};
+  auto otherMapping = builder.lookup(otherValues);
+  ASSERT_TRUE(otherMapping.has_value());
+  EXPECT_EQ(
+      std::vector<int32_t>(
+          builder.alphabet().begin(), builder.alphabet().end()),
+      (std::vector<int32_t>{10, 20}));
 }
 
 TEST_F(SharedDictionaryBuilderTest, reset) {
-  StreamingSharedDictionaryBuilder<int16_t> builder{pool_.get()};
+  StreamingSharedDictionaryBuilder<int16_t> builder{
+      SharedDictionaryScope::Stripe, /*dictionaryId=*/7, pool_.get()};
   const std::array<int16_t, 2> values{4, 8};
-  auto mapping = builder.prepare(values);
+  auto mapping = builder.lookup(values);
   ASSERT_TRUE(mapping.has_value());
-  builder.commit(mapping.value());
   EXPECT_FALSE(builder.alphabet().empty());
 
-  NIMBLE_ASSERT_THROW(builder.reset(), "cannot reset while Ready");
-  auto resetMapping = builder.prepare(values);
+  builder.reset();
+  EXPECT_TRUE(builder.alphabet().empty());
+
+  auto resetMapping = builder.lookup(values);
   ASSERT_TRUE(resetMapping.has_value());
+  EXPECT_FALSE(builder.alphabet().empty());
+
   builder.reset();
   EXPECT_TRUE(builder.alphabet().empty());
 
   const std::array<int16_t, 2> afterResetValues{8, 4};
-  auto afterResetMapping = builder.prepare(afterResetValues);
+  auto afterResetMapping = builder.lookup(afterResetValues);
   ASSERT_TRUE(afterResetMapping.has_value());
   EXPECT_EQ(
       std::vector<uint32_t>(
           afterResetMapping->indices().begin(),
           afterResetMapping->indices().end()),
       (std::vector<uint32_t>{0, 1}));
-  builder.commit(afterResetMapping.value());
   EXPECT_EQ(
       std::vector<int16_t>(
           builder.alphabet().begin(), builder.alphabet().end()),
@@ -506,10 +526,15 @@ TEST_F(SharedDictionaryBuilderTest, reset) {
 
 TEST_F(SharedDictionaryBuilderTest, fixedBuilderRejectsMissingValue) {
   const std::array<int32_t, 3> alphabet{7, 11, 13};
-  FixedSharedDictionaryBuilder<int32_t> prebuiltBuilder{pool_.get(), alphabet};
+  const std::span<const int32_t> alphabetSpan{alphabet};
+  FixedSharedDictionaryBuilder<int32_t> prebuiltBuilder{
+      alphabetSpan,
+      SharedDictionaryScope::File,
+      /*dictionaryId=*/7,
+      pool_.get()};
   DictionaryIndexType<int32_t> dictionaryIndex{{7, 0}, {11, 1}, {13, 2}};
   ExternalSharedDictionaryBuilder<int32_t> externalBuilder{
-      std::move(dictionaryIndex), pool_.get()};
+      std::move(dictionaryIndex), /*dictionaryId=*/7, pool_.get()};
 
   struct BuilderCase {
     const char* name;
@@ -518,9 +543,9 @@ TEST_F(SharedDictionaryBuilderTest, fixedBuilderRejectsMissingValue) {
   };
 
   const std::array<BuilderCase, 2> builders{{
-      {"prebuilt",
+      {"fixed",
        &prebuiltBuilder,
-       SharedDictionaryBuilder<int32_t>::Kind::PrebuiltFile},
+       SharedDictionaryBuilder<int32_t>::Kind::Fixed},
       {"external",
        &externalBuilder,
        SharedDictionaryBuilder<int32_t>::Kind::External},
@@ -531,66 +556,50 @@ TEST_F(SharedDictionaryBuilderTest, fixedBuilderRejectsMissingValue) {
   for (const auto& builderCase : builders) {
     SCOPED_TRACE(builderCase.name);
     EXPECT_EQ(builderCase.builder->kind(), builderCase.kind);
-    auto mapping = builderCase.builder->prepare(covered);
+    auto mapping = builderCase.builder->lookup(covered);
     ASSERT_TRUE(mapping.has_value());
     EXPECT_EQ(
         std::vector<uint32_t>(
             mapping->indices().begin(), mapping->indices().end()),
         (std::vector<uint32_t>{2, 0, 1}));
-    builderCase.builder->commit(mapping.value());
-    EXPECT_FALSE(builderCase.builder->prepare(missing).has_value());
+    EXPECT_FALSE(builderCase.builder->lookup(missing).has_value());
   }
 
   EXPECT_EQ(
       std::vector<int32_t>(
           prebuiltBuilder.alphabet().begin(), prebuiltBuilder.alphabet().end()),
       (std::vector<int32_t>{7, 11, 13}));
-  auto prebuiltResetMapping = prebuiltBuilder.prepare(covered);
+  auto prebuiltResetMapping = prebuiltBuilder.lookup(covered);
   ASSERT_TRUE(prebuiltResetMapping.has_value());
   NIMBLE_ASSERT_THROW(prebuiltBuilder.reset(), "does not support reset()");
   NIMBLE_ASSERT_THROW(
       externalBuilder.alphabet(), "does not expose an alphabet");
 }
 
-TEST_F(SharedDictionaryBuilderTest, commitOnExternalAndPrebuiltBuilder) {
+TEST_F(SharedDictionaryBuilderTest, fixedAndExternalLookupDoesNotGrowAlphabet) {
   const std::array<int32_t, 3> alphabet{7, 11, 13};
-  FixedSharedDictionaryBuilder<int32_t> fixedBuilder{pool_.get(), alphabet};
+  const std::span<const int32_t> alphabetSpan{alphabet};
+  FixedSharedDictionaryBuilder<int32_t> fixedBuilder{
+      alphabetSpan,
+      SharedDictionaryScope::File,
+      /*dictionaryId=*/7,
+      pool_.get()};
   DictionaryIndexType<int32_t> dictionaryIndex{{7, 0}, {11, 1}, {13, 2}};
   ExternalSharedDictionaryBuilder<int32_t> externalBuilder{
-      std::move(dictionaryIndex), pool_.get()};
+      std::move(dictionaryIndex), /*dictionaryId=*/7, pool_.get()};
 
   const std::array<int32_t, 3> covered{13, 7, 11};
-  auto fixedMapping = fixedBuilder.prepare(covered);
+  auto fixedMapping = fixedBuilder.lookup(covered);
   ASSERT_TRUE(fixedMapping.has_value());
-  EXPECT_EQ(fixedMapping->newEntryCount(), 0);
-  fixedBuilder.commit(fixedMapping.value());
+  EXPECT_TRUE(fixedMapping->newEntries().empty());
   EXPECT_EQ(
       std::vector<int32_t>(
           fixedBuilder.alphabet().begin(), fixedBuilder.alphabet().end()),
       (std::vector<int32_t>{7, 11, 13}));
 
-  auto externalMapping = externalBuilder.prepare(covered);
+  auto externalMapping = externalBuilder.lookup(covered);
   ASSERT_TRUE(externalMapping.has_value());
-  EXPECT_EQ(externalMapping->newEntryCount(), 0);
-  externalBuilder.commit(externalMapping.value());
-
-  StreamingSharedDictionaryBuilder<int32_t> streamingBuilder{pool_.get()};
-  const std::array<int32_t, 1> newValues{17};
-  auto mappingWithNewEntries = streamingBuilder.prepare(newValues);
-  ASSERT_TRUE(mappingWithNewEntries.has_value());
-  EXPECT_GT(mappingWithNewEntries->newEntryCount(), 0);
-
-  auto fixedPendingMapping = fixedBuilder.prepare(covered);
-  ASSERT_TRUE(fixedPendingMapping.has_value());
-  NIMBLE_ASSERT_THROW(
-      fixedBuilder.commit(mappingWithNewEntries.value()),
-      "should not stage new entries");
-
-  auto externalPendingMapping = externalBuilder.prepare(covered);
-  ASSERT_TRUE(externalPendingMapping.has_value());
-  NIMBLE_ASSERT_THROW(
-      externalBuilder.commit(mappingWithNewEntries.value()),
-      "should not stage new entries");
+  EXPECT_TRUE(externalMapping->newEntries().empty());
 }
 
 } // namespace

--- a/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/common/EncodingPrefix.h"
+#include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::nimble {
+namespace {
+
+class TestSharedDictionaryAlphabet final : public SharedDictionaryAlphabet {
+ public:
+  explicit TestSharedDictionaryAlphabet(
+      std::vector<int32_t> values,
+      std::optional<EncodingType> encodingType = std::nullopt)
+      : SharedDictionaryAlphabet{DataType::Int32},
+        values_{std::make_shared<std::vector<int32_t>>(std::move(values))},
+        encodingType_{encodingType} {
+    setEntryCount(static_cast<uint32_t>(values_->size()));
+  }
+
+  const std::vector<uint32_t>& materializedIndices() const {
+    return materializedIndices_;
+  }
+
+ private:
+  void physicalValueAtImpl(uint32_t index, void* output) const final {
+    NIMBLE_CHECK_LT(
+        index,
+        values_->size(),
+        "Shared dictionary index exceeds alphabet size.");
+    *static_cast<TypeTraits<int32_t>::physicalType*>(output) =
+        static_cast<TypeTraits<int32_t>::physicalType>((*values_)[index]);
+  }
+
+  void materializeImpl(std::span<const uint32_t> indices, void* output)
+      const final {
+    materializedIndices_.assign(indices.begin(), indices.end());
+
+    auto* values = static_cast<TypeTraits<int32_t>::physicalType*>(output);
+    for (size_t i{0}; i < indices.size(); ++i) {
+      NIMBLE_CHECK_LT(
+          indices[i],
+          values_->size(),
+          "Shared dictionary index exceeds alphabet size.");
+      values[i] = static_cast<TypeTraits<int32_t>::physicalType>(
+          (*values_)[indices[i]]);
+    }
+  }
+
+  std::optional<EncodingType> encodingTypeImpl() const final {
+    return encodingType_;
+  }
+
+  const std::shared_ptr<const std::vector<int32_t>> values_;
+  const std::optional<EncodingType> encodingType_;
+  mutable std::vector<uint32_t> materializedIndices_;
+};
+
+class TestSharedDictionaryResolver final : public SharedDictionaryResolver {
+ public:
+  TestSharedDictionaryResolver(
+      uint32_t dictionaryId,
+      std::vector<int32_t> alphabet,
+      std::optional<EncodingType> encodingType = std::nullopt)
+      : dictionaryId_{dictionaryId},
+        alphabet_{std::make_shared<TestSharedDictionaryAlphabet>(
+            std::move(alphabet),
+            encodingType)} {}
+
+  const TestSharedDictionaryAlphabet& alphabet() const {
+    return *alphabet_;
+  }
+
+  std::shared_ptr<const SharedDictionaryAlphabet> resolve(
+      SharedDictionaryScope scope,
+      uint32_t dictionaryId,
+      DataType dataType) const final {
+    if (scope != SharedDictionaryScope::Stripe ||
+        dictionaryId != dictionaryId_ || dataType != DataType::Int32) {
+      return nullptr;
+    }
+    return alphabet_;
+  }
+
+ private:
+  const uint32_t dictionaryId_;
+  const std::shared_ptr<const TestSharedDictionaryAlphabet> alphabet_;
+};
+
+class SharedDictionaryEncodingTest : public ::testing::Test {
+ protected:
+  static void SetUpTestCase() {
+    velox::memory::MemoryManager::testingSetInstance({});
+  }
+
+  void SetUp() final {
+    rootPool_ = velox::memory::memoryManager()->addRootPool(
+        "SharedDictionaryEncodingTest");
+    pool_ = rootPool_->addLeafChild("SharedDictionaryEncodingTestLeaf");
+    buffer_ = std::make_unique<Buffer>(*pool_);
+  }
+
+  std::unique_ptr<Encoding> createEncoding(std::string_view encoded) {
+    return createEncoding(encoded, Encoding::Options{});
+  }
+
+  std::unique_ptr<Encoding> createEncoding(
+      std::string_view encoded,
+      const Encoding::Options& options) {
+    return EncodingFactory{options}.create(
+        *pool_, encoded, stringBufferFactory());
+  }
+
+  std::function<void*(uint32_t)> stringBufferFactory() {
+    return [&](uint32_t totalLength) {
+      auto& buffer = stringBuffers_.emplace_back(
+          velox::AlignedBuffer::allocate<char>(totalLength, pool_.get()));
+      return buffer->asMutable<void>();
+    };
+  }
+
+  std::vector<int32_t> materialize(std::string_view encoded) {
+    auto encoding = createEncoding(encoded);
+    Vector<int32_t> output{pool_.get(), encoding->rowCount()};
+    encoding->materialize(encoding->rowCount(), output.data());
+    return {output.begin(), output.end()};
+  }
+
+  static std::vector<int32_t> sequentialAlphabet(uint32_t size) {
+    std::vector<int32_t> values;
+    values.reserve(size);
+    for (uint32_t i{0}; i < size; ++i) {
+      values.push_back(static_cast<int32_t>(i));
+    }
+    return values;
+  }
+
+  std::string_view dictionaryAlphabet(std::string_view encoded) const {
+    const char* pos = encoded.data() +
+        EncodingPrefix::prefixSize(encoded, /*useVarint=*/false);
+    const uint32_t alphabetBytes = encoding::readUint32(pos);
+    return {pos, alphabetBytes};
+  }
+
+  std::string_view dictionaryIndices(std::string_view encoded) const {
+    const char* pos = encoded.data() +
+        EncodingPrefix::prefixSize(encoded, /*useVarint=*/false);
+    const uint32_t alphabetBytes = encoding::readUint32(pos);
+    pos += alphabetBytes;
+    return {pos, static_cast<size_t>(encoded.data() + encoded.size() - pos)};
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<Buffer> buffer_;
+  std::vector<velox::BufferPtr> stringBuffers_;
+};
+
+TEST_F(SharedDictionaryEncodingTest, publicApiMaterializesAndSkipsRows) {
+  const std::vector<uint32_t> indices{2, 0, 3, 1, 2};
+  const auto encoded = test::encodeSharedDictionary(*buffer_, indices);
+
+  Encoding::Options options;
+  options.sharedDictionaryResolver =
+      std::make_shared<TestSharedDictionaryResolver>(
+          /*dictionaryId=*/7, std::vector<int32_t>{10, 20, 30, 40});
+
+  auto encoding = createEncoding(encoded, options);
+  EXPECT_EQ(encoding->encodingType(), EncodingType::SharedDictionary);
+  EXPECT_EQ(encoding->dataType(), DataType::Int32);
+  EXPECT_EQ(encoding->rowCount(), indices.size());
+  EXPECT_EQ(encoding->dictionarySize(), 4);
+
+  Vector<int32_t> values{pool_.get(), indices.size()};
+  encoding->materialize(indices.size(), values.data());
+  const std::vector<int32_t> expected{30, 10, 40, 20, 30};
+  EXPECT_EQ(std::vector<int32_t>(values.begin(), values.end()), expected);
+
+  encoding->reset();
+  encoding->skip(2);
+  Vector<int32_t> suffix{pool_.get(), 2};
+  encoding->materialize(2, suffix.data());
+  const std::vector<int32_t> expectedSuffix{40, 20};
+  EXPECT_EQ(std::vector<int32_t>(suffix.begin(), suffix.end()), expectedSuffix);
+}
+
+TEST_F(SharedDictionaryEncodingTest, sliceConvertsToLocalDictionary) {
+  struct Scenario {
+    std::string_view name;
+    std::vector<uint32_t> sourceIndices;
+    uint32_t offset;
+    uint32_t length;
+    std::vector<int32_t> alphabetValues;
+    std::optional<EncodingType> alphabetEncodingType;
+    std::vector<uint32_t> expectedMaterializedIndices;
+    std::vector<int32_t> expected;
+  };
+
+  const std::vector<Scenario> scenarios{
+      {
+          "denseSharedIndexRange",
+          {2, 1, 2, 3, 1, 4},
+          /*offset=*/0,
+          /*length=*/6,
+          {100, 200, 300, 400, 500, 600},
+          EncodingType::Trivial,
+          {1, 2, 3, 4},
+          {300, 200, 300, 400, 200, 500},
+      },
+      {
+          "fixedAlphabetEncodingHint",
+          {0, 1, 0, 2, 3, 1},
+          /*offset=*/0,
+          /*length=*/4,
+          {100, 200, 300, 400, 500, 600},
+          EncodingType::FixedBitWidth,
+          {0, 1, 2},
+          {100, 200, 100, 300},
+      },
+      {
+          "noAlphabetEncodingHint",
+          {0, 1, 0, 2, 3, 1},
+          /*offset=*/0,
+          /*length=*/4,
+          {100, 200, 300, 400, 500, 600},
+          std::nullopt,
+          {0, 1, 2},
+          {100, 200, 100, 300},
+      },
+      {
+          "sparseSharedIndexRange",
+          {1000, 1, 1000, 500},
+          /*offset=*/0,
+          /*length=*/4,
+          sequentialAlphabet(/*size=*/1001),
+          EncodingType::Trivial,
+          {1, 500, 1000},
+          {1000, 1, 1000, 500},
+      },
+  };
+
+  for (const auto& testCase : scenarios) {
+    SCOPED_TRACE(testCase.name);
+    const auto encoded =
+        test::encodeSharedDictionary(*buffer_, testCase.sourceIndices);
+
+    Encoding::Options options;
+    auto resolver = std::make_shared<TestSharedDictionaryResolver>(
+        /*dictionaryId=*/7,
+        testCase.alphabetValues,
+        testCase.alphabetEncodingType);
+    options.sharedDictionaryResolver = resolver;
+
+    const auto sliced = EncodingFactory::slice(
+        encoded, testCase.offset, testCase.length, *buffer_, options);
+    EXPECT_NE(sliced.data(), encoded.data());
+    EXPECT_EQ(EncodingPrefix::encodingType(sliced), EncodingType::Dictionary);
+    EXPECT_EQ(EncodingPrefix::dataType(sliced), DataType::Int32);
+    EXPECT_EQ(
+        EncodingPrefix::readRowCount(sliced, /*useVarint=*/false),
+        testCase.length);
+    EXPECT_EQ(materialize(sliced), testCase.expected);
+
+    const auto alphabet = dictionaryAlphabet(sliced);
+    const auto localIndices = dictionaryIndices(sliced);
+    EXPECT_EQ(
+        resolver->alphabet().materializedIndices(),
+        testCase.expectedMaterializedIndices);
+    EXPECT_EQ(
+        EncodingPrefix::readRowCount(alphabet, /*useVarint=*/false),
+        static_cast<uint32_t>(testCase.expectedMaterializedIndices.size()));
+    if (testCase.alphabetEncodingType.has_value()) {
+      EXPECT_EQ(
+          EncodingPrefix::encodingType(alphabet),
+          *testCase.alphabetEncodingType);
+    }
+    EXPECT_EQ(
+        EncodingPrefix::encodingType(localIndices),
+        EncodingType::FixedBitWidth);
+  }
+}
+
+TEST_F(SharedDictionaryEncodingTest, sliceConvertsToConstantEncoding) {
+  const std::vector<uint32_t> indices{0, 0, 0, 1};
+  const auto encoded = test::encodeSharedDictionary(*buffer_, indices);
+
+  Encoding::Options options;
+  options.sharedDictionaryResolver =
+      std::make_shared<TestSharedDictionaryResolver>(
+          /*dictionaryId=*/7, std::vector<int32_t>{100, 200, 300});
+
+  const auto sliced = EncodingFactory::slice(
+      encoded, /*offset=*/0, /*length=*/3, *buffer_, options);
+  EXPECT_EQ(EncodingPrefix::encodingType(sliced), EncodingType::Constant);
+  EXPECT_EQ(EncodingPrefix::readRowCount(sliced, /*useVarint=*/false), 3);
+
+  const std::vector<int32_t> expected{100, 100, 100};
+  EXPECT_EQ(materialize(sliced), expected);
+}
+
+} // namespace
+} // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.cpp
+++ b/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.cpp
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
+
+#include <algorithm>
+#include <iterator>
+#include <optional>
+#include <utility>
+
+#include "dwio/nimble/common/DataTypeDispatch.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+
+namespace facebook::nimble::test {
+
+TestSharedDictionaryAlphabet::TestSharedDictionaryAlphabet(
+    DataType dataType,
+    std::vector<Chunk> chunks)
+    : SharedDictionaryAlphabet{dataType}, chunks_{std::move(chunks)} {
+  setEntryCount(validateChunks(chunks_));
+}
+
+uint32_t TestSharedDictionaryAlphabet::validateChunks(
+    const std::vector<Chunk>& chunks) {
+  uint32_t nextBegin{0};
+  for (const auto& chunk : chunks) {
+    NIMBLE_CHECK_EQ(
+        chunk.begin,
+        nextBegin,
+        "Shared dictionary alphabet chunks must be contiguous.");
+    NIMBLE_CHECK_NOT_NULL(chunk.entries);
+    NIMBLE_CHECK_NOT_NULL(chunk.owner);
+    NIMBLE_CHECK_LE(
+        chunk.count,
+        kMaxSharedDictionarySize - nextBegin,
+        "Shared dictionary alphabet chunk count overflows.");
+    nextBegin += chunk.count;
+  }
+  return nextBegin;
+}
+
+void TestSharedDictionaryAlphabet::physicalValueAtImpl(
+    uint32_t index,
+    void* output) const {
+  NIMBLE_RETURN_BY_DATA_TYPE_OR(
+      dataType(),
+      T,
+      (getPhysicalValueTyped<T>(index, output), void()),
+      NIMBLE_UNSUPPORTED(
+          "{} is not supported by shared dictionary alphabets.", dataType()));
+}
+
+void TestSharedDictionaryAlphabet::materializeImpl(
+    std::span<const uint32_t> indices,
+    void* output) const {
+  NIMBLE_RETURN_BY_DATA_TYPE_OR(
+      dataType(),
+      T,
+      (materializeTyped<T>(
+           indices, static_cast<typename TypeTraits<T>::physicalType*>(output)),
+       void()),
+      NIMBLE_UNSUPPORTED(
+          "{} is not supported by shared dictionary alphabets.", dataType()));
+}
+
+const TestSharedDictionaryAlphabet::Chunk&
+TestSharedDictionaryAlphabet::chunkForIndex(uint32_t index) const {
+  NIMBLE_CHECK_LT(
+      index, entryCount(), "Shared dictionary index exceeds alphabet size.");
+  if (chunks_.size() == 1) {
+    return chunks_.front();
+  }
+  const auto it = std::upper_bound(
+      chunks_.begin(),
+      chunks_.end(),
+      index,
+      [](uint32_t value, const Chunk& chunk) { return value < chunk.begin; });
+  NIMBLE_CHECK(it != chunks_.begin());
+  return *std::prev(it);
+}
+
+std::shared_ptr<const SharedDictionaryAlphabet>
+createTestSharedDictionaryAlphabet(
+    DataType dataType,
+    std::vector<TestSharedDictionaryAlphabet::Chunk> chunks) {
+  return std::make_shared<TestSharedDictionaryAlphabet>(
+      dataType, std::move(chunks));
+}
+
+TestSharedDictionarySelectionPolicy::TestSharedDictionarySelectionPolicy(
+    SharedDictionaryEncodingInput sharedDictionary,
+    EncodingSelectionPolicyCreator nestedPolicyCreator)
+    : sharedDictionary_{sharedDictionary},
+      nestedPolicyCreator_{std::move(nestedPolicyCreator)} {
+  NIMBLE_CHECK_NOT_NULL(nestedPolicyCreator_);
+}
+
+EncodingSelectionResult TestSharedDictionarySelectionPolicy::select(
+    std::span<const physicalType> /*values*/,
+    const Statistics<physicalType>& /*statistics*/,
+    const Encoding::Options& /*options*/) {
+  return {
+      .encodingType = EncodingType::SharedDictionary,
+      .sharedDictionaryInput = sharedDictionary_};
+}
+
+EncodingSelectionResult TestSharedDictionarySelectionPolicy::selectNullable(
+    std::span<const physicalType> /*values*/,
+    std::span<const bool> /*nulls*/,
+    const Statistics<physicalType>& /*statistics*/,
+    const Encoding::Options& /*options*/) {
+  return {.encodingType = EncodingType::Nullable};
+}
+
+std::unique_ptr<EncodingSelectionPolicyBase>
+TestSharedDictionarySelectionPolicy::createImpl(
+    EncodingType /*parentEncodingType*/,
+    NestedEncodingIdentifier /*nestedEncodingIdentifier*/,
+    DataType nestedDataType) {
+  auto policy = nestedPolicyCreator_(nestedDataType);
+  NIMBLE_CHECK_NOT_NULL(policy);
+  return policy;
+}
+
+std::string_view encodeSharedDictionary(
+    Buffer& buffer,
+    const std::vector<uint32_t>& indices) {
+  std::vector<int32_t> values;
+  values.reserve(indices.size());
+  for (const auto index : indices) {
+    values.push_back(static_cast<int32_t>(index));
+  }
+  auto options = Encoding::Options{};
+  auto nestedPolicyCreator =
+      [](DataType dataType) -> std::unique_ptr<EncodingSelectionPolicyBase> {
+    const auto encodingType = dataType == DataType::Uint32
+        ? EncodingType::FixedBitWidth
+        : EncodingType::Trivial;
+    ManualEncodingSelectionPolicyFactory factory{
+        {{encodingType, 1.0}}, std::nullopt};
+    return factory.createPolicy(dataType);
+  };
+  return EncodingFactory::encode<int32_t>(
+      std::make_unique<TestSharedDictionarySelectionPolicy>(
+          SharedDictionaryEncodingInput{
+              .scope = SharedDictionaryScope::Stripe,
+              .dictionaryId = 7,
+              .indices = std::span<const uint32_t>{indices}},
+          nestedPolicyCreator),
+      values,
+      buffer,
+      options);
+}
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h
+++ b/dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <span>
+#include <string_view>
+#include <vector>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Exceptions.h"
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/SharedDictionaryEncoding.h"
+#include "dwio/nimble/encodings/selection/EncodingSelectionPolicy.h"
+
+namespace facebook::nimble::test {
+
+class TestSharedDictionaryAlphabet final : public SharedDictionaryAlphabet {
+ public:
+  struct Chunk {
+    uint32_t begin{};
+    uint32_t count{};
+    const void* entries{};
+    std::shared_ptr<const void> owner;
+  };
+
+  TestSharedDictionaryAlphabet(DataType dataType, std::vector<Chunk> chunks);
+
+ private:
+  static uint32_t validateChunks(const std::vector<Chunk>& chunks);
+
+  template <typename T>
+  void getPhysicalValueTyped(uint32_t index, void* output) const {
+    const auto& chunk = chunkForIndex(index);
+    *static_cast<typename TypeTraits<T>::physicalType*>(output) =
+        static_cast<const typename TypeTraits<T>::physicalType*>(
+            chunk.entries)[index - chunk.begin];
+  }
+
+  template <typename T>
+  void materializeTyped(
+      std::span<const uint32_t> indices,
+      typename TypeTraits<T>::physicalType* output) const {
+    if (chunks_.size() == 1) {
+      const auto* entries =
+          static_cast<const typename TypeTraits<T>::physicalType*>(
+              chunks_[0].entries);
+      for (size_t i = 0; i < indices.size(); ++i) {
+        NIMBLE_CHECK_LT(
+            indices[i],
+            entryCount(),
+            "Shared dictionary index exceeds alphabet size.");
+        output[i] = entries[indices[i]];
+      }
+      return;
+    }
+    for (size_t i = 0; i < indices.size(); ++i) {
+      const auto& chunk = chunkForIndex(indices[i]);
+      output[i] = static_cast<const typename TypeTraits<T>::physicalType*>(
+          chunk.entries)[indices[i] - chunk.begin];
+    }
+  }
+
+  void physicalValueAtImpl(uint32_t index, void* output) const final;
+
+  void materializeImpl(std::span<const uint32_t> indices, void* output)
+      const final;
+
+  std::optional<EncodingType> encodingTypeImpl() const final {
+    return std::nullopt;
+  }
+
+  const Chunk& chunkForIndex(uint32_t index) const;
+
+  const std::vector<Chunk> chunks_;
+};
+
+std::shared_ptr<const SharedDictionaryAlphabet>
+createTestSharedDictionaryAlphabet(
+    DataType dataType,
+    std::vector<TestSharedDictionaryAlphabet::Chunk> chunks);
+
+class TestSharedDictionarySelectionPolicy final
+    : public EncodingSelectionPolicy<int32_t> {
+ public:
+  using physicalType = typename TypeTraits<int32_t>::physicalType;
+
+  TestSharedDictionarySelectionPolicy(
+      SharedDictionaryEncodingInput sharedDictionary,
+      EncodingSelectionPolicyCreator nestedPolicyCreator);
+
+  EncodingSelectionResult select(
+      std::span<const physicalType> values,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) final;
+
+  EncodingSelectionResult selectNullable(
+      std::span<const physicalType> values,
+      std::span<const bool> nulls,
+      const Statistics<physicalType>& statistics,
+      const Encoding::Options& options) final;
+
+ private:
+  std::unique_ptr<EncodingSelectionPolicyBase> createImpl(
+      EncodingType parentEncodingType,
+      NestedEncodingIdentifier nestedEncodingIdentifier,
+      DataType nestedDataType) final;
+
+  const SharedDictionaryEncodingInput sharedDictionary_;
+  const EncodingSelectionPolicyCreator nestedPolicyCreator_;
+};
+
+std::string_view encodeSharedDictionary(
+    Buffer& buffer,
+    const std::vector<uint32_t>& indices);
+
+} // namespace facebook::nimble::test

--- a/dwio/nimble/encodings/tests/SharedDictionaryTypesTest.cpp
+++ b/dwio/nimble/encodings/tests/SharedDictionaryTypesTest.cpp
@@ -16,654 +16,206 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <cstdint>
-#include <memory>
-#include <random>
+#include <optional>
 #include <span>
 #include <string>
 #include <string_view>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
 #include <fmt/core.h>
 
-#include "dwio/nimble/common/Buffer.h"
-#include "dwio/nimble/common/Vector.h"
-#include "dwio/nimble/encodings/BlockBitPackingEncoding.h"
-#include "dwio/nimble/encodings/DeltaBlockEncoding.h"
+#include "dwio/nimble/common/Varint.h"
+#include "dwio/nimble/common/tests/GTestUtils.h"
 #include "dwio/nimble/encodings/SharedDictionaryTypes.h"
-#include "dwio/nimble/encodings/TrivialEncoding.h"
-#include "dwio/nimble/encodings/tests/TestUtils.h"
-#include "velox/common/memory/Memory.h"
 
 namespace facebook::nimble {
 namespace {
 
-enum class AlphabetStorageKind {
-  DecodedChunk,
-  EncodedView,
+class BasicSharedDictionaryAlphabet final : public SharedDictionaryAlphabet {
+ public:
+  BasicSharedDictionaryAlphabet(
+      std::vector<int32_t> values,
+      std::optional<EncodingType> encodingType)
+      : SharedDictionaryAlphabet{DataType::Int32},
+        values_{std::move(values)},
+        encodingType_{encodingType} {
+    setEntryCount(static_cast<uint32_t>(values_.size()));
+  }
+
+ private:
+  void physicalValueAtImpl(uint32_t index, void* output) const final {
+    NIMBLE_CHECK_LT(
+        index,
+        values_.size(),
+        "Shared dictionary index exceeds alphabet size.");
+    *static_cast<TypeTraits<int32_t>::physicalType*>(output) =
+        static_cast<TypeTraits<int32_t>::physicalType>(values_[index]);
+  }
+
+  void materializeImpl(std::span<const uint32_t> indices, void* output)
+      const final {
+    auto* values = static_cast<TypeTraits<int32_t>::physicalType*>(output);
+    for (size_t i{0}; i < indices.size(); ++i) {
+      NIMBLE_CHECK_LT(
+          indices[i],
+          values_.size(),
+          "Shared dictionary index exceeds alphabet size.");
+      values[i] =
+          static_cast<TypeTraits<int32_t>::physicalType>(values_[indices[i]]);
+    }
+  }
+
+  std::optional<EncodingType> encodingTypeImpl() const final {
+    return encodingType_;
+  }
+
+  const std::vector<int32_t> values_;
+  const std::optional<EncodingType> encodingType_;
 };
 
-enum class AlphabetValueKind {
-  Int16,
-  Uint32,
-  Int64,
-  String,
-};
-
-struct AlphabetMaterializeCase {
-  AlphabetStorageKind storage{AlphabetStorageKind::DecodedChunk};
-  AlphabetValueKind value{AlphabetValueKind::Int16};
-  EncodingType encodingType{EncodingType::Trivial};
-  std::vector<std::vector<int64_t>> numberChunks;
-  std::vector<std::vector<std::string_view>> stringChunks;
-  uint32_t valueAtIndex{};
-  std::vector<uint32_t> indices;
-};
-
-std::string alphabetStorageKindName(AlphabetStorageKind storage) {
-  switch (storage) {
-    case AlphabetStorageKind::DecodedChunk:
-      return "decodedChunk";
-    case AlphabetStorageKind::EncodedView:
-      return "encodedView";
-  }
-  return fmt::format("unknownStorage{}", static_cast<int>(storage));
+std::string encodeSharedDictionaryIdForTest(uint32_t dictionaryId) {
+  std::string encoded(varint::varintSize(dictionaryId), '\0');
+  char* pos = encoded.data();
+  varint::writeVarint(dictionaryId, &pos);
+  encoded.resize(static_cast<size_t>(pos - encoded.data()));
+  return encoded;
 }
 
-std::string alphabetValueKindName(AlphabetValueKind kind) {
-  switch (kind) {
-    case AlphabetValueKind::Int16:
-      return "int16";
-    case AlphabetValueKind::Uint32:
-      return "uint32";
-    case AlphabetValueKind::Int64:
-      return "int64";
-    case AlphabetValueKind::String:
-      return "string";
-  }
-  return fmt::format("unknownValue{}", static_cast<int>(kind));
+TEST(SharedDictionaryAlphabetTest, publicApi) {
+  const BasicSharedDictionaryAlphabet alphabet{
+      {10, 20, 30}, EncodingType::FixedBitWidth};
+
+  EXPECT_EQ(alphabet.dataType(), DataType::Int32);
+  EXPECT_EQ(alphabet.entryCount(), 3);
+  const auto encodingType = alphabet.encodingType();
+  ASSERT_TRUE(encodingType.has_value());
+  EXPECT_EQ(*encodingType, EncodingType::FixedBitWidth);
+  EXPECT_EQ(alphabet.physicalValueAt<int32_t>(1), 20);
+
+  const std::vector<uint32_t> indices{2, 0, 1};
+  std::vector<TypeTraits<int32_t>::physicalType> values(indices.size());
+  alphabet.materialize<int32_t>(
+      std::span<const uint32_t>{indices.data(), indices.size()}, values.data());
+
+  const std::vector<TypeTraits<int32_t>::physicalType> expected{30, 10, 20};
+  EXPECT_EQ(values, expected);
 }
 
-std::string alphabetEncodingTypeName(EncodingType encodingType) {
-  if (encodingType == EncodingType::Trivial) {
-    return "trivial";
-  }
-  if (encodingType == EncodingType::BlockBitPacking) {
-    return "blockBitPacking";
-  }
-  if (encodingType == EncodingType::DeltaBlock) {
-    return "deltaBlock";
-  }
-  return fmt::format("encoding{}", static_cast<int>(encodingType));
-}
+TEST(SharedDictionaryScopeTest, scopeName) {
+  struct Case {
+    SharedDictionaryScope scope;
+    uint8_t wireValue;
+    std::string_view name;
+  };
 
-std::string alphabetMaterializeCaseName(
-    const testing::TestParamInfo<AlphabetMaterializeCase>& info) {
-  auto name = alphabetStorageKindName(info.param.storage) + "_" +
-      alphabetValueKindName(info.param.value);
-  if (info.param.storage == AlphabetStorageKind::EncodedView) {
-    name += "_" + alphabetEncodingTypeName(info.param.encodingType);
-  }
-  return name;
-}
+  const std::vector<Case> cases{
+      {SharedDictionaryScope::Stripe, 0, "Stripe"},
+      {SharedDictionaryScope::File, 2, "File"},
+      {SharedDictionaryScope::External, 3, "External"},
+  };
 
-std::string alphabetMaterializeCaseDescription(
-    const AlphabetMaterializeCase& testCase) {
-  return fmt::format(
-      "{}_{}_{}",
-      alphabetStorageKindName(testCase.storage),
-      alphabetValueKindName(testCase.value),
-      alphabetEncodingTypeName(testCase.encodingType));
-}
-
-uint32_t alphabetMaterializeCaseSeed(const AlphabetMaterializeCase& testCase) {
-  return 0x5EED'1000u ^ (static_cast<uint32_t>(testCase.storage) << 16) ^
-      (static_cast<uint32_t>(testCase.value) << 8) ^
-      static_cast<uint32_t>(testCase.encodingType);
-}
-
-constexpr size_t kNumberValuesPerChunk{18};
-constexpr size_t kNumberChunkCount{3};
-constexpr size_t kRandomReadIterations{64};
-
-std::vector<uint32_t> numberMaterializeIndices() {
-  return {17, 0, 28, 3, 45, 21, 53, 12, 37};
-}
-
-std::vector<uint32_t> stringMaterializeIndices() {
-  return {7, 0, 10, 3, 17, 12, 23};
-}
-
-std::vector<std::vector<int64_t>> unsortedSignedNumberChunks() {
-  std::vector<std::vector<int64_t>> chunks;
-  chunks.reserve(kNumberChunkCount);
-  for (size_t chunkIndex{0}; chunkIndex < kNumberChunkCount; ++chunkIndex) {
-    auto& chunk = chunks.emplace_back();
-    chunk.reserve(kNumberValuesPerChunk);
-    for (size_t i{0}; i < kNumberValuesPerChunk; ++i) {
-      const auto magnitude =
-          static_cast<int64_t>((chunkIndex + 1) * 100 + i * 11);
-      chunk.push_back(i % 2 == 0 ? magnitude : -magnitude);
-    }
-  }
-  return chunks;
-}
-
-std::vector<std::vector<int64_t>> sortedSignedNumberChunks() {
-  std::vector<std::vector<int64_t>> chunks;
-  chunks.reserve(kNumberChunkCount);
-  for (size_t chunkIndex{0}; chunkIndex < kNumberChunkCount; ++chunkIndex) {
-    auto& chunk = chunks.emplace_back();
-    chunk.reserve(kNumberValuesPerChunk);
-    const auto first = static_cast<int64_t>(chunkIndex * 1'000) - 800;
-    for (size_t i{0}; i < kNumberValuesPerChunk; ++i) {
-      chunk.push_back(first + static_cast<int64_t>(i * 13));
-    }
-  }
-  return chunks;
-}
-
-std::vector<std::vector<int64_t>> unsortedUnsignedNumberChunks() {
-  std::vector<std::vector<int64_t>> chunks;
-  chunks.reserve(kNumberChunkCount);
-  for (size_t chunkIndex{0}; chunkIndex < kNumberChunkCount; ++chunkIndex) {
-    auto& chunk = chunks.emplace_back();
-    chunk.reserve(kNumberValuesPerChunk);
-    for (size_t i{0}; i < kNumberValuesPerChunk; ++i) {
-      chunk.push_back(
-          static_cast<int64_t>((chunkIndex + 1) * 1'000 + i) +
-          static_cast<int64_t>((i * 7) % kNumberValuesPerChunk) * 31);
-    }
-  }
-  return chunks;
-}
-
-std::vector<std::vector<std::string_view>> stringChunks() {
-  return {
-      {"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"},
-      {"iota", "kappa", "lambda", "mu", "nu", "xi", "omicron", "pi"},
-      {"rho", "sigma", "tau", "upsilon", "phi", "chi", "psi", "omega"}};
-}
-
-AlphabetMaterializeCase numberCase(
-    AlphabetStorageKind storage,
-    AlphabetValueKind value,
-    EncodingType encodingType,
-    std::vector<std::vector<int64_t>> chunks) {
-  AlphabetMaterializeCase testCase;
-  testCase.storage = storage;
-  testCase.value = value;
-  testCase.encodingType = encodingType;
-  testCase.numberChunks = std::move(chunks);
-  testCase.valueAtIndex = 45;
-  testCase.indices = numberMaterializeIndices();
-  return testCase;
-}
-
-AlphabetMaterializeCase stringCase(
-    AlphabetStorageKind storage,
-    EncodingType encodingType) {
-  AlphabetMaterializeCase testCase;
-  testCase.storage = storage;
-  testCase.value = AlphabetValueKind::String;
-  testCase.encodingType = encodingType;
-  testCase.stringChunks = stringChunks();
-  testCase.valueAtIndex = 17;
-  testCase.indices = stringMaterializeIndices();
-  return testCase;
-}
-
-class SharedDictionaryTypesTestBase : public testing::Test {
- protected:
-  void SetUp() final {
-    pool_ = velox::memory::deprecatedAddDefaultLeafMemoryPool();
-    buffer_ = std::make_unique<Buffer>(*pool_);
-  }
-
-  template <typename T>
-  Vector<T> makeVector(const std::vector<T>& values) {
-    Vector<T> out{pool_.get()};
-    out.insert(out.end(), values.data(), values.data() + values.size());
-    return out;
-  }
-
-  SharedDictionaryAlphabet::EncodedChunk makeEncodedChunk(
-      uint32_t begin,
-      std::string_view encoded,
-      const Encoding::Options& options) {
-    auto owner = std::make_shared<std::string>(encoded);
-    auto view = createEncodingView(
-        std::string_view{owner->data(), owner->size()}, pool_.get(), options);
-    encodedOwners_.push_back(owner);
-    return SharedDictionaryAlphabet::encodedChunk(
-        begin, std::shared_ptr<const EncodingView>{std::move(view)});
-  }
-
-  template <typename T>
-  static typename TypeTraits<T>::physicalType physical(T value) {
-    return EncodingPhysicalType<T>::asEncodingPhysicalType(value);
-  }
-
-  template <typename T>
-  static std::vector<std::vector<T>> valueChunks(
-      const AlphabetMaterializeCase& testCase) {
-    if constexpr (std::is_same_v<T, std::string_view>) {
-      return testCase.stringChunks;
-    } else {
-      std::vector<std::vector<T>> out;
-      out.reserve(testCase.numberChunks.size());
-      for (const auto& chunk : testCase.numberChunks) {
-        auto& typedChunk = out.emplace_back();
-        typedChunk.reserve(chunk.size());
-        for (const auto value : chunk) {
-          typedChunk.push_back(static_cast<T>(value));
-        }
-      }
-      return out;
-    }
-  }
-
-  template <typename T>
-  static std::vector<T> flattenedValues(
-      const AlphabetMaterializeCase& testCase) {
-    std::vector<T> out;
-    for (const auto& chunk : valueChunks<T>(testCase)) {
-      out.insert(out.end(), chunk.begin(), chunk.end());
-    }
-    return out;
-  }
-
-  template <typename T>
-  static std::vector<T> expectedValues(
-      const AlphabetMaterializeCase& testCase) {
-    return expectedValues<T>(
-        testCase,
-        std::span<const uint32_t>{
-            testCase.indices.data(), testCase.indices.size()});
-  }
-
-  template <typename T>
-  static std::vector<T> expectedValues(
-      const AlphabetMaterializeCase& testCase,
-      std::span<const uint32_t> indices) {
-    const auto values = flattenedValues<T>(testCase);
-    std::vector<T> out;
-    out.reserve(indices.size());
-    for (const auto index : indices) {
-      NIMBLE_CHECK_LT(index, values.size());
-      out.push_back(values[index]);
-    }
-    return out;
-  }
-
-  template <typename T>
-  std::shared_ptr<std::vector<typename TypeTraits<T>::physicalType>>
-  makePhysicalVector(const std::vector<T>& values) {
-    auto out =
-        std::make_shared<std::vector<typename TypeTraits<T>::physicalType>>();
-    out->reserve(values.size());
-    for (const auto& value : values) {
-      out->push_back(physical<T>(value));
-    }
-    return out;
-  }
-
-  template <typename T>
-  std::shared_ptr<const SharedDictionaryAlphabet> makeDecodedAlphabet(
-      const AlphabetMaterializeCase& testCase) {
-    std::vector<SharedDictionaryAlphabet::DecodedChunk> decodedChunks;
-    uint32_t begin{0};
-    for (const auto& chunk : valueChunks<T>(testCase)) {
-      auto entries = makePhysicalVector<T>(chunk);
-      decodedChunks.push_back(
-          SharedDictionaryAlphabet::decodedChunk(
-              begin,
-              static_cast<uint32_t>(entries->size()),
-              entries->data(),
-              entries));
-      begin += static_cast<uint32_t>(entries->size());
-    }
-    return SharedDictionaryAlphabet::createDecoded(
-        TypeTraits<T>::dataType, std::move(decodedChunks));
-  }
-
-  template <typename T>
-  std::string_view encodeWithTrivial(
-      const std::vector<T>& values,
-      const Encoding::Options& options) {
-    return test::Encoder<TrivialEncoding<T>>::encode(
-        *buffer_,
-        makeVector<T>(values),
-        CompressionType::Uncompressed,
-        options);
-  }
-
-  template <typename T>
-  std::string_view encodeWithBlockBitPacking(
-      const std::vector<T>& values,
-      const Encoding::Options& options) {
-    if constexpr (isNumericType<typename TypeTraits<T>::physicalType>()) {
-      return test::Encoder<BlockBitPackingEncoding<T>>::encode(
-          *buffer_,
-          makeVector<T>(values),
-          CompressionType::Uncompressed,
-          options);
-    }
-    NIMBLE_UNSUPPORTED(
-        "BlockBitPacking test mode does not support {}.",
-        TypeTraits<T>::dataType);
-  }
-
-  template <typename T>
-  std::string_view encodeWithDeltaBlock(
-      const std::vector<T>& values,
-      const Encoding::Options& options) {
-    if constexpr (isIntegralType<T>() && !std::is_same_v<T, bool>) {
-      return test::Encoder<DeltaBlockEncoding<T>>::encode(
-          *buffer_,
-          makeVector<T>(values),
-          CompressionType::Uncompressed,
-          options);
-    }
-    NIMBLE_UNSUPPORTED(
-        "DeltaBlock test mode does not support {}.", TypeTraits<T>::dataType);
-  }
-
-  Encoding::Options encodingOptions(EncodingType encodingType) const {
-    Encoding::Options options;
-    if (encodingType == EncodingType::DeltaBlock) {
-      options.deltaBlockSize = 16;
-    }
-    return options;
-  }
-
-  template <typename T>
-  std::string_view encodeValues(
-      const std::vector<T>& values,
-      EncodingType encodingType,
-      const Encoding::Options& options) {
-    if (encodingType == EncodingType::Trivial) {
-      return encodeWithTrivial<T>(values, options);
-    }
-    if (encodingType == EncodingType::BlockBitPacking) {
-      return encodeWithBlockBitPacking<T>(values, options);
-    }
-    if (encodingType == EncodingType::DeltaBlock) {
-      return encodeWithDeltaBlock<T>(values, options);
-    }
-    NIMBLE_UNSUPPORTED(
-        "{} test mode is not supported by shared dictionary tests.",
-        encodingType);
-  }
-
-  template <typename T>
-  SharedDictionaryAlphabet::EncodedChunk makeEncodedChunk(
-      uint32_t begin,
-      const std::vector<T>& values,
-      EncodingType encodingType) {
-    const auto options = encodingOptions(encodingType);
-    return makeEncodedChunk(
-        begin, encodeValues<T>(values, encodingType, options), options);
-  }
-
-  template <typename T>
-  std::shared_ptr<const SharedDictionaryAlphabet> makeEncodedAlphabet(
-      const AlphabetMaterializeCase& testCase) {
-    std::vector<SharedDictionaryAlphabet::EncodedChunk> encodedChunks;
-    uint32_t begin{0};
-    for (const auto& chunk : valueChunks<T>(testCase)) {
-      encodedChunks.push_back(
-          makeEncodedChunk<T>(begin, chunk, testCase.encodingType));
-      begin += static_cast<uint32_t>(chunk.size());
-    }
-    return SharedDictionaryAlphabet::createEncoded(
-        TypeTraits<T>::dataType, std::move(encodedChunks));
-  }
-
-  template <typename T>
-  std::shared_ptr<const SharedDictionaryAlphabet> makeAlphabet(
-      const AlphabetMaterializeCase& testCase) {
-    switch (testCase.storage) {
-      case AlphabetStorageKind::DecodedChunk:
-        return makeDecodedAlphabet<T>(testCase);
-      case AlphabetStorageKind::EncodedView:
-        return makeEncodedAlphabet<T>(testCase);
-    }
-    NIMBLE_UNSUPPORTED(
-        "Unsupported alphabet storage kind {}.",
-        alphabetStorageKindName(testCase.storage));
-  }
-
-  template <typename T>
-  static std::vector<T> logicalValues(
-      const std::vector<typename TypeTraits<T>::physicalType>& values) {
-    std::vector<T> out;
-    out.reserve(values.size());
-    for (const auto& value : values) {
-      out.push_back(EncodingPhysicalType<T>::asEncodingLogicalType(value));
-    }
-    return out;
-  }
-
-  template <typename T>
-  void verifyMaterialize(const AlphabetMaterializeCase& testCase) {
-    const auto alphabet = makeAlphabet<T>(testCase);
-
-    EXPECT_EQ(alphabet->entryCount(), flattenedValues<T>(testCase).size());
+  for (const auto& testCase : cases) {
+    SCOPED_TRACE(
+        fmt::format(
+            "scope={} value={}",
+            static_cast<int>(testCase.scope),
+            static_cast<int>(testCase.wireValue)));
+    EXPECT_EQ(SharedDictionaryScopeName::toName(testCase.scope), testCase.name);
     EXPECT_EQ(
-        EncodingPhysicalType<T>::asEncodingLogicalType(
-            alphabet->template physicalValueAt<T>(testCase.valueAtIndex)),
-        flattenedValues<T>(testCase)[testCase.valueAtIndex]);
-
-    std::vector<typename TypeTraits<T>::physicalType> values(
-        testCase.indices.size());
-    alphabet->template materialize<T>(
-        std::span<const uint32_t>{
-            testCase.indices.data(), testCase.indices.size()},
-        values.data());
-    EXPECT_EQ(logicalValues<T>(values), expectedValues<T>(testCase));
+        SharedDictionaryScopeName::toSharedDictionaryScope(testCase.name),
+        testCase.scope);
+    EXPECT_EQ(fmt::format("{}", testCase.scope), testCase.name);
+    EXPECT_EQ(toSharedDictionaryScope(testCase.wireValue), testCase.scope);
   }
-
-  template <typename T>
-  void verifyMaterialize(
-      const SharedDictionaryAlphabet& alphabet,
-      const AlphabetMaterializeCase& testCase,
-      std::span<const uint32_t> indices) {
-    std::vector<typename TypeTraits<T>::physicalType> values(indices.size());
-    alphabet.template materialize<T>(indices, values.data());
-    EXPECT_EQ(logicalValues<T>(values), expectedValues<T>(testCase, indices));
-  }
-
-  std::vector<uint32_t> rangeIndices(uint32_t begin, uint32_t count) {
-    std::vector<uint32_t> indices;
-    indices.reserve(count);
-    for (uint32_t offset{0}; offset < count; ++offset) {
-      indices.push_back(begin + offset);
-    }
-    return indices;
-  }
-
-  std::vector<uint32_t> randomIndices(
-      std::mt19937& random,
-      uint32_t entryCount) {
-    std::uniform_int_distribution<uint32_t> sizeDistribution{1, entryCount};
-    std::uniform_int_distribution<uint32_t> indexDistribution{
-        0, entryCount - 1};
-    const auto size = sizeDistribution(random);
-    std::vector<uint32_t> indices;
-    indices.reserve(size);
-    for (uint32_t i{0}; i < size; ++i) {
-      indices.push_back(indexDistribution(random));
-    }
-    return indices;
-  }
-
-  std::vector<uint32_t> randomRangeIndices(
-      std::mt19937& random,
-      uint32_t entryCount) {
-    std::uniform_int_distribution<uint32_t> beginDistribution{
-        0, entryCount - 1};
-    const auto begin = beginDistribution(random);
-    std::uniform_int_distribution<uint32_t> countDistribution{
-        1, entryCount - begin};
-    return rangeIndices(begin, countDistribution(random));
-  }
-
-  template <typename T>
-  void verifyRandomMaterialize(const AlphabetMaterializeCase& testCase) {
-    const auto alphabet = makeAlphabet<T>(testCase);
-    const auto values = flattenedValues<T>(testCase);
-    ASSERT_EQ(alphabet->entryCount(), values.size());
-    ASSERT_GT(alphabet->entryCount(), 0);
-
-    auto random = std::mt19937{alphabetMaterializeCaseSeed(testCase)};
-    const auto entryCount = alphabet->entryCount();
-
-    const auto verifyIndices = [&](std::string_view label,
-                                   const std::vector<uint32_t>& indices) {
-      SCOPED_TRACE(
-          fmt::format(
-              "{} {} size={}",
-              alphabetMaterializeCaseDescription(testCase),
-              label,
-              indices.size()));
-      verifyMaterialize<T>(
-          *alphabet,
-          testCase,
-          std::span<const uint32_t>{indices.data(), indices.size()});
-    };
-
-    verifyIndices("singleValueRange", rangeIndices(entryCount / 2, 1));
-    verifyIndices("fullRange", rangeIndices(/*begin=*/0, entryCount));
-
-    std::uniform_int_distribution<uint32_t> indexDistribution{
-        0, entryCount - 1};
-    for (size_t i{0}; i < kRandomReadIterations; ++i) {
-      SCOPED_TRACE(
-          fmt::format(
-              "{} iteration={}",
-              alphabetMaterializeCaseDescription(testCase),
-              i));
-      const auto index = indexDistribution(random);
-      EXPECT_EQ(
-          EncodingPhysicalType<T>::asEncodingLogicalType(
-              alphabet->template physicalValueAt<T>(index)),
-          values[index]);
-      verifyIndices("randomIndices", randomIndices(random, entryCount));
-      verifyIndices("randomRange", randomRangeIndices(random, entryCount));
-    }
-  }
-
-  std::shared_ptr<velox::memory::MemoryPool> pool_;
-  std::unique_ptr<Buffer> buffer_;
-  std::vector<std::shared_ptr<const std::string>> encodedOwners_;
-};
-
-class SharedDictionaryTypesTest
-    : public SharedDictionaryTypesTestBase,
-      public testing::WithParamInterface<AlphabetMaterializeCase> {
- protected:
-  void verifyMaterialize() {
-    const auto& testCase = GetParam();
-    switch (testCase.value) {
-      case AlphabetValueKind::Int16:
-        SharedDictionaryTypesTestBase::verifyMaterialize<int16_t>(testCase);
-        return;
-      case AlphabetValueKind::Uint32:
-        SharedDictionaryTypesTestBase::verifyMaterialize<uint32_t>(testCase);
-        return;
-      case AlphabetValueKind::Int64:
-        SharedDictionaryTypesTestBase::verifyMaterialize<int64_t>(testCase);
-        return;
-      case AlphabetValueKind::String:
-        SharedDictionaryTypesTestBase::verifyMaterialize<std::string_view>(
-            testCase);
-        return;
-    }
-  }
-
-  void verifyRandomMaterialize() {
-    const auto& testCase = GetParam();
-    switch (testCase.value) {
-      case AlphabetValueKind::Int16:
-        SharedDictionaryTypesTestBase::verifyRandomMaterialize<int16_t>(
-            testCase);
-        return;
-      case AlphabetValueKind::Uint32:
-        SharedDictionaryTypesTestBase::verifyRandomMaterialize<uint32_t>(
-            testCase);
-        return;
-      case AlphabetValueKind::Int64:
-        SharedDictionaryTypesTestBase::verifyRandomMaterialize<int64_t>(
-            testCase);
-        return;
-      case AlphabetValueKind::String:
-        SharedDictionaryTypesTestBase::verifyRandomMaterialize<
-            std::string_view>(testCase);
-        return;
-    }
-  }
-};
-
-TEST_P(SharedDictionaryTypesTest, materializesAcrossChunks) {
-  verifyMaterialize();
 }
 
-TEST_P(SharedDictionaryTypesTest, materializesRandomIndicesAndRanges) {
-  verifyRandomMaterialize();
-}
-
-TEST(SharedDictionaryScopeTest, formatsNames) {
-  EXPECT_EQ(
-      SharedDictionaryScopeName::toName(SharedDictionaryScope::Stripe),
-      "Stripe");
-  EXPECT_EQ(
-      SharedDictionaryScopeName::toSharedDictionaryScope("File"),
-      SharedDictionaryScope::File);
-  EXPECT_EQ(fmt::format("{}", SharedDictionaryScope::External), "External");
+TEST(SharedDictionaryScopeTest, scopeNameError) {
   EXPECT_FALSE(
       SharedDictionaryScopeName::tryToSharedDictionaryScope("Unknown"));
+
+  for (const auto value : {uint8_t{1}, uint8_t{4}, uint8_t{255}}) {
+    SCOPED_TRACE(fmt::format("value={}", static_cast<int>(value)));
+    NIMBLE_ASSERT_THROW(
+        toSharedDictionaryScope(value),
+        fmt::format(
+            "Unsupported shared dictionary scope {}.",
+            static_cast<int>(value)));
+  }
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    sharedDictionaryAlphabet,
-    SharedDictionaryTypesTest,
-    testing::Values(
-        numberCase(
-            AlphabetStorageKind::DecodedChunk,
-            AlphabetValueKind::Int16,
-            EncodingType::Trivial,
-            unsortedSignedNumberChunks()),
-        numberCase(
-            AlphabetStorageKind::EncodedView,
-            AlphabetValueKind::Int16,
-            EncodingType::Trivial,
-            unsortedSignedNumberChunks()),
-        numberCase(
-            AlphabetStorageKind::DecodedChunk,
-            AlphabetValueKind::Uint32,
-            EncodingType::Trivial,
-            unsortedUnsignedNumberChunks()),
-        numberCase(
-            AlphabetStorageKind::EncodedView,
-            AlphabetValueKind::Uint32,
-            EncodingType::BlockBitPacking,
-            unsortedUnsignedNumberChunks()),
-        numberCase(
-            AlphabetStorageKind::DecodedChunk,
-            AlphabetValueKind::Int64,
-            EncodingType::Trivial,
-            unsortedSignedNumberChunks()),
-        numberCase(
-            AlphabetStorageKind::EncodedView,
-            AlphabetValueKind::Int64,
-            EncodingType::DeltaBlock,
-            sortedSignedNumberChunks()),
-        stringCase(AlphabetStorageKind::DecodedChunk, EncodingType::Trivial),
-        stringCase(AlphabetStorageKind::EncodedView, EncodingType::Trivial)),
-    alphabetMaterializeCaseName);
+TEST(SharedDictionaryScopeTest, readsScope) {
+  const std::string data{
+      static_cast<char>(0), static_cast<char>(2), static_cast<char>(3)};
+  const char* pos = data.data();
+
+  EXPECT_EQ(
+      readSharedDictionaryScope(data, pos), SharedDictionaryScope::Stripe);
+  EXPECT_EQ(pos, data.data() + 1);
+  EXPECT_EQ(readSharedDictionaryScope(data, pos), SharedDictionaryScope::File);
+  EXPECT_EQ(pos, data.data() + 2);
+  EXPECT_EQ(
+      readSharedDictionaryScope(data, pos), SharedDictionaryScope::External);
+  EXPECT_EQ(pos, data.data() + 3);
+}
+
+TEST(SharedDictionaryScopeTest, readScopeError) {
+  {
+    const std::string data;
+    const char* pos = data.data();
+
+    NIMBLE_ASSERT_THROW(
+        readSharedDictionaryScope(data, pos),
+        "Shared dictionary encoding is missing its scope.");
+  }
+
+  {
+    const std::string data{static_cast<char>(1)};
+    const char* pos = data.data();
+
+    NIMBLE_ASSERT_THROW(
+        readSharedDictionaryScope(data, pos),
+        "Unsupported shared dictionary scope 1.");
+  }
+}
+
+TEST(SharedDictionaryScopeTest, readsDictionaryId) {
+  std::string data = encodeSharedDictionaryIdForTest(0);
+  const auto secondIdOffset = data.size();
+  data += encodeSharedDictionaryIdForTest(300);
+  const char* pos = data.data();
+
+  EXPECT_EQ(readSharedDictionaryId(data, pos), 0);
+  EXPECT_EQ(pos, data.data() + secondIdOffset);
+  EXPECT_EQ(readSharedDictionaryId(data, pos), 300);
+  EXPECT_EQ(pos, data.data() + data.size());
+}
+
+TEST(SharedDictionaryScopeTest, readDictionaryIdError) {
+  struct Case {
+    std::string data;
+    std::string_view message;
+  };
+
+  const std::vector<Case> cases{
+      {"", "Truncated shared dictionary ID varint."},
+      {std::string{static_cast<char>(0x80)},
+       "Truncated shared dictionary ID varint."},
+      {std::string(
+           varint::maxVarintSizeForBitWidth(/*bitWidth=*/32),
+           static_cast<char>(0x80)),
+       "Shared dictionary ID varint is too long."},
+  };
+
+  for (const auto& testCase : cases) {
+    SCOPED_TRACE(fmt::format("bytes={}", testCase.data.size()));
+    const char* pos = testCase.data.data();
+    NIMBLE_ASSERT_THROW(
+        readSharedDictionaryId(testCase.data, pos), testCase.message);
+  }
+}
 
 } // namespace
 } // namespace facebook::nimble

--- a/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SliceEncodingTest.cpp
@@ -17,7 +17,9 @@
 #include "dwio/nimble/encodings/EncodingSliceFactory.h"
 
 #include <algorithm>
+#include <memory>
 #include <random>
+#include <span>
 #include <string_view>
 #include <type_traits>
 #include <vector>

--- a/dwio/nimble/tablet/Constants.h
+++ b/dwio/nimble/tablet/Constants.h
@@ -15,6 +15,8 @@
  */
 #pragma once
 
+#include <string_view>
+
 namespace facebook::nimble {
 
 constexpr uint16_t kMagicNumber = 0xA1FA;
@@ -37,5 +39,7 @@ constexpr std::string_view kVectorizedStatsSection =
 constexpr std::string_view kIndexSection = "columnar.indexes";
 constexpr std::string_view kChunkStatsSection = "columnar.chunk.stats";
 constexpr std::string_view kFeaturesSection = "columnar.features";
+constexpr std::string_view kSharedDictionarySection =
+    "columnar.shared_dictionaries";
 
 } // namespace facebook::nimble

--- a/dwio/nimble/tools/EncodingUtilities.cpp
+++ b/dwio/nimble/tools/EncodingUtilities.cpp
@@ -17,6 +17,7 @@
 #include "dwio/nimble/common/Exceptions.h"
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/FsstEncoding.h"
+#include "dwio/nimble/encodings/SharedDictionaryTypes.h"
 #include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingUtils.h"
 
@@ -53,6 +54,7 @@ void extractCompressionType(
     }
     case EncodingType::RLE:
     case EncodingType::Dictionary:
+    case EncodingType::SharedDictionary:
     case EncodingType::Sentinel:
     case EncodingType::Nullable:
     case EncodingType::SparseBool:
@@ -323,6 +325,24 @@ void traverseEncodings(
           {pos, stream.size() - (pos - stream.data())},
           level + 1,
           1,
+          "Indices",
+          useVarintRowCount,
+          visitor);
+      break;
+    }
+    case EncodingType::SharedDictionary: {
+      const char* pos = stream.data() + prefixSize(stream, useVarintRowCount);
+      readSharedDictionaryScope(stream, pos);
+      readSharedDictionaryId(stream, pos);
+      const auto indicesOffset = static_cast<size_t>(pos - stream.data());
+      NIMBLE_CHECK_LT(
+          indicesOffset,
+          stream.size(),
+          "Shared dictionary encoding is missing its indices.");
+      traverseEncodings(
+          {pos, stream.size() - indicesOffset},
+          level + 1,
+          0,
           "Indices",
           useVarintRowCount,
           visitor);

--- a/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
+++ b/dwio/nimble/tools/tests/EncodingUtilitiesTest.cpp
@@ -24,6 +24,7 @@
 #include "dwio/nimble/common/Varint.h"
 #include "dwio/nimble/encodings/common/EncodingPrefix.h"
 #include "dwio/nimble/encodings/common/EncodingPrimitives.h"
+#include "dwio/nimble/encodings/tests/SharedDictionaryEncodingTestUtils.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
 #include "dwio/nimble/tools/EncodingUtilities.h"
 #include "velox/common/memory/Memory.h"
@@ -470,6 +471,51 @@ TEST_F(EncodingUtilitiesTest, GetEncodingLabelBlockBitPacking) {
   EXPECT_NE(label.find("Baselines:Trivial"), std::string::npos);
   EXPECT_NE(label.find("BitWidths:Trivial"), std::string::npos);
   EXPECT_NE(label.find("DataOffsets:Trivial"), std::string::npos);
+}
+
+TEST_F(EncodingUtilitiesTest, traverseEncodingsSharedDictionary) {
+  nimble::Buffer buffer(*pool_);
+  const std::vector<uint32_t> indices{0, 1, 0, 2, 1, 2};
+  const auto encoded =
+      facebook::nimble::test::encodeSharedDictionary(buffer, indices);
+
+  struct TraversedEncoding {
+    EncodingType encodingType;
+    DataType dataType;
+    uint32_t level;
+    uint32_t index;
+    std::string nestedEncodingName;
+  };
+  std::vector<TraversedEncoding> traversed;
+  traverseEncodings(
+      encoded,
+      [&](EncodingType encodingType,
+          DataType dataType,
+          uint32_t level,
+          uint32_t index,
+          std::string nestedEncodingName,
+          std::unordered_map<EncodingPropertyType, EncodingProperty>
+          /* properties */) {
+        traversed.push_back(
+            TraversedEncoding{
+                .encodingType = encodingType,
+                .dataType = dataType,
+                .level = level,
+                .index = index,
+                .nestedEncodingName = std::move(nestedEncodingName)});
+        return true;
+      });
+
+  ASSERT_EQ(traversed.size(), 2);
+  EXPECT_EQ(traversed[0].encodingType, EncodingType::SharedDictionary);
+  EXPECT_EQ(traversed[0].dataType, DataType::Int32);
+  EXPECT_EQ(traversed[0].level, 0);
+  EXPECT_TRUE(traversed[0].nestedEncodingName.empty());
+  EXPECT_EQ(traversed[1].encodingType, EncodingType::FixedBitWidth);
+  EXPECT_EQ(traversed[1].dataType, DataType::Uint32);
+  EXPECT_EQ(traversed[1].level, 1);
+  EXPECT_EQ(traversed[1].index, 0);
+  EXPECT_EQ(traversed[1].nestedEncodingName, "Indices");
 }
 
 } // namespace facebook::nimble::tools::test

--- a/dwio/nimble/velox/tests/CMakeLists.txt
+++ b/dwio/nimble/velox/tests/CMakeLists.txt
@@ -48,7 +48,6 @@ add_executable(
   RowRangeTest.cpp
   SchemaTest.cpp
   SchemaUtilsTest.cpp
-  SharedDictionaryBuilderTest.cpp
   StreamChunkerTest.cpp
   StreamDataTest.cpp
   StreamLabelsTest.cpp


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/velox/pull/18418

Add shared dictionary scope/type support, test alphabet APIs, builder-owned dictionary mapping state, and SharedDictionary encoding layout support.

SharedDictionary slicing now materializes only the referenced unique shared dictionary values into a local dictionary, remaps sliced rows through sorted local indices, preserves hinted alphabet/index encoding types when available, and falls back to normal encoding selection otherwise. Single-value slices are converted to top-level Constant encodings.

This also adds direct tests for the shared dictionary wire helpers, alphabet public API, SharedDictionaryEncoding materialize/skip/readWithVisitor behavior, and slice conversion cases with and without alphabet encoding hints.

Reviewed By: tanjialiang

Differential Revision: D114459328
