### PR TITLE
Support nested Nimble encoding read factors (#1078)

### DIFF
--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.cpp
@@ -126,9 +126,12 @@ ManualEncodingSelectionPolicyFactory::create(
 
 ManualEncodingSelectionPolicyFactory::ManualEncodingSelectionPolicyFactory(
     std::vector<std::pair<EncodingType, float>> encodingReadFactors,
-    std::optional<CompressionOptions> compressionOptions)
+    std::optional<CompressionOptions> compressionOptions,
+    std::optional<std::vector<std::pair<EncodingType, float>>>
+        nestedEncodingReadFactors)
     : encodingReadFactors_{std::move(encodingReadFactors)},
-      compressionOptions_{std::move(compressionOptions)} {}
+      compressionOptions_{std::move(compressionOptions)},
+      nestedEncodingReadFactors_{std::move(nestedEncodingReadFactors)} {}
 
 std::unique_ptr<EncodingSelectionPolicyBase>
 ManualEncodingSelectionPolicyFactory::createPolicy(DataType dataType) const {
@@ -137,7 +140,8 @@ ManualEncodingSelectionPolicyFactory::createPolicy(DataType dataType) const {
       ManualEncodingSelectionPolicy,
       encodingReadFactors_,
       compressionOptions_,
-      std::nullopt);
+      std::nullopt,
+      nestedEncodingReadFactors_);
 }
 
 /* static */ std::vector<EncodingType>

--- a/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
+++ b/dwio/nimble/encodings/selection/EncodingSelectionPolicy.h
@@ -109,10 +109,14 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   ManualEncodingSelectionPolicy(
       std::vector<std::pair<EncodingType, float>> encodingReadFactors,
       std::optional<CompressionOptions> compressionOptions,
-      std::optional<NestedEncodingIdentifier> identifier)
+      std::optional<NestedEncodingIdentifier> identifier,
+      std::optional<std::vector<std::pair<EncodingType, float>>>
+          nestedEncodingReadFactors = std::nullopt)
       : candidateEncodingReadFactors_{std::move(encodingReadFactors)},
         compressionOptions_{std::move(compressionOptions)},
-        identifier_{identifier} {}
+        identifier_{identifier},
+        nestedEncodingReadFactorsOverride_{
+            std::move(nestedEncodingReadFactors)} {}
 
   EncodingSelectionResult select(
       std::span<const physicalType> values,
@@ -240,8 +244,12 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
     // should we allow trivial string lengths to be encoded using trivial
     // encoding?)
     std::vector<std::pair<EncodingType, float>> nestedEncodingReadFactors;
-    nestedEncodingReadFactors.reserve(candidateEncodingReadFactors_.size());
-    for (const auto& entry : candidateEncodingReadFactors_) {
+    const auto& sourceEncodingReadFactors =
+        nestedEncodingReadFactorsOverride_.has_value()
+        ? nestedEncodingReadFactorsOverride_.value()
+        : candidateEncodingReadFactors_;
+    nestedEncodingReadFactors.reserve(sourceEncodingReadFactors.size());
+    for (const auto& entry : sourceEncodingReadFactors) {
       if (entry.first != parentEncodingType) {
         nestedEncodingReadFactors.emplace_back(entry);
       }
@@ -251,7 +259,8 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
         ManualEncodingSelectionPolicy,
         std::move(nestedEncodingReadFactors),
         compressionOptions_,
-        nestedEncodingIdentifier);
+        nestedEncodingIdentifier,
+        std::nullopt);
   }
 
  private:
@@ -268,6 +277,10 @@ class ManualEncodingSelectionPolicy : public EncodingSelectionPolicy<T> {
   // policies created from it.
   const std::optional<CompressionOptions> compressionOptions_;
   const std::optional<NestedEncodingIdentifier> identifier_;
+  // An override for the next nested policy. Deeper policies inherit their
+  // parent's already-filtered candidates.
+  const std::optional<std::vector<std::pair<EncodingType, float>>>
+      nestedEncodingReadFactorsOverride_;
 };
 
 class ManualEncodingSelectionPolicyFactory {
@@ -298,7 +311,9 @@ class ManualEncodingSelectionPolicyFactory {
       std::vector<std::pair<EncodingType, float>> encodingReadFactors =
           defaultEncodingReadFactors(),
       std::optional<CompressionOptions> compressionOptions =
-          CompressionOptions{});
+          CompressionOptions{},
+      std::optional<std::vector<std::pair<EncodingType, float>>>
+          nestedEncodingReadFactors = std::nullopt);
 
   std::unique_ptr<EncodingSelectionPolicyBase> createPolicy(
       DataType dataType) const;
