### PR TITLE
feat: Add cross-version Nimble serialization and projection compatibility validator (#1077)

### DIFF
--- a/dwio/nimble/tools/compatibility/Compatibility.cpp
+++ b/dwio/nimble/tools/compatibility/Compatibility.cpp
@@ -1,0 +1,237 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "dwio/nimble/tools/compatibility/Compatibility.h"
+
+#include <fstream>
+#include <iterator>
+#include <utility>
+
+#include <fmt/format.h>
+#include <folly/json/json.h>
+#include <thrift/lib/cpp2/protocol/Serializer.h>
+#include <velox/common/base/Exceptions.h>
+
+#include "dwio/nimble/serializer/SerializationHeader.h"
+
+namespace facebook::nimble::tools::compatibility {
+namespace {
+
+SerializationVersion payloadVersion(std::string_view payload) {
+  VELOX_CHECK(!payload.empty(), "Compatibility payload is empty");
+  const auto* position = payload.data();
+  return nimble::serde::readSerializationHeader(
+             position, payload.data() + payload.size(), /*hasHeader=*/true)
+      .version;
+}
+
+void validateFormat(SerializationVersion format) {
+  switch (format) {
+    case SerializationVersion::kLegacyCompact:
+    case SerializationVersion::kSerialization:
+    case SerializationVersion::kProjection:
+    case SerializationVersion::kTablet:
+      return;
+    case SerializationVersion::kLegacy:
+    case SerializationVersion::kLegacySerialization:
+      VELOX_UNSUPPORTED(
+          "Unsupported compatibility serialization version: {}",
+          nimble::toString(format));
+  }
+  VELOX_UNREACHABLE("Unknown serialization version");
+}
+
+folly::dynamic resultToJson(const Result& result) {
+  folly::dynamic writerOptions = folly::dynamic::object();
+  for (const auto& [name, value] : result.resolvedWriterOptions) {
+    writerOptions[name] = value;
+  }
+  folly::dynamic featureEncodingOverrides = folly::dynamic::object();
+  for (const auto& [subfield, encoding] : result.featureEncodingOverrides) {
+    featureEncodingOverrides[subfield] = encoding;
+  }
+  return folly::dynamic::object("schema_profile", result.schemaProfile)(
+      "writer_profile", result.writerProfile)(
+      "read_case_id", result.readCaseId)(
+      "resolved_writer_options", std::move(writerOptions))(
+      "feature_encoding_overrides", std::move(featureEncodingOverrides))(
+      "status", statusName(result.status))(
+      "failure_summary", result.failureSummary);
+}
+
+uint8_t statusSeverity(Status status) {
+  switch (status) {
+    case Status::Passed:
+      return 0;
+    case Status::NotExercised:
+      return 1;
+    case Status::Incompatible:
+      return 2;
+    case Status::TestDataError:
+      return 3;
+    case Status::InfraError:
+      return 4;
+  }
+  VELOX_UNREACHABLE("Unsupported validation status");
+}
+
+} // namespace
+
+SerializationVersion parseFormat(std::string_view format) {
+  if (format == "legacy_compact") {
+    return SerializationVersion::kLegacyCompact;
+  }
+  if (format == "serialization") {
+    return SerializationVersion::kSerialization;
+  }
+  if (format == "projection") {
+    return SerializationVersion::kProjection;
+  }
+  if (format == "tablet") {
+    return SerializationVersion::kTablet;
+  }
+  VELOX_USER_FAIL("Unsupported compatibility format: {}", format);
+}
+
+std::string_view formatName(SerializationVersion format) {
+  validateFormat(format);
+  switch (format) {
+    case SerializationVersion::kLegacyCompact:
+      return "legacy_compact";
+    case SerializationVersion::kSerialization:
+      return "serialization";
+    case SerializationVersion::kProjection:
+      return "projection";
+    case SerializationVersion::kTablet:
+      return "tablet";
+    case SerializationVersion::kLegacy:
+    case SerializationVersion::kLegacySerialization:
+      VELOX_UNREACHABLE("Unsupported compatibility serialization version");
+  }
+  VELOX_UNREACHABLE("Unknown serialization version");
+}
+
+Payload::Payload(SerdePayload envelope) : envelope_{std::move(envelope)} {}
+
+SerdePayload& Payload::envelope() {
+  return envelope_;
+}
+
+const SerdePayload& Payload::envelope() const {
+  return envelope_;
+}
+
+SerializationVersion Payload::format() const {
+  VELOX_CHECK(!envelope_.payloads()->empty(), "No payload rows were produced");
+  const auto format = payloadVersion(envelope_.payloads()->front());
+  validateFormat(format);
+  for (const auto& rowPayload : *envelope_.payloads()) {
+    VELOX_CHECK_EQ(
+        payloadVersion(rowPayload),
+        format,
+        "Payload rows have inconsistent serialization versions");
+  }
+  return format;
+}
+
+void Payload::writeToFile(const std::string& path) const {
+  const auto data =
+      apache::thrift::CompactSerializer::serialize<std::string>(envelope_);
+  std::ofstream output{path, std::ios::binary | std::ios::trunc};
+  VELOX_CHECK(output, "Failed to open output file: {}", path);
+  output.write(data.data(), data.size());
+  VELOX_CHECK(output, "Failed to write output file: {}", path);
+}
+
+Payload Payload::readFromFile(const std::string& path) {
+  std::ifstream input{path, std::ios::binary};
+  VELOX_CHECK(input, "Failed to open input file: {}", path);
+  const std::string data{
+      std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}};
+  SerdePayload envelope;
+  apache::thrift::CompactSerializer::deserialize(data, envelope);
+  return Payload{std::move(envelope)};
+}
+
+std::string_view statusName(Status status) {
+  switch (status) {
+    case Status::Passed:
+      return "PASSED";
+    case Status::Incompatible:
+      return "INCOMPATIBLE";
+    case Status::TestDataError:
+      return "TEST_DATA_ERROR";
+    case Status::NotExercised:
+      return "NOT_EXERCISED";
+    case Status::InfraError:
+      return "INFRA_ERROR";
+  }
+  VELOX_UNREACHABLE("Unsupported validation status");
+}
+
+void Report::writeToFile(const std::string& path) const {
+  folly::dynamic jsonResults = folly::dynamic::array();
+  folly::dynamic safeProfiles = folly::dynamic::array();
+  folly::dynamic unsafeProfiles = folly::dynamic::array();
+  folly::dynamic notExercisedProfiles = folly::dynamic::array();
+  auto overallStatus = Status::Passed;
+  for (const auto& result : results) {
+    jsonResults.push_back(resultToJson(result));
+    const auto profile =
+        fmt::format("{}/{}", result.writerProfile, result.readCaseId);
+    switch (result.status) {
+      case Status::Passed:
+        safeProfiles.push_back(profile);
+        break;
+      case Status::NotExercised:
+        notExercisedProfiles.push_back(profile);
+        break;
+      case Status::Incompatible:
+      case Status::TestDataError:
+      case Status::InfraError:
+        unsafeProfiles.push_back(profile);
+        break;
+    }
+    if (statusSeverity(result.status) > statusSeverity(overallStatus)) {
+      overallStatus = result.status;
+    }
+  }
+  const folly::dynamic json =
+      folly::dynamic::object("report_version", reportVersion)(
+          "catalog_version", catalogVersion)("writer_commit", writerCommit)(
+          "reader_commit", readerCommit)("format", format)(
+          "check_kind", checkKind)("overall_status", statusName(overallStatus))(
+          "results", std::move(jsonResults))(
+          "safe_profiles", std::move(safeProfiles))(
+          "unsafe_profiles", std::move(unsafeProfiles))(
+          "not_exercised_profiles", std::move(notExercisedProfiles));
+  folly::json::serialization_opts options;
+  options.pretty_formatting = true;
+  const auto data = folly::json::serialize(json, options);
+  std::ofstream output{path, std::ios::trunc};
+  VELOX_CHECK(output, "Failed to open report file: {}", path);
+  output << data << '\n';
+  VELOX_CHECK(output, "Failed to write report file: {}", path);
+}
+
+std::string Report::summary() const {
+  std::string output = fmt::format(
+      "Nimble compatibility: writer={} reader={} format={} check={}\n",
+      writerCommit,
+      readerCommit,
+      format,
+      checkKind);
+  for (const auto& result : results) {
+    output += fmt::format(
+        "  {} / {} / {}: {}{}\n",
+        result.schemaProfile,
+        result.writerProfile,
+        result.readCaseId,
+        statusName(result.status),
+        result.failureSummary.empty()
+            ? ""
+            : fmt::format(" - {}", result.failureSummary));
+  }
+  return output;
+}
+
+} // namespace facebook::nimble::tools::compatibility

