### PR TITLE
fix: Add missing typename for dependent type in SharedDictionaryEncodingTest

### DIFF
--- a/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp
+++ b/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp
@@ -149,7 +149,7 @@ template <typename T>
 EncodingType selectEncoding(
     EncodingSelectionPolicy<T>& policy,
     std::span<const T> values) {
-  using PhysicalType = TypeTraits<T>::physicalType;
+  using PhysicalType = typename TypeTraits<T>::physicalType;
   static_assert(sizeof(T) == sizeof(PhysicalType));
   const auto physicalValues = std::span<const PhysicalType>{
       reinterpret_cast<const PhysicalType*>(values.data()), values.size()};


### PR DESCRIPTION
```C++
/home/runner/work/nimble/nimble/nimble/dwio/nimble/encodings/tests/SharedDictionaryEncodingTest.cpp:152:24: error: missing 'typename' prior to dependent type name 'TypeTraits<T>::physicalType'
  using PhysicalType = TypeTraits<T>::physicalType;
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~
                       typename 
1 error generated.
```