@@ -310,6 +325,8 @@ class ManualEncodingSelectionPolicyFactory {
  private:
   const std::vector<std::pair<EncodingType, float>> encodingReadFactors_;
   const std::optional<CompressionOptions> compressionOptions_;
+  const std::optional<std::vector<std::pair<EncodingType, float>>>
+      nestedEncodingReadFactors_;
 };
 
 /// Learned encoding selection implementation.

--- a/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
+++ b/dwio/nimble/encodings/tests/EncodingSelectionTest.cpp
@@ -285,6 +285,76 @@ TYPED_TEST_CASE(EncodingSelectionNumericTests, NumericTypes);
 template <typename C>
 class EncodingSelectionNumericTests : public ::testing::Test {};
 
+TEST(ManualEncodingSelectionPolicyFactoryTest, nestedReadFactorsInheritRoot) {
+  nimble::ManualEncodingSelectionPolicyFactory factory{
+      {{nimble::EncodingType::Trivial, 1.0},
+       {nimble::EncodingType::FixedBitWidth, 1.0}},
+      /*compressionOptions=*/std::nullopt};
+
+  auto rootBase = factory.createPolicy(nimble::DataType::Uint32);
+  auto* root = dynamic_cast<nimble::ManualEncodingSelectionPolicy<uint32_t>*>(
+      rootBase.get());
+  ASSERT_NE(root, nullptr);
+  EXPECT_EQ(
+      root->candidateEncodingReadFactors(),
+      (std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::Trivial, 1.0},
+          {nimble::EncodingType::FixedBitWidth, 1.0}}));
+
+  auto nestedBase = rootBase->create<uint32_t>(
+      nimble::EncodingType::Trivial,
+      nimble::EncodingIdentifiers::Dictionary::Indices);
+  auto* nested = dynamic_cast<nimble::ManualEncodingSelectionPolicy<uint32_t>*>(
+      nestedBase.get());
+  ASSERT_NE(nested, nullptr);
+  EXPECT_EQ(
+      nested->candidateEncodingReadFactors(),
+      (std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::FixedBitWidth, 1.0}}));
+}
+
+TEST(ManualEncodingSelectionPolicyFactoryTest, nestedReadFactorsOverrideRoot) {
+  nimble::ManualEncodingSelectionPolicyFactory factory{
+      {{nimble::EncodingType::Trivial, 1.0}},
+      /*compressionOptions=*/std::nullopt,
+      std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::FixedBitWidth, 1.0},
+          {nimble::EncodingType::Varint, 1.0}}};
+
+  auto rootBase = factory.createPolicy(nimble::DataType::Uint32);
+  auto* root = dynamic_cast<nimble::ManualEncodingSelectionPolicy<uint32_t>*>(
+      rootBase.get());
+  ASSERT_NE(root, nullptr);
+  EXPECT_EQ(
+      root->candidateEncodingReadFactors(),
+      (std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::Trivial, 1.0}}));
+
+  auto nestedBase = rootBase->create<uint32_t>(
+      nimble::EncodingType::Trivial,
+      nimble::EncodingIdentifiers::Dictionary::Indices);
+  auto* nested = dynamic_cast<nimble::ManualEncodingSelectionPolicy<uint32_t>*>(
+      nestedBase.get());
+  ASSERT_NE(nested, nullptr);
+  EXPECT_EQ(
+      nested->candidateEncodingReadFactors(),
+      (std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::FixedBitWidth, 1.0},
+          {nimble::EncodingType::Varint, 1.0}}));
+
+  auto deeperNestedBase = nestedBase->create<uint32_t>(
+      nimble::EncodingType::FixedBitWidth,
+      nimble::EncodingIdentifiers::Dictionary::Indices);
+  auto* deeperNested =
+      dynamic_cast<nimble::ManualEncodingSelectionPolicy<uint32_t>*>(
+          deeperNestedBase.get());
+  ASSERT_NE(deeperNested, nullptr);
+  EXPECT_EQ(
+      deeperNested->candidateEncodingReadFactors(),
+      (std::vector<std::pair<nimble::EncodingType, float>>{
+          {nimble::EncodingType::Varint, 1.0}}));
+}
+
 TYPED_TEST(EncodingSelectionNumericTests, selectConst) {
   using T = TypeParam;
 


### PR DESCRIPTION
Summary:

Add an optional nested read-factor vector to ManualEncodingSelectionPolicyFactory. Root encoding selection keeps using --read_factors, while nested child streams can inherit root factors or use --nested_read_factors when explicitly configured.

Wire --nested_read_factors through the SST, Nimble cluster-index, and encoding-eval benchmark entry points. This replaces the ambiguous disable/nested-enable boolean knobs with an explicit nested candidate/factor policy.

Reviewed By: xiaoxmeng, HuamengJiang

Differential Revision: D113835418