--- a/dwio/nimble/tools/compatibility/Compatibility.h
+++ b/dwio/nimble/tools/compatibility/Compatibility.h
@@ -1,0 +1,71 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "dwio/nimble/serializer/Options.h"
+#include "dwio/nimble/tools/compatibility/gen-cpp2/SerdePayload_types.h"
+
+namespace facebook::nimble::tools::compatibility {
+
+SerializationVersion parseFormat(std::string_view format);
+
+std::string_view formatName(SerializationVersion format);
+
+class Payload {
+ public:
+  Payload() = default;
+  explicit Payload(SerdePayload envelope);
+
+  SerdePayload& envelope();
+  const SerdePayload& envelope() const;
+
+  SerializationVersion format() const;
+  void writeToFile(const std::string& path) const;
+
+  static Payload readFromFile(const std::string& path);
+
+ private:
+  SerdePayload envelope_;
+};
+
+enum class Status {
+  Passed,
+  Incompatible,
+  TestDataError,
+  NotExercised,
+  InfraError,
+};
+
+struct Result {
+  std::string schemaProfile;
+  std::string writerProfile;
+  std::string readCaseId;
+  std::map<std::string, std::string> resolvedWriterOptions;
+  std::map<std::string, std::string> featureEncodingOverrides;
+  Status status{Status::InfraError};
+  std::string failureSummary;
+};
+
+class Report {
+ public:
+  int32_t reportVersion{0};
+  std::string catalogVersion;
+  std::string writerCommit;
+  std::string readerCommit;
+  std::string format;
+  std::string checkKind;
+  std::vector<Result> results;
+
+  void writeToFile(const std::string& path) const;
+  std::string summary() const;
+};
+
+std::string_view statusName(Status status);
+
+} // namespace facebook::nimble::tools::compatibility

--- a/dwio/nimble/tools/compatibility/CompatibilityTest.cpp
+++ b/dwio/nimble/tools/compatibility/CompatibilityTest.cpp
@@ -1,0 +1,68 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+#include "dwio/nimble/tools/compatibility/Compatibility.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include <folly/json/json.h>
+#include <gtest/gtest.h>
+
+#include "dwio/nimble/serializer/SerializationHeader.h"
+
+namespace facebook::nimble::tools::compatibility {
+namespace {
+
+TEST(CompatibilityTest, UsesSerializationVersionAsFormat) {
+  EXPECT_EQ(
+      parseFormat("legacy_compact"), SerializationVersion::kLegacyCompact);
+  EXPECT_EQ(parseFormat("serialization"), SerializationVersion::kSerialization);
+  EXPECT_EQ(parseFormat("projection"), SerializationVersion::kProjection);
+  EXPECT_EQ(parseFormat("tablet"), SerializationVersion::kTablet);
+  EXPECT_THROW(parseFormat("legacy"), velox::VeloxException);
+}
+
+TEST(CompatibilityTest, DetectsLegacyCompactPayload) {
+  std::string rowPayload;
+  serde::writeLegacySerializationHeader(
+      rowPayload, SerializationVersion::kLegacyCompact, /*rowCount=*/1);
+  SerdePayload envelope;
+  *envelope.payloads() = {std::move(rowPayload)};
+
+  const Payload payload{std::move(envelope)};
+
+  EXPECT_EQ(payload.format(), SerializationVersion::kLegacyCompact);
+  EXPECT_EQ(formatName(payload.format()), "legacy_compact");
+}
+
+TEST(CompatibilityTest, ReportDoesNotMaskFailureWithNotExercised) {
+  const Report report{
+      .reportVersion = 1,
+      .catalogVersion = "1",
+      .writerCommit = "writer",
+      .readerCommit = "reader",
+      .format = "legacy_compact",
+      .checkKind = "candidate_current",
+      .results =
+          {{.writerProfile = "unsafe",
+            .readCaseId = "full",
+            .status = Status::Incompatible},
+           {.writerProfile = "not_run",
+            .readCaseId = "full",
+            .status = Status::NotExercised}},
+  };
+  const auto path =
+      std::filesystem::temp_directory_path() / "nimble_compatibility_test.json";
+
+  report.writeToFile(path.string());
+
+  std::ifstream input{path};
+  const std::string data{
+      std::istreambuf_iterator<char>{input}, std::istreambuf_iterator<char>{}};
+  const auto json = folly::parseJson(data);
+  EXPECT_EQ(json["overall_status"], "INCOMPATIBLE");
+  std::filesystem::remove(path);
+}
+
+} // namespace
+} // namespace facebook::nimble::tools::compatibility

--- a/dwio/nimble/tools/compatibility/SerdePayload.thrift
+++ b/dwio/nimble/tools/compatibility/SerdePayload.thrift
@@ -1,0 +1,27 @@
+// (c) Meta Platforms, Inc. and affiliates. Confidential and proprietary.
+
+package "facebook.com/dwio/nimble/tools/compatibility"
+
+namespace cpp2 facebook.nimble.tools.compatibility
+
+struct SerdePayload {
+  // Versions this envelope contract, not the Nimble serialization format.
+  1: i32 envelopeVersion;
+  2: string schemaProfile;
+  3: list<binary> payloads;
+  4: i64 rowCount;
+  5: string logicalChecksum;
+  // Schema matching payloads: serializer schema for serialization payloads,
+  // projected schema for projection payloads.
+  6: binary payloadSchema;
+  7: i64 fuzzerSeed;
+  // Stable test-case name whose resolved selection is projectedSubfields.
+  8: string projectionCaseId;
+  // Concrete projection resolved from projectionCaseId. Serialization readers
+  // use it to run Projector; projection validation uses it to verify test intent.
+  9: list<string> projectedSubfields;
+  10: string knobProfile;
+  11: map<string, string> resolvedKnobs;
+  // Per-feature writer encoding overrides; empty when selection is automatic.
+  12: map<string, string> featureEncodingOverrides;
+}


### PR DESCRIPTION
Summary:

Introduces the profile-agnostic backbone for cross-version Nimble compatibility validation.
This diff adds:

 1. A Thrift envelope that carries Nimble payloads with their matching schema, resolved projection fields, writer knob metadata, and logical checksum.
2. Detection of `kSerialization` and `kProjection` payload formats, with `kTablet` reserved for future NimbleIndexProjector validation.
3. Compact-Thrift artifact file IO for passing writer output across fbcode commits.
4. Structured JSON and human-readable compatibility reports with explicit validation status

Differential Revision: D114782115


