### PR TITLE
perf(nimble): SubIntSplit and Future Reordering microbenchmark drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,3 +232,7 @@ add_subdirectory(dwio/nimble/tablet)
 add_subdirectory(dwio/nimble/velox)
 add_subdirectory(dwio/nimble/writer)
 add_subdirectory(dwio/nimble/serializer)
+
+if(NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS)
+  add_subdirectory(dwio/nimble/ML_ID_Compression)
+endif()

--- a/dwio/nimble/ML_ID_Compression/AblationPolicy.h
+++ b/dwio/nimble/ML_ID_Compression/AblationPolicy.h
@@ -57,8 +57,8 @@ struct EncodingInfo {
   bool hasCostModel;
 };
 
-inline std::vector<EncodingInfo> encodingInventory() {
-  return {
+inline const std::vector<EncodingInfo>& encodingInventory() {
+  static const std::vector<EncodingInfo> inv = {
       {EncodingType::Trivial, "Trivial", AccessClass::PureRA, true},
       {EncodingType::FixedBitWidth, "FixedBitWidth", AccessClass::PureRA, true},
       {EncodingType::Constant, "Constant", AccessClass::PureRA, true},
@@ -68,6 +68,7 @@ inline std::vector<EncodingInfo> encodingInventory() {
       {EncodingType::RLE, "RLE", AccessClass::PureSeq, true},
       {EncodingType::Varint, "Varint", AccessClass::PureSeq, true},
   };
+  return inv;
 }
 
 inline AccessClass accessClassOf(EncodingType t) {
@@ -152,92 +153,15 @@ inline SelectorResult selectSplitsRestricted(
     size_t fullCount,
     const SelectorConfig& cfg,
     const std::unordered_set<EncodingType>& allowed) {
-  if (samples.empty() || kBits <= 0) return {};
-  kBits = std::min(kBits, 64);
-
-  const MetricFlags requiredFlags = allCostModelRequiredFlags();
-  MetricCollector collector;
-
-  struct SegmentChoice {
-    double cost{std::numeric_limits<double>::infinity()};
-    EncodingType encoding{EncodingType::Trivial};
-  };
-
-  const int sz = kBits;
-  std::vector<SegmentChoice> bestCost(sz * sz);
-
-  BitRangeExtractor extractor(samples);
-  const size_t numSamples = samples.size();
-
-  for (int l = 0; l < sz; ++l) {
-    extractor.reset(l);
-    for (int r = l; r < sz; ++r) {
-      extractor.extend(r);
-      const auto& segValues = extractor.values();
-      const SegmentMetrics metrics =
-          collector.compute(segValues, requiredFlags);
-      const int bitWidth = r - l + 1;
-
-      EncodingType bestEnc = EncodingType::Trivial;
-      const double perSampleCost = bestCostBitsRestricted(
-          metrics, numSamples, bitWidth, bestEnc, allowed);
-
-      const double fullCost = perSampleCost *
-          static_cast<double>(fullCount) / static_cast<double>(numSamples);
-
-      bestCost[l * sz + r] = {fullCost, bestEnc};
-    }
-  }
-
-  std::vector<double> dp(sz + 1, std::numeric_limits<double>::infinity());
-  std::vector<int> prev(sz + 1, -1);
-  std::vector<EncodingType> chosen(sz + 1, EncodingType::Trivial);
-  dp[0] = 0.0;
-
-  for (int i = 1; i <= sz; ++i) {
-    for (int j = 0; j < i; ++j) {
-      const int width = i - j;
-      if (width < cfg.minSegmentWidth) continue;
-      const auto& choice = bestCost[j * sz + (i - 1)];
-      if (!std::isfinite(choice.cost)) continue;
-      const double splitCost = (j == 0) ? 0.0 : cfg.splitPenalty;
-      const double candidate = dp[j] + choice.cost + splitCost;
-      if (candidate < dp[i]) {
-        dp[i] = candidate;
-        prev[i] = j;
-        chosen[i] = choice.encoding;
-      }
-    }
-  }
-
-  SelectorResult result;
-  result.totalCost = dp[sz];
-
-  if (!std::isfinite(result.totalCost)) {
-    SegmentPlan fallback;
-    fallback.bitStart = 0;
-    fallback.bitEnd = sz - 1;
-    fallback.encoding = EncodingType::Trivial;
-    fallback.cost = bestCost[0 * sz + (sz - 1)].cost;
-    result.segments.push_back(fallback);
-    result.totalCost = fallback.cost;
-    return result;
-  }
-
-  int idx = sz;
-  while (idx > 0) {
-    const int start = prev[idx];
-    if (start < 0) break;
-    SegmentPlan plan;
-    plan.bitStart = start;
-    plan.bitEnd = idx - 1;
-    plan.encoding = chosen[idx];
-    plan.cost = bestCost[start * sz + (idx - 1)].cost;
-    result.segments.push_back(plan);
-    idx = start;
-  }
-  std::reverse(result.segments.begin(), result.segments.end());
-  return result;
+  return selectSplitsImpl(
+      samples, kBits, fullCount, cfg,
+      [&allowed](
+          const SegmentMetrics& m,
+          size_t numValues,
+          int bitWidth,
+          EncodingType& bestEnc) noexcept {
+        return bestCostBitsRestricted(m, numValues, bitWidth, bestEnc, allowed);
+      });
 }
 
 } // namespace detail_ablation

--- a/dwio/nimble/ML_ID_Compression/AblationPolicy.h
+++ b/dwio/nimble/ML_ID_Compression/AblationPolicy.h
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include "dwio/nimble/common/Types.h"
+#include "dwio/nimble/encodings/SubIntSplitCostModels.h"
+#include "dwio/nimble/encodings/SubIntSplitMetrics.h"
+#include "dwio/nimble/encodings/SubIntSplitSelector.h"
+
+namespace facebook::nimble::mlidc {
+
+enum class AccessClass : uint8_t {
+  PureRA = 0,
+  HybridRA = 1,
+  BoundedSeq = 2,
+  PureSeq = 3,
+};
+
+inline const char* accessClassName(AccessClass c) {
+  switch (c) {
+    case AccessClass::PureRA: return "PureRA";
+    case AccessClass::HybridRA: return "HybridRA";
+    case AccessClass::BoundedSeq: return "BoundedSeq";
+    case AccessClass::PureSeq: return "PureSeq";
+  }
+  return "Unknown";
+}
+
+struct EncodingInfo {
+  EncodingType type;
+  std::string name;
+  AccessClass accessClass;
+  bool hasCostModel;
+};
+
+inline std::vector<EncodingInfo> encodingInventory() {
+  return {
+      {EncodingType::Trivial, "Trivial", AccessClass::PureRA, true},
+      {EncodingType::FixedBitWidth, "FixedBitWidth", AccessClass::PureRA, true},
+      {EncodingType::Constant, "Constant", AccessClass::PureRA, true},
+      {EncodingType::Dictionary, "Dictionary", AccessClass::PureRA, true},
+      {EncodingType::MainlyConstant, "MainlyConstant", AccessClass::PureSeq,
+       true},
+      {EncodingType::RLE, "RLE", AccessClass::PureSeq, true},
+      {EncodingType::Varint, "Varint", AccessClass::PureSeq, true},
+  };
+}
+
+inline AccessClass accessClassOf(EncodingType t) {
+  for (const auto& e : encodingInventory()) {
+    if (e.type == t) return e.accessClass;
+  }
+  return AccessClass::PureSeq;
+}
+
+struct AblationRung {
+  std::string name;
+  std::unordered_set<EncodingType> allowed;
+  AccessClass worstAllowed;
+  bool costModelConsistent;
+};
+
+inline std::vector<AblationRung> combinedLadder() {
+  std::vector<AblationRung> rungs;
+
+  rungs.push_back(
+      {"trivial_only",
+       {EncodingType::Trivial},
+       AccessClass::PureRA,
+       true});
+
+  rungs.push_back(
+      {"pure_ra",
+       {EncodingType::Trivial, EncodingType::FixedBitWidth,
+        EncodingType::Constant, EncodingType::Dictionary},
+       AccessClass::PureRA,
+       true});
+
+  rungs.push_back(
+      {"full_set",
+       {EncodingType::Trivial, EncodingType::FixedBitWidth,
+        EncodingType::Constant, EncodingType::Dictionary,
+        EncodingType::MainlyConstant, EncodingType::RLE, EncodingType::Varint},
+       AccessClass::PureSeq,
+       true});
+
+  return rungs;
+}
+
+namespace detail_ablation {
+using namespace facebook::nimble::detail::subintsplit;
+
+inline double bestCostBitsRestricted(
+    const SegmentMetrics& m,
+    size_t numValues,
+    int bitWidth,
+    EncodingType& bestEncoding,
+    const std::unordered_set<EncodingType>& allowed) noexcept {
+  double best = std::numeric_limits<double>::infinity();
+  auto consider = [&](double cost, EncodingType type) noexcept {
+    if (allowed.count(type) && cost < best) {
+      best = cost;
+      bestEncoding = type;
+    }
+  };
+
+  consider(trivialCostBits(m, numValues, bitWidth), EncodingType::Trivial);
+  consider(
+      fixedBitWidthCostBits(m, numValues, bitWidth),
+      EncodingType::FixedBitWidth);
+  consider(constantCostBits(m, numValues, bitWidth), EncodingType::Constant);
+  consider(
+      mainlyConstantCostBits(m, numValues, bitWidth),
+      EncodingType::MainlyConstant);
+  consider(rleCostBits(m, numValues, bitWidth), EncodingType::RLE);
+  consider(varintCostBits(m, numValues, bitWidth), EncodingType::Varint);
+  if (allowed.count(EncodingType::Dictionary) && m.uniqueCount > 0 &&
+      (m.uniqueCountCapped || m.uniqueCount < numValues / 2)) {
+    consider(
+        dictionaryCostBits(m, numValues, bitWidth), EncodingType::Dictionary);
+  }
+  return best;
+}
+
+inline SelectorResult selectSplitsRestricted(
+    const std::vector<uint64_t>& samples,
+    int kBits,
+    size_t fullCount,
+    const SelectorConfig& cfg,
+    const std::unordered_set<EncodingType>& allowed) {
+  if (samples.empty() || kBits <= 0) return {};
+  kBits = std::min(kBits, 64);
+
+  const MetricFlags requiredFlags = allCostModelRequiredFlags();
+  MetricCollector collector;
+
+  struct SegmentChoice {
+    double cost{std::numeric_limits<double>::infinity()};
+    EncodingType encoding{EncodingType::Trivial};
+  };
+
+  const int sz = kBits;
+  std::vector<SegmentChoice> bestCost(sz * sz);
+
+  BitRangeExtractor extractor(samples);
+  const size_t numSamples = samples.size();
+
+  for (int l = 0; l < sz; ++l) {
+    extractor.reset(l);
+    for (int r = l; r < sz; ++r) {
+      extractor.extend(r);
+      const auto& segValues = extractor.values();
+      const SegmentMetrics metrics =
+          collector.compute(segValues, requiredFlags);
+      const int bitWidth = r - l + 1;
+
+      EncodingType bestEnc = EncodingType::Trivial;
+      const double perSampleCost = bestCostBitsRestricted(
+          metrics, numSamples, bitWidth, bestEnc, allowed);
+
+      const double fullCost = perSampleCost *
+          static_cast<double>(fullCount) / static_cast<double>(numSamples);
+
+      bestCost[l * sz + r] = {fullCost, bestEnc};
+    }
+  }
+
+  std::vector<double> dp(sz + 1, std::numeric_limits<double>::infinity());
+  std::vector<int> prev(sz + 1, -1);
+  std::vector<EncodingType> chosen(sz + 1, EncodingType::Trivial);
+  dp[0] = 0.0;
+
+  for (int i = 1; i <= sz; ++i) {
+    for (int j = 0; j < i; ++j) {
+      const int width = i - j;
+      if (width < cfg.minSegmentWidth) continue;
+      const auto& choice = bestCost[j * sz + (i - 1)];
+      if (!std::isfinite(choice.cost)) continue;
+      const double splitCost = (j == 0) ? 0.0 : cfg.splitPenalty;
+      const double candidate = dp[j] + choice.cost + splitCost;
+      if (candidate < dp[i]) {
+        dp[i] = candidate;
+        prev[i] = j;
+        chosen[i] = choice.encoding;
+      }
+    }
+  }
+
+  SelectorResult result;
+  result.totalCost = dp[sz];
+
+  if (!std::isfinite(result.totalCost)) {
+    SegmentPlan fallback;
+    fallback.bitStart = 0;
+    fallback.bitEnd = sz - 1;
+    fallback.encoding = EncodingType::Trivial;
+    fallback.cost = bestCost[0 * sz + (sz - 1)].cost;
+    result.segments.push_back(fallback);
+    result.totalCost = fallback.cost;
+    return result;
+  }
+
+  int idx = sz;
+  while (idx > 0) {
+    const int start = prev[idx];
+    if (start < 0) break;
+    SegmentPlan plan;
+    plan.bitStart = start;
+    plan.bitEnd = idx - 1;
+    plan.encoding = chosen[idx];
+    plan.cost = bestCost[start * sz + (idx - 1)].cost;
+    result.segments.push_back(plan);
+    idx = start;
+  }
+  std::reverse(result.segments.begin(), result.segments.end());
+  return result;
+}
+
+} // namespace detail_ablation
+
+} // namespace facebook::nimble::mlidc
+
+#endif // NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS

--- a/dwio/nimble/ML_ID_Compression/Axes.h
+++ b/dwio/nimble/ML_ID_Compression/Axes.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -23,30 +24,31 @@
 namespace facebook::nimble::mlidc {
 
 inline std::vector<size_t> logSpaced(size_t lo, size_t hi, size_t steps) {
-    std::vector<size_t> out;
-    if (steps == 0) return out;
-    out.reserve(steps);
-    if (steps == 1 || lo >= hi) { out.push_back(lo); return out; }
-    const double lgLo = std::log2(static_cast<double>(lo));
-    const double lgHi = std::log2(static_cast<double>(hi));
-    for (size_t i = 0; i < steps; ++i) {
-        const double f = static_cast<double>(i) / static_cast<double>(steps - 1);
-        out.push_back(static_cast<size_t>(std::llround(std::exp2(lgLo + f * (lgHi - lgLo)))));
-    }
-    out.erase(std::unique(out.begin(), out.end()), out.end());
-    return out;
+  std::vector<size_t> out;
+  if (steps == 0) return out;
+  out.reserve(steps);
+  if (steps == 1 || lo >= hi) { out.push_back(lo); return out; }
+  const double lgLo = std::log2(static_cast<double>(lo));
+  const double lgHi = std::log2(static_cast<double>(hi));
+  for (size_t i = 0; i < steps; ++i) {
+    const double f = static_cast<double>(i) / static_cast<double>(steps - 1);
+    out.push_back(static_cast<size_t>(
+        std::llround(std::exp2(lgLo + f * (lgHi - lgLo)))));
+  }
+  out.erase(std::unique(out.begin(), out.end()), out.end());
+  return out;
 }
 
 inline std::vector<double> linSpaced(double lo, double hi, size_t steps) {
-    std::vector<double> out;
-    if (steps == 0) return out;
-    out.reserve(steps);
-    if (steps == 1) { out.push_back(hi); return out; }
-    for (size_t i = 0; i < steps; ++i) {
-        const double f = static_cast<double>(i) / static_cast<double>(steps - 1);
-        out.push_back(lo + f * (hi - lo));
-    }
-    return out;
+  std::vector<double> out;
+  if (steps == 0) return out;
+  out.reserve(steps);
+  if (steps == 1) { out.push_back(hi); return out; }
+  for (size_t i = 0; i < steps; ++i) {
+    const double f = static_cast<double>(i) / static_cast<double>(steps - 1);
+    out.push_back(lo + f * (hi - lo));
+  }
+  return out;
 }
 
-}  // namespace facebook::nimble::mlidc
+} // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/Axes.h
+++ b/dwio/nimble/ML_ID_Compression/Axes.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace facebook::nimble::mlidc {
+
+inline std::vector<size_t> logSpaced(size_t lo, size_t hi, size_t steps) {
+    std::vector<size_t> out;
+    if (steps == 0) return out;
+    out.reserve(steps);
+    if (steps == 1 || lo >= hi) { out.push_back(lo); return out; }
+    const double lgLo = std::log2(static_cast<double>(lo));
+    const double lgHi = std::log2(static_cast<double>(hi));
+    for (size_t i = 0; i < steps; ++i) {
+        const double f = static_cast<double>(i) / static_cast<double>(steps - 1);
+        out.push_back(static_cast<size_t>(std::llround(std::exp2(lgLo + f * (lgHi - lgLo)))));
+    }
+    out.erase(std::unique(out.begin(), out.end()), out.end());
+    return out;
+}
+
+inline std::vector<double> linSpaced(double lo, double hi, size_t steps) {
+    std::vector<double> out;
+    if (steps == 0) return out;
+    out.reserve(steps);
+    if (steps == 1) { out.push_back(hi); return out; }
+    for (size_t i = 0; i < steps; ++i) {
+        const double f = static_cast<double>(i) / static_cast<double>(steps - 1);
+        out.push_back(lo + f * (hi - lo));
+    }
+    return out;
+}
+
+}  // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/BenchCommon.h
+++ b/dwio/nimble/ML_ID_Compression/BenchCommon.h
@@ -73,18 +73,17 @@ class NimbleBenchTarget {
   using T = typename EncodingT::cppDataType;
 
   NimbleBenchTarget()
-      : pool_(benchmarks::benchmarkPool()),
-        buffer_(*pool_) {}
+      : pool_(benchmarks::benchmarkPool()) {}
 
   // Encode data.  Destroys any previously encoded state.
   void encode(
       const Vector<T>& data,
       const Encoding::Options& options = {},
       bool realNestedSelection = false) {
-    buffer_ = Buffer{*pool_};
+    Buffer buf{*pool_};
     encoded_ = std::string(
         test::Encoder<EncodingT>::encode(
-            buffer_, data, CompressionType::Uncompressed, options,
+            buf, data, CompressionType::Uncompressed, options,
             realNestedSelection));
     // Construct the Encoding directly from the encoded bytes rather than
     // re-encoding via createEncoding(), which would silently drop
@@ -150,7 +149,6 @@ class NimbleBenchTarget {
 
  private:
   std::shared_ptr<velox::memory::MemoryPool> pool_;
-  Buffer buffer_;
   std::string encoded_;
   std::unique_ptr<Encoding> encoding_;
 };

--- a/dwio/nimble/ML_ID_Compression/BenchCommon.h
+++ b/dwio/nimble/ML_ID_Compression/BenchCommon.h
@@ -1,0 +1,583 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// BenchCommon.h — shared infrastructure for the ML ID Compression benchmark
+// suite.  Provides NimbleBenchTarget<E>, CsvResultWriter, RunManifest,
+// EncoderEntry, DatasetEntry, and seeded dataset generators.
+//
+// Gated on NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS because it transitively
+// includes SubIntSplitEncoding.h via TestUtils.h.
+
+#pragma once
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <cstdint>
+#include <fstream>
+#include <functional>
+#include <map>
+#include <span>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <folly/FileUtil.h>
+#include <folly/Random.h>
+#include <folly/dynamic.h>
+#include <folly/json/json.h>
+#include <gflags/gflags.h>
+#include <glog/logging.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+
+// ---------------------------------------------------------------------------
+// CLI flags shared across benchmark binaries
+// ---------------------------------------------------------------------------
+
+// Defined in BenchCommonFlags.cpp; link nimble_mlidc_common to get them.
+DECLARE_string(mlidc_output_csv);
+DECLARE_string(mlidc_output_manifest);
+DECLARE_int32(mlidc_rows);
+DECLARE_int32(mlidc_iters);
+DECLARE_int64(mlidc_seed);
+
+namespace facebook::nimble::mlidc {
+
+// ---------------------------------------------------------------------------
+// NimbleBenchTarget<EncodingT>
+// ---------------------------------------------------------------------------
+// Wraps a single encode/decode cycle.  After encode() the object holds the
+// serialised bytes in an internal Buffer together with a live Encoding object
+// ready for decode operations.
+
+template <typename EncodingT>
+class NimbleBenchTarget {
+ public:
+  using T = typename EncodingT::cppDataType;
+
+  NimbleBenchTarget()
+      : pool_(benchmarks::benchmarkPool()),
+        buffer_(*pool_) {}
+
+  // Encode data.  Destroys any previously encoded state.
+  void encode(
+      const Vector<T>& data,
+      const Encoding::Options& options = {},
+      bool realNestedSelection = false) {
+    buffer_ = Buffer{*pool_};
+    encoded_ = std::string(
+        test::Encoder<EncodingT>::encode(
+            buffer_, data, CompressionType::Uncompressed, options,
+            realNestedSelection));
+    // Construct the Encoding directly from the encoded bytes rather than
+    // re-encoding via createEncoding(), which would silently drop
+    // realNestedSelection and produce different encoded data.
+    encoding_ = std::make_unique<EncodingT>(
+        *pool_,
+        std::string_view(encoded_),
+        benchmarks::nullFactory(),
+        options);
+  }
+
+  // reset + materialize all n rows into dst.
+  void materializeAll(T* dst, uint32_t n) {
+    encoding_->reset();
+    encoding_->materialize(n, dst);
+  }
+
+  // reset + skip begin rows + materialize count rows into dst.
+  void materializeRange(uint32_t begin, uint32_t count, T* dst) {
+    encoding_->reset();
+    if (begin > 0) {
+      encoding_->skip(begin);
+    }
+    encoding_->materialize(count, dst);
+  }
+
+  // Gather pattern: for each [begin, count) range in sorted order, skip then
+  // materialize.  dst must have space for the total number of rows across all
+  // ranges.
+  void skipThenMaterialize(
+      const std::vector<std::pair<uint32_t, uint32_t>>& ranges,
+      T* dst) {
+    encoding_->reset();
+    uint32_t cursor = 0;
+    for (auto& [begin, count] : ranges) {
+      if (begin > cursor) {
+        encoding_->skip(begin - cursor);
+        cursor = begin;
+      }
+      encoding_->materialize(count, dst);
+      dst += count;
+      cursor += count;
+    }
+  }
+
+  std::span<const std::byte> payloadBytes() const {
+    return {
+        reinterpret_cast<const std::byte*>(encoded_.data()), encoded_.size()};
+  }
+
+  size_t payloadSize() const {
+    return encoded_.size();
+  }
+
+  // Spans covering all internal buffer regions — useful for cache eviction.
+  std::vector<std::span<const std::byte>> internalBuffers() const {
+    return {payloadBytes()};
+  }
+
+  Encoding* encoding() {
+    return encoding_.get();
+  }
+
+ private:
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  Buffer buffer_;
+  std::string encoded_;
+  std::unique_ptr<Encoding> encoding_;
+};
+
+// ---------------------------------------------------------------------------
+// CsvResultWriter
+// ---------------------------------------------------------------------------
+
+class CsvResultWriter {
+ public:
+  CsvResultWriter(
+      const std::string& path,
+      std::vector<std::string> columns)
+      : path_(path), columns_(std::move(columns)) {
+    file_.open(path_, std::ios::out | std::ios::trunc);
+    NIMBLE_CHECK(file_.is_open(), "Cannot open CSV output: " + path_);
+    // Write header.
+    for (size_t i = 0; i < columns_.size(); ++i) {
+      if (i) {
+        file_ << ',';
+      }
+      file_ << columns_[i];
+    }
+    file_ << '\n';
+  }
+
+  void beginRow() {
+    row_.clear();
+  }
+
+  void set(const std::string& col, const std::string& value) {
+    // Minimal CSV quoting: wrap in quotes if value contains comma, quote, or
+    // newline.
+    if (value.find_first_of(",\"\n") != std::string::npos) {
+      std::string quoted = "\"";
+      for (char c : value) {
+        if (c == '"') {
+          quoted += "\"\"";
+        } else {
+          quoted += c;
+        }
+      }
+      quoted += '"';
+      row_[col] = std::move(quoted);
+    } else {
+      row_[col] = value;
+    }
+  }
+
+  void set(const std::string& col, int64_t value) {
+    row_[col] = std::to_string(value);
+  }
+
+  void set(const std::string& col, double value) {
+    std::ostringstream oss;
+    oss << value;
+    row_[col] = oss.str();
+  }
+
+  void endRow() {
+    for (size_t i = 0; i < columns_.size(); ++i) {
+      if (i) {
+        file_ << ',';
+      }
+      auto it = row_.find(columns_[i]);
+      if (it != row_.end()) {
+        file_ << it->second;
+      }
+      // Missing column → empty (null in CSV).
+    }
+    file_ << '\n';
+  }
+
+  void flush() {
+    file_.flush();
+  }
+
+ private:
+  std::string path_;
+  std::vector<std::string> columns_;
+  std::ofstream file_;
+  std::map<std::string, std::string> row_;
+};
+
+// ---------------------------------------------------------------------------
+// RunManifest
+// ---------------------------------------------------------------------------
+
+namespace detail {
+
+inline std::string readFirstLine(const std::string& path) {
+  std::ifstream f(path);
+  if (!f.is_open()) {
+    return "";
+  }
+  std::string line;
+  std::getline(f, line);
+  return line;
+}
+
+inline std::string readFile(const std::string& path) {
+  std::ifstream f(path);
+  if (!f.is_open()) {
+    return "";
+  }
+  std::ostringstream ss;
+  ss << f.rdbuf();
+  std::string s = ss.str();
+  // Strip trailing newline.
+  while (!s.empty() && (s.back() == '\n' || s.back() == '\r')) {
+    s.pop_back();
+  }
+  return s;
+}
+
+inline std::string cpuModel() {
+  std::ifstream f("/proc/cpuinfo");
+  if (!f.is_open()) {
+    return "unknown";
+  }
+  std::string line;
+  while (std::getline(f, line)) {
+    if (line.rfind("model name", 0) == 0) {
+      auto colon = line.find(':');
+      if (colon != std::string::npos) {
+        auto s = line.substr(colon + 1);
+        // ltrim
+        s.erase(0, s.find_first_not_of(" \t"));
+        return s;
+      }
+    }
+  }
+  return "unknown";
+}
+
+inline folly::dynamic cacheTopology() {
+  folly::dynamic result = folly::dynamic::object;
+  const std::string base = "/sys/devices/system/cpu/cpu0/cache/";
+  for (int idx = 0; idx < 8; ++idx) {
+    std::string dir = base + "index" + std::to_string(idx) + "/";
+    std::string level = readFile(dir + "level");
+    std::string type = readFile(dir + "type");
+    std::string size = readFile(dir + "size");
+    if (level.empty() && type.empty()) {
+      break;
+    }
+    std::string key = "L" + level + "-" + type;
+    result[key] = size;
+  }
+  return result;
+}
+
+inline std::string scalingGovernor() {
+  return readFile(
+      "/sys/devices/system/cpu/cpu0/cpufreq/scaling_governor");
+}
+
+inline std::string hostname() {
+  char buf[256] = {};
+  if (::gethostname(buf, sizeof(buf)) == 0) {
+    return buf;
+  }
+  return "unknown";
+}
+
+} // namespace detail
+
+// Write a JSON manifest sidecar describing the current run environment.
+inline void writeRunManifest(const std::string& path) {
+  folly::dynamic manifest = folly::dynamic::object;
+
+  manifest["hostname"] = detail::hostname();
+  manifest["cpu_model"] = detail::cpuModel();
+  manifest["cache_topology"] = detail::cacheTopology();
+  manifest["scaling_governor"] = detail::scalingGovernor();
+  manifest["compiler_version"] = __VERSION__;
+
+#ifdef MLIDC_GIT_SHA
+  manifest["build_sha"] = MLIDC_GIT_SHA;
+#else
+  manifest["build_sha"] = "unknown";
+#endif
+
+  // Reproduce key flags.
+  manifest["flags"] = folly::dynamic::object(
+      "mlidc_rows", FLAGS_mlidc_rows)(
+      "mlidc_iters", FLAGS_mlidc_iters)(
+      "mlidc_seed", FLAGS_mlidc_seed);
+
+  auto json = folly::toPrettyJson(manifest);
+  if (folly::writeFile(json, path.c_str())) {
+    LOG(INFO) << "Manifest written to " << path;
+  } else {
+    LOG(WARNING) << "Failed to write manifest to " << path;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// EncoderEntry
+// ---------------------------------------------------------------------------
+
+template <typename T>
+struct NimbleBenchTargetBase {
+  virtual ~NimbleBenchTargetBase() = default;
+  virtual void encode(const Vector<T>& data, const Encoding::Options& opts) = 0;
+  virtual void materializeAll(T* dst, uint32_t n) = 0;
+  virtual void materializeRange(uint32_t begin, uint32_t count, T* dst) = 0;
+  virtual void skipThenMaterialize(
+      const std::vector<std::pair<uint32_t, uint32_t>>& ranges,
+      T* dst) = 0;
+  virtual size_t payloadSize() const = 0;
+  virtual std::vector<std::span<const std::byte>> internalBuffers() const = 0;
+};
+
+template <typename EncodingT>
+struct NimbleBenchTargetImpl : NimbleBenchTargetBase<typename EncodingT::cppDataType> {
+  using T = typename EncodingT::cppDataType;
+
+  NimbleBenchTarget<EncodingT> target;
+
+  void encode(const Vector<T>& data, const Encoding::Options& opts) override {
+    target.encode(data, opts);
+  }
+  void materializeAll(T* dst, uint32_t n) override {
+    target.materializeAll(dst, n);
+  }
+  void materializeRange(uint32_t begin, uint32_t count, T* dst) override {
+    target.materializeRange(begin, count, dst);
+  }
+  void skipThenMaterialize(
+      const std::vector<std::pair<uint32_t, uint32_t>>& ranges,
+      T* dst) override {
+    target.skipThenMaterialize(ranges, dst);
+  }
+  size_t payloadSize() const override {
+    return target.payloadSize();
+  }
+  std::vector<std::span<const std::byte>> internalBuffers() const override {
+    return target.internalBuffers();
+  }
+};
+
+template <typename T>
+struct EncoderEntry {
+  std::string name;
+  std::string family;   // "baseline", "sis-manual", "sis-auto", "fpe-index"
+  std::string variant;
+  bool isSequential{true};
+  bool fastSkip{false};
+  bool randomAccess{false};
+
+  // Factory: construct a fresh target and encode the given data.
+  std::function<std::unique_ptr<NimbleBenchTargetBase<T>>(
+      const Vector<T>&,
+      const Encoding::Options&)>
+      factory;
+};
+
+// Convenience builder for a concrete EncodingT.
+template <typename EncodingT>
+EncoderEntry<typename EncodingT::cppDataType> makeEncoderEntry(
+    std::string name,
+    std::string family,
+    std::string variant,
+    bool isSequential = true,
+    bool fastSkip = false,
+    bool randomAccess = false) {
+  using T = typename EncodingT::cppDataType;
+  EncoderEntry<T> entry;
+  entry.name = std::move(name);
+  entry.family = std::move(family);
+  entry.variant = std::move(variant);
+  entry.isSequential = isSequential;
+  entry.fastSkip = fastSkip;
+  entry.randomAccess = randomAccess;
+  entry.factory = [](const Vector<T>& data, const Encoding::Options& opts) {
+    auto impl = std::make_unique<NimbleBenchTargetImpl<EncodingT>>();
+    impl->encode(data, opts);
+    return impl;
+  };
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+// DatasetEntry and default int64 datasets
+// ---------------------------------------------------------------------------
+
+template <typename T>
+struct DatasetEntry {
+  std::string name;
+  std::function<Vector<T>(uint32_t n, uint64_t seed)> generate;
+};
+
+namespace detail {
+
+// Seed-controlled wrappers around BenchmarkUtils generators.  The seed is
+// applied by seeding folly::Random before calling the generator — the
+// generators use folly::Random::secureRand* which is thread-local state
+// (unseedable), so we provide a best-effort deterministic path via a simple
+// linear-congruential RNG to fill the buffer directly.
+
+template <typename T>
+Vector<T> makeRandomSeeded(uint32_t n, uint64_t seed) {
+  auto& pool = benchmarks::benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  // LCG for reproducibility (Knuth parameters).
+  uint64_t state = seed ^ 0x9e3779b97f4a7c15ULL;
+  for (uint32_t i = 0; i < n; ++i) {
+    state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+    if constexpr (sizeof(T) <= 4) {
+      data[i] = static_cast<T>(static_cast<uint32_t>(state >> 33));
+    } else {
+      uint64_t hi = state;
+      state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+      data[i] = static_cast<T>((hi & 0xFFFFFFFF00000000ULL) | (state >> 33));
+    }
+  }
+  return data;
+}
+
+template <typename T>
+Vector<T> makeNarrowSeeded(int bitWidth, uint32_t n, uint64_t seed) {
+  auto& pool = benchmarks::benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  using U = std::make_unsigned_t<T>;
+  U mask = (bitWidth >= static_cast<int>(sizeof(T) * 8))
+      ? static_cast<U>(~U{0})
+      : (static_cast<U>(1) << bitWidth) - 1;
+  uint64_t state = seed ^ 0x9e3779b97f4a7c15ULL;
+  for (uint32_t i = 0; i < n; ++i) {
+    state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+    data[i] = static_cast<T>(static_cast<U>(state >> (64 - sizeof(T) * 8)) & mask);
+  }
+  return data;
+}
+
+template <typename T>
+Vector<T> makeIncreasingSeeded(uint32_t n, uint64_t seed) {
+  auto& pool = benchmarks::benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  uint64_t state = seed ^ 0x9e3779b97f4a7c15ULL;
+  T val = 0;
+  for (uint32_t i = 0; i < n; ++i) {
+    state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+    val += static_cast<T>((state >> 61) + 1); // delta in [1,8]
+    data[i] = val;
+  }
+  return data;
+}
+
+template <typename T>
+Vector<T> makeLowCardinalitySeeded(
+    uint32_t cardinality,
+    uint32_t n,
+    uint64_t seed) {
+  auto& pool = benchmarks::benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  uint64_t state = seed ^ 0x9e3779b97f4a7c15ULL;
+  for (uint32_t i = 0; i < n; ++i) {
+    state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+    data[i] = static_cast<T>((state >> 33) % cardinality);
+  }
+  return data;
+}
+
+template <typename T>
+Vector<T> makeRunLengthSeeded(uint32_t n, uint64_t seed) {
+  auto& pool = benchmarks::benchmarkPool();
+  Vector<T> data{pool.get()};
+  data.resize(n);
+  uint64_t state = seed ^ 0x9e3779b97f4a7c15ULL;
+  auto next = [&]() -> uint64_t {
+    state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+    return state >> 33;
+  };
+  uint32_t i = 0;
+  while (i < n) {
+    T val = static_cast<T>(next() % 1000);
+    uint32_t runLen = static_cast<uint32_t>(10 + next() % 50);
+    runLen = std::min(runLen, n - i);
+    for (uint32_t j = 0; j < runLen; ++j) {
+      data[i + j] = val;
+    }
+    i += runLen;
+  }
+  return data;
+}
+
+} // namespace detail
+
+// Default dataset suite for int64 — covers the main distribution shapes
+// expected for ML ID workloads.
+template <typename T>
+std::vector<DatasetEntry<T>> defaultInt64Datasets() {
+  std::vector<DatasetEntry<T>> out;
+
+  out.push_back({"uniform-64bit", [](uint32_t n, uint64_t seed) {
+                   return detail::makeRandomSeeded<T>(n, seed);
+                 }});
+
+  out.push_back({"narrow-20bit", [](uint32_t n, uint64_t seed) {
+                   return detail::makeNarrowSeeded<T>(20, n, seed);
+                 }});
+
+  out.push_back({"narrow-40bit", [](uint32_t n, uint64_t seed) {
+                   return detail::makeNarrowSeeded<T>(40, n, seed);
+                 }});
+
+  out.push_back({"increasing-small-delta", [](uint32_t n, uint64_t seed) {
+                   return detail::makeIncreasingSeeded<T>(n, seed);
+                 }});
+
+  out.push_back({"low-cardinality-256", [](uint32_t n, uint64_t seed) {
+                   return detail::makeLowCardinalitySeeded<T>(256, n, seed);
+                 }});
+
+  out.push_back({"run-length", [](uint32_t n, uint64_t seed) {
+                   return detail::makeRunLengthSeeded<T>(n, seed);
+                 }});
+
+  return out;
+}
+
+} // namespace facebook::nimble::mlidc
+
+#endif // NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS

--- a/dwio/nimble/ML_ID_Compression/BenchCommon.h
+++ b/dwio/nimble/ML_ID_Compression/BenchCommon.h
@@ -14,17 +14,11 @@
  * limitations under the License.
  */
 
-// BenchCommon.h — shared infrastructure for the ML ID Compression benchmark
-// suite.  Provides NimbleBenchTarget<E>, CsvResultWriter, RunManifest,
-// EncoderEntry, DatasetEntry, and seeded dataset generators.
-//
-// Gated on NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS because it transitively
-// includes SubIntSplitEncoding.h via TestUtils.h.
-
 #pragma once
 
 #ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 
+#include <array>
 #include <cstdint>
 #include <fstream>
 #include <functional>
@@ -43,6 +37,7 @@
 
 #include "dwio/nimble/common/Buffer.h"
 #include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
 #include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
 #include "dwio/nimble/encodings/common/Encoding.h"
 #include "dwio/nimble/encodings/tests/TestUtils.h"
@@ -239,16 +234,6 @@ class CsvResultWriter {
 
 namespace detail {
 
-inline std::string readFirstLine(const std::string& path) {
-  std::ifstream f(path);
-  if (!f.is_open()) {
-    return "";
-  }
-  std::string line;
-  std::getline(f, line);
-  return line;
-}
-
 inline std::string readFile(const std::string& path) {
   std::ifstream f(path);
   if (!f.is_open()) {
@@ -285,20 +270,12 @@ inline std::string cpuModel() {
 }
 
 inline folly::dynamic cacheTopology() {
-  folly::dynamic result = folly::dynamic::object;
-  const std::string base = "/sys/devices/system/cpu/cpu0/cache/";
-  for (int idx = 0; idx < 8; ++idx) {
-    std::string dir = base + "index" + std::to_string(idx) + "/";
-    std::string level = readFile(dir + "level");
-    std::string type = readFile(dir + "type");
-    std::string size = readFile(dir + "size");
-    if (level.empty() && type.empty()) {
-      break;
-    }
-    std::string key = "L" + level + "-" + type;
-    result[key] = size;
-  }
-  return result;
+  auto topo = CacheTopology::detect();
+  return folly::dynamic::object(
+      "l1d_bytes", static_cast<int64_t>(topo.l1dBytes))(
+      "l2_bytes", static_cast<int64_t>(topo.l2Bytes))(
+      "llc_bytes", static_cast<int64_t>(topo.llcBytes))(
+      "line_bytes", static_cast<int64_t>(topo.lineBytes));
 }
 
 inline std::string scalingGovernor() {
@@ -574,6 +551,69 @@ std::vector<DatasetEntry<T>> defaultInt64Datasets() {
                  }});
 
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// Default 9-encoder suite shared across decode/encode/smoke drivers.
+// ---------------------------------------------------------------------------
+
+template <typename T>
+std::vector<EncoderEntry<T>> buildDefaultEncoders() {
+  std::vector<EncoderEntry<T>> encoders;
+
+  encoders.push_back(makeEncoderEntry<TrivialEncoding<T>>(
+      "Trivial", "Baseline", "trivial", true, true, false));
+  encoders.push_back(makeEncoderEntry<FixedBitWidthEncoding<T>>(
+      "FixedBitWidth", "Baseline", "fbw", true, true, false));
+  encoders.push_back(makeEncoderEntry<DictionaryEncoding<T>>(
+      "Dictionary", "Baseline", "dict", true, false, false));
+  encoders.push_back(makeEncoderEntry<RLEEncoding<T>>(
+      "RLE", "Baseline", "rle", true, true, false));
+
+  const std::array<std::string, 4> fpeNames = {
+      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
+  const std::array<bool, 4> fpeRA = {false, true, true, true};
+  const std::array<bool, 4> fpeSkip = {false, true, true, true};
+
+  for (int idx = 0; idx < 4; ++idx) {
+    EncoderEntry<T> entry;
+    entry.name = "FPE/" + fpeNames[idx];
+    entry.family = "FrequencyPartition";
+    entry.variant = fpeNames[idx];
+    entry.isSequential = true;
+    entry.fastSkip = fpeSkip[idx];
+    entry.randomAccess = fpeRA[idx];
+    entry.factory = [idx](const Vector<T>& data,
+                          const Encoding::Options& opts) {
+      auto impl = std::make_unique<
+          NimbleBenchTargetImpl<FrequencyPartitionEncoding<T>>>();
+      Encoding::Options o = opts;
+      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
+      impl->target.encode(data, o);
+      return std::unique_ptr<NimbleBenchTargetBase<T>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+
+  {
+    EncoderEntry<T> entry;
+    entry.name = "SIS/realNested";
+    entry.family = "SubIntSplit";
+    entry.variant = "real_nested";
+    entry.isSequential = false;
+    entry.fastSkip = false;
+    entry.randomAccess = false;
+    entry.factory = [](const Vector<T>& data,
+                       const Encoding::Options& opts) {
+      auto impl =
+          std::make_unique<NimbleBenchTargetImpl<SubIntSplitEncoding<T>>>();
+      impl->target.encode(data, opts, /*realNestedSelection=*/true);
+      return std::unique_ptr<NimbleBenchTargetBase<T>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+
+  return encoders;
 }
 
 } // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/BenchCommonFlags.cpp
+++ b/dwio/nimble/ML_ID_Compression/BenchCommonFlags.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Defines the gflags shared across all ML_ID_Compression benchmark drivers.
+// Declared in BenchCommon.h; defined here in exactly one TU.
+
+#include <gflags/gflags.h>
+
+DEFINE_string(mlidc_output_csv, "mlidc_results.csv", "CSV output path");
+DEFINE_string(
+    mlidc_output_manifest,
+    "mlidc_manifest.json",
+    "JSON manifest sidecar path");
+DEFINE_int32(mlidc_rows, 100000, "Number of rows per dataset instance");
+DEFINE_int32(mlidc_iters, 5, "Benchmark iterations per (encoder, dataset) pair");
+DEFINE_int64(mlidc_seed, 42, "Base random seed for dataset generators");

--- a/dwio/nimble/ML_ID_Compression/CMakeLists.txt
+++ b/dwio/nimble/ML_ID_Compression/CMakeLists.txt
@@ -1,0 +1,58 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---------------------------------------------------------------------------
+# Shared library used by all drivers in this benchmark suite.
+# Contains the gflag definitions (BenchCommonFlags.cpp) so that each driver
+# links exactly one copy; headers are exposed via PUBLIC include dirs.
+# ---------------------------------------------------------------------------
+add_library(nimble_mlidc_common BenchCommonFlags.cpp)
+
+target_include_directories(
+  nimble_mlidc_common
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(
+  nimble_mlidc_common
+  PUBLIC
+    gflags
+)
+
+# ---------------------------------------------------------------------------
+# bench_compression: encodes a column of ML IDs under every candidate
+# encoding and reports compressed size + round-trip latency.
+# ---------------------------------------------------------------------------
+add_executable(nimble_mlidc_compression bench_compression.cpp)
+
+target_link_libraries(
+  nimble_mlidc_compression
+  nimble_mlidc_common
+  nimble_encodings
+  nimble_encodings_tests_utils
+  nimble_common
+  Folly::folly
+  velox_memory
+  gflags
+)
+
+# ---------------------------------------------------------------------------
+# Future driver targets (placeholders)
+# ---------------------------------------------------------------------------
+# add_executable(nimble_mlidc_gather      bench_gather.cpp)
+# target_link_libraries(nimble_mlidc_gather ...)
+#
+# add_executable(nimble_mlidc_skip        bench_skip.cpp)
+# target_link_libraries(nimble_mlidc_skip ...)

--- a/dwio/nimble/ML_ID_Compression/CMakeLists.txt
+++ b/dwio/nimble/ML_ID_Compression/CMakeLists.txt
@@ -43,6 +43,7 @@ target_link_libraries(
   nimble_encodings
   nimble_encodings_tests_utils
   nimble_common
+  openzl_cpp
   Folly::folly
   velox_memory
   gflags
@@ -59,6 +60,7 @@ target_link_libraries(
   nimble_encodings
   nimble_encodings_tests_utils
   nimble_common
+  openzl_cpp
   Folly::folly
   velox_memory
   gflags
@@ -91,6 +93,7 @@ target_link_libraries(
   nimble_encodings
   nimble_encodings_tests_utils
   nimble_common
+  openzl_cpp
   Folly::folly
   velox_memory
   gflags

--- a/dwio/nimble/ML_ID_Compression/CMakeLists.txt
+++ b/dwio/nimble/ML_ID_Compression/CMakeLists.txt
@@ -65,10 +65,130 @@ target_link_libraries(
 )
 
 # ---------------------------------------------------------------------------
-# Future driver targets (placeholders)
+# bench_decode_range: contiguous-range decode throughput heatmap.
 # ---------------------------------------------------------------------------
-# add_executable(nimble_mlidc_gather      bench_gather.cpp)
-# target_link_libraries(nimble_mlidc_gather ...)
-#
-# add_executable(nimble_mlidc_skip        bench_skip.cpp)
-# target_link_libraries(nimble_mlidc_skip ...)
+add_executable(nimble_mlidc_decode_range bench_decode_range.cpp)
+
+target_link_libraries(
+  nimble_mlidc_decode_range
+  nimble_mlidc_common
+  nimble_encodings
+  nimble_encodings_tests_utils
+  nimble_common
+  Folly::folly
+  velox_memory
+  gflags
+)
+
+# ---------------------------------------------------------------------------
+# bench_encode: encode throughput per encoder/dataset pair.
+# ---------------------------------------------------------------------------
+add_executable(nimble_mlidc_encode bench_encode.cpp)
+
+target_link_libraries(
+  nimble_mlidc_encode
+  nimble_mlidc_common
+  nimble_encodings
+  nimble_encodings_tests_utils
+  nimble_common
+  Folly::folly
+  velox_memory
+  gflags
+)
+
+# ---------------------------------------------------------------------------
+# bench_decode_point: single-probe point-lookup latency.
+# ---------------------------------------------------------------------------
+add_executable(nimble_mlidc_decode_point bench_decode_point.cpp)
+
+target_link_libraries(
+  nimble_mlidc_decode_point
+  nimble_mlidc_common
+  nimble_encodings
+  nimble_encodings_tests_utils
+  nimble_common
+  Folly::folly
+  velox_memory
+  gflags
+)
+
+# ---------------------------------------------------------------------------
+# bench_decode_gather: gather-pattern decode throughput.
+# ---------------------------------------------------------------------------
+add_executable(nimble_mlidc_decode_gather bench_decode_gather.cpp)
+
+target_link_libraries(
+  nimble_mlidc_decode_gather
+  nimble_mlidc_common
+  nimble_encodings
+  nimble_encodings_tests_utils
+  nimble_common
+  Folly::folly
+  velox_memory
+  gflags
+)
+
+# ---------------------------------------------------------------------------
+# bench_costmodel_oracle: validates SubIntSplit's DP cost model against an
+# oracle that actually encodes each candidate bit range.
+# ---------------------------------------------------------------------------
+add_executable(nimble_mlidc_costmodel_oracle bench_costmodel_oracle.cpp)
+
+target_link_libraries(
+  nimble_mlidc_costmodel_oracle
+  nimble_mlidc_common
+  nimble_encodings
+  nimble_encodings_tests_utils
+  nimble_common
+  Folly::folly
+  velox_memory
+  gflags
+)
+
+# ---------------------------------------------------------------------------
+# bench_index_oracle: sweeps FPE index types, Pareto frontier, scalarised oracle.
+# ---------------------------------------------------------------------------
+add_executable(nimble_mlidc_index_oracle bench_index_oracle.cpp)
+
+target_link_libraries(
+  nimble_mlidc_index_oracle
+  nimble_mlidc_common
+  nimble_encodings
+  nimble_encodings_tests_utils
+  nimble_common
+  Folly::folly
+  velox_memory
+  gflags
+)
+
+# ---------------------------------------------------------------------------
+# bench_ablation: progressive encoding-set restriction for SIS sections.
+# ---------------------------------------------------------------------------
+add_executable(nimble_mlidc_ablation bench_ablation.cpp)
+
+target_link_libraries(
+  nimble_mlidc_ablation
+  nimble_mlidc_common
+  nimble_encodings
+  nimble_encodings_tests_utils
+  nimble_common
+  Folly::folly
+  velox_memory
+  gflags
+)
+
+# ---------------------------------------------------------------------------
+# bench_smoke: encode + decode correctness check (no timing).
+# ---------------------------------------------------------------------------
+add_executable(nimble_mlidc_smoke bench_smoke.cpp)
+
+target_link_libraries(
+  nimble_mlidc_smoke
+  nimble_mlidc_common
+  nimble_encodings
+  nimble_encodings_tests_utils
+  nimble_common
+  Folly::folly
+  velox_memory
+  gflags
+)

--- a/dwio/nimble/ML_ID_Compression/CMakeLists.txt
+++ b/dwio/nimble/ML_ID_Compression/CMakeLists.txt
@@ -49,6 +49,22 @@ target_link_libraries(
 )
 
 # ---------------------------------------------------------------------------
+# bench_decode_bulk: full-materialization decode throughput.
+# ---------------------------------------------------------------------------
+add_executable(nimble_mlidc_decode_bulk bench_decode_bulk.cpp)
+
+target_link_libraries(
+  nimble_mlidc_decode_bulk
+  nimble_mlidc_common
+  nimble_encodings
+  nimble_encodings_tests_utils
+  nimble_common
+  Folly::folly
+  velox_memory
+  gflags
+)
+
+# ---------------------------------------------------------------------------
 # Future driver targets (placeholders)
 # ---------------------------------------------------------------------------
 # add_executable(nimble_mlidc_gather      bench_gather.cpp)

--- a/dwio/nimble/ML_ID_Compression/CachePolicy.h
+++ b/dwio/nimble/ML_ID_Compression/CachePolicy.h
@@ -84,6 +84,13 @@ inline const char* evictMethodName(EvictMethod m) {
   return "auto";
 }
 
+inline bool parseCacheState(const std::string& text, CacheState& out) {
+  if (text == "hot") { out = CacheState::Hot; return true; }
+  if (text == "cold-payload") { out = CacheState::ColdPayload; return true; }
+  if (text == "cold-all") { out = CacheState::ColdAll; return true; }
+  return false;
+}
+
 struct CacheTopology {
   size_t l1dBytes{};
   size_t l2Bytes{};

--- a/dwio/nimble/ML_ID_Compression/CachePolicy.h
+++ b/dwio/nimble/ML_ID_Compression/CachePolicy.h
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+// Cache-state control for decode measurements.
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <fcntl.h>
+
+#include <fstream>
+#include <sstream>
+
+#if defined(__x86_64__) || defined(__i386__) || defined(_M_X64)
+#define ENCODINGS_BENCH_HAVE_CLFLUSH 1
+#include <immintrin.h>
+#else
+#define ENCODINGS_BENCH_HAVE_CLFLUSH 0
+#endif
+
+namespace facebook::nimble::mlidc {
+
+enum class CacheState {
+  Hot,
+  ColdPayload,
+  ColdAll,
+  ColdFileBuffered,  // posix_fadvise DONTNEED then normal pread
+  ColdFileDirect,    // O_DIRECT bypass (caller opens file with O_DIRECT)
+  ColdSystemDrop,    // /proc/sys/vm/drop_caches (root required, opt-in only)
+};
+enum class EvictMethod { Auto, Clflush, LlcThrash, None };
+
+inline const char* cacheStateName(CacheState s) {
+  switch (s) {
+    case CacheState::Hot:
+      return "hot";
+    case CacheState::ColdPayload:
+      return "cold-payload";
+    case CacheState::ColdAll:
+      return "cold-all";
+    case CacheState::ColdFileBuffered:
+      return "cold-file-buffered";
+    case CacheState::ColdFileDirect:
+      return "cold-file-direct";
+    case CacheState::ColdSystemDrop:
+      return "cold-system-drop";
+  }
+  return "hot";
+}
+
+inline const char* evictMethodName(EvictMethod m) {
+  switch (m) {
+    case EvictMethod::Auto:
+      return "auto";
+    case EvictMethod::Clflush:
+      return "clflush";
+    case EvictMethod::LlcThrash:
+      return "llc-thrash";
+    case EvictMethod::None:
+      return "none";
+  }
+  return "auto";
+}
+
+struct CacheTopology {
+  size_t l1dBytes{};
+  size_t l2Bytes{};
+  size_t llcBytes{};
+  size_t lineBytes{64};
+
+  static CacheTopology detect() {
+    CacheTopology t;
+    for (int idx = 0; idx < 16; ++idx) {
+      const std::string dir = "/sys/devices/system/cpu/cpu0/cache/index" +
+          std::to_string(idx) + "/";
+      const std::string levelStr = readSysfs(dir + "level");
+      if (levelStr.empty())
+        continue;
+      const int level = std::atoi(levelStr.c_str());
+      const std::string type = readSysfs(dir + "type");
+      const size_t bytes = parseSize(readSysfs(dir + "size"));
+      const size_t line = static_cast<size_t>(
+          std::atoi(readSysfs(dir + "coherency_line_size").c_str()));
+      if (line > 0)
+        t.lineBytes = line;
+      if (bytes == 0)
+        continue;
+      const bool isInstruction = (type.rfind("Instruction", 0) == 0);
+      if (level == 1 && !isInstruction)
+        t.l1dBytes = bytes;
+      else if (level == 2 && !isInstruction)
+        t.l2Bytes = bytes;
+      if (!isInstruction && level >= 2 && bytes > t.llcBytes)
+        t.llcBytes = bytes;
+    }
+    return t;
+  }
+
+  std::string describe() const {
+    std::ostringstream os;
+    os << "l1d=" << humanBytes(l1dBytes) << " l2=" << humanBytes(l2Bytes)
+       << " llc=" << humanBytes(llcBytes) << " line=" << lineBytes << "B";
+    return os.str();
+  }
+
+  static std::string humanBytes(size_t bytes) {
+    std::ostringstream os;
+    if (bytes >= (size_t{1} << 20) && bytes % (size_t{1} << 20) == 0)
+      os << (bytes >> 20) << "MiB";
+    else if (bytes >= (size_t{1} << 20))
+      os << (static_cast<double>(bytes) / 1048576.0) << "MiB";
+    else if (bytes >= 1024 && bytes % 1024 == 0)
+      os << (bytes >> 10) << "KiB";
+    else
+      os << bytes << "B";
+    return os.str();
+  }
+
+ private:
+  static std::string readSysfs(const std::string& path) {
+    std::ifstream in(path);
+    if (!in)
+      return {};
+    std::string line;
+    std::getline(in, line);
+    return line;
+  }
+
+  static size_t parseSize(const std::string& s) {
+    if (s.empty())
+      return 0;
+    size_t value = 0;
+    size_t i = 0;
+    for (; i < s.size() && s[i] >= '0' && s[i] <= '9'; ++i)
+      value = value * 10 + static_cast<size_t>(s[i] - '0');
+    if (i < s.size()) {
+      if (s[i] == 'K' || s[i] == 'k')
+        value *= 1024;
+      else if (s[i] == 'M' || s[i] == 'm')
+        value *= 1024 * 1024;
+      else if (s[i] == 'G' || s[i] == 'g')
+        value *= 1024 * 1024 * 1024;
+    }
+    return value;
+  }
+};
+
+struct CachePolicy {
+  CacheState state{CacheState::Hot};
+  EvictMethod method{EvictMethod::Auto};
+  bool activeWarm{false};
+  size_t clflushMaxBytes{0};
+  double thrashMultiple{2.0};
+  bool strict{true};
+};
+
+struct EvictionTargets {
+  std::span<const std::byte> payload;
+  std::span<std::byte> sink;
+  std::vector<std::span<const std::byte>> codecInternal;
+  std::optional<int> fileFd; // fd for file-backed eviction
+  std::optional<size_t> fileSize; // file size for fadvise
+};
+
+class CacheController {
+ public:
+  CacheController(CachePolicy policy, CacheTopology topo)
+      : policy_(policy), topo_(topo) {
+    requestedMethod_ = policy.method;
+    if (topo_.lineBytes == 0)
+      topo_.lineBytes = 64;
+    if (policy_.clflushMaxBytes == 0)
+      policy_.clflushMaxBytes =
+          (topo_.llcBytes ? topo_.llcBytes : size_t{16} << 20) * 4;
+    policy_.method = resolveMethod(policy_.method);
+    if (policy_.method == EvictMethod::LlcThrash) {
+      const double base = static_cast<double>(
+          topo_.llcBytes ? topo_.llcBytes : size_t{16} << 20);
+      const double mult =
+          policy_.thrashMultiple > 1.0 ? policy_.thrashMultiple : 2.0;
+      thrash_.assign(static_cast<size_t>(base * mult), std::byte{1});
+    }
+  }
+
+  void enableSystemDrop() {
+    systemDropEnabled_ = true;
+  }
+
+  void warm(const EvictionTargets& t) {
+    const auto t0 = Clock::now();
+    uint64_t acc = 0;
+    acc += touch(t.payload);
+    acc += touch(std::span<const std::byte>(t.sink.data(), t.sink.size()));
+    for (const auto& b : t.codecInternal)
+      acc += touch(b);
+    volatileSink_ = acc;
+    lastEvictNs_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                       Clock::now() - t0)
+                       .count();
+  }
+
+  void prepare(const EvictionTargets& t) {
+    latchSizeDependentMethod(t.payload.size());
+    if (policy_.state == CacheState::Hot) {
+      if (policy_.activeWarm) {
+        warm(t);
+        return;
+      }
+      lastEvictNs_ = 0;
+      return;
+    }
+    if (policy_.state == CacheState::ColdFileBuffered) {
+      prepareColdFileBuffered(t);
+      return;
+    }
+    if (policy_.state == CacheState::ColdFileDirect) {
+      lastEvictNs_ = 0;
+      return;
+    }
+    if (policy_.state == CacheState::ColdSystemDrop) {
+      prepareColdSystemDrop();
+      return;
+    }
+    const auto t0 = Clock::now();
+    switch (policy_.method) {
+      case EvictMethod::Clflush:
+        flushTargets(t);
+        break;
+      case EvictMethod::LlcThrash:
+        thrash();
+        break;
+      case EvictMethod::None:
+        break;
+      case EvictMethod::Auto:
+        break;
+    }
+    lastEvictNs_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                       Clock::now() - t0)
+                       .count();
+  }
+
+  int64_t lastEvictNs() const {
+    return lastEvictNs_;
+  }
+  const CachePolicy& effectivePolicy() const {
+    return policy_;
+  }
+
+  std::string describe() const {
+    std::string s = std::string(cacheStateName(policy_.state)) + "/" +
+        evictMethodName(policy_.method);
+    if (policy_.method == EvictMethod::LlcThrash) {
+      s += "(llc=" + CacheTopology::humanBytes(topo_.llcBytes) +
+          ",buf=" + CacheTopology::humanBytes(thrash_.size()) + ")";
+    } else if (policy_.method == EvictMethod::Clflush) {
+      s += "(line=" + std::to_string(topo_.lineBytes) + "B)";
+    }
+    return s;
+  }
+
+ private:
+  using Clock = std::chrono::high_resolution_clock;
+
+  EvictMethod resolveMethod(EvictMethod requested) const {
+    if (policy_.state == CacheState::Hot)
+      return EvictMethod::None;
+    if (policy_.state == CacheState::ColdFileBuffered ||
+        policy_.state == CacheState::ColdFileDirect ||
+        policy_.state == CacheState::ColdSystemDrop)
+      return EvictMethod::None;
+    if (requested == EvictMethod::Auto) {
+      if (policy_.state == CacheState::ColdPayload) {
+#if ENCODINGS_BENCH_HAVE_CLFLUSH
+        return EvictMethod::Clflush;
+#else
+        return EvictMethod::LlcThrash;
+#endif
+      }
+      return EvictMethod::LlcThrash;
+    }
+#if !ENCODINGS_BENCH_HAVE_CLFLUSH
+    if (requested == EvictMethod::Clflush) {
+      if (policy_.strict)
+        throw std::runtime_error(
+            "CacheController: clflush requested but not x86");
+      return EvictMethod::LlcThrash;
+    }
+#endif
+    if (requested == EvictMethod::None && policy_.strict)
+      throw std::runtime_error(
+          std::string("CacheController: state '") +
+          cacheStateName(policy_.state) + "' with evict-method 'none'");
+    return requested;
+  }
+
+  void latchSizeDependentMethod(size_t payloadBytes) {
+    if (sizeLatched_) {
+      if (policy_.strict && requestedMethod_ == EvictMethod::Auto &&
+          policy_.method == EvictMethod::Clflush &&
+          payloadBytes > policy_.clflushMaxBytes)
+        throw std::runtime_error(
+            "payload grew past clflushMaxBytes after latch");
+      return;
+    }
+    sizeLatched_ = true;
+    if (requestedMethod_ == EvictMethod::Auto &&
+        policy_.method == EvictMethod::Clflush &&
+        payloadBytes > policy_.clflushMaxBytes) {
+      policy_.method = EvictMethod::LlcThrash;
+      if (thrash_.empty()) {
+        const double base = static_cast<double>(
+            topo_.llcBytes ? topo_.llcBytes : size_t{16} << 20);
+        const double mult =
+            policy_.thrashMultiple > 1.0 ? policy_.thrashMultiple : 2.0;
+        thrash_.assign(static_cast<size_t>(base * mult), std::byte{1});
+      }
+    }
+  }
+
+  void prepareColdFileBuffered(const EvictionTargets& t) {
+    if (!t.fileFd.has_value())
+      throw std::runtime_error(
+          "ColdFileBuffered requires fileFd in EvictionTargets");
+    const auto t0 = Clock::now();
+    posix_fadvise(
+        *t.fileFd,
+        0,
+        static_cast<off_t>(t.fileSize.value_or(0)),
+        POSIX_FADV_DONTNEED);
+    lastEvictNs_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                       Clock::now() - t0)
+                       .count();
+  }
+
+  void prepareColdSystemDrop() {
+    if (!systemDropEnabled_)
+      throw std::runtime_error(
+          "ColdSystemDrop requires explicit opt-in via enableSystemDrop()");
+    fprintf(
+        stderr,
+        "WARNING: CacheController is dropping system page cache via "
+        "/proc/sys/vm/drop_caches (requires root)\n");
+    const auto t0 = Clock::now();
+    std::ofstream f("/proc/sys/vm/drop_caches");
+    if (!f)
+      throw std::runtime_error(
+          "Cannot write to /proc/sys/vm/drop_caches (requires root)");
+    f << "3" << std::flush;
+    lastEvictNs_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                       Clock::now() - t0)
+                       .count();
+  }
+
+  void flushTargets(const EvictionTargets& t) {
+    flushRange(t.payload);
+    if (policy_.state == CacheState::ColdAll) {
+      flushRange(std::span<const std::byte>(t.sink.data(), t.sink.size()));
+      for (const auto& b : t.codecInternal)
+        flushRange(b);
+    }
+#if ENCODINGS_BENCH_HAVE_CLFLUSH
+    _mm_mfence();
+#endif
+  }
+
+  void flushRange(std::span<const std::byte> r) {
+#if ENCODINGS_BENCH_HAVE_CLFLUSH
+    const std::byte* p = r.data();
+    const std::byte* end = p + r.size();
+    for (; p < end; p += topo_.lineBytes)
+      _mm_clflush(p);
+#else
+    (void)r;
+#endif
+  }
+
+  void thrash() {
+    uint64_t acc = 0;
+    const size_t stride = topo_.lineBytes;
+    for (size_t i = 0; i < thrash_.size(); i += stride)
+      acc += static_cast<uint64_t>(thrash_[i]);
+    volatileSink_ = acc;
+  }
+
+  uint64_t touch(std::span<const std::byte> r) const {
+    uint64_t acc = 0;
+    const size_t stride = topo_.lineBytes;
+    for (size_t i = 0; i < r.size(); i += stride)
+      acc += static_cast<uint64_t>(r[i]);
+    return acc;
+  }
+
+  CachePolicy policy_;
+  CacheTopology topo_;
+  EvictMethod requestedMethod_{EvictMethod::Auto};
+  std::vector<std::byte> thrash_;
+  volatile uint64_t volatileSink_{0};
+  int64_t lastEvictNs_{0};
+  bool sizeLatched_{false};
+  bool systemDropEnabled_{false};
+};
+
+} // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/GatherTraceGen.h
+++ b/dwio/nimble/ML_ID_Compression/GatherTraceGen.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -29,122 +30,129 @@ namespace facebook::nimble::mlidc {
 enum class GapModel { UniformDeterministic, Geometric };
 
 inline std::string gapModelName(GapModel m) {
-    return m == GapModel::Geometric ? "geometric" : "uniform";
+  return m == GapModel::Geometric ? "geometric" : "uniform";
 }
 
 struct GatherAccessParams {
-    size_t   start{0};
-    size_t   span{0};
-    double   selectivity{1.0};
-    size_t   runLength{8};
-    GapModel gapModel{GapModel::UniformDeterministic};
-    uint64_t seed{42};
-    size_t   maxRanges{0};
+  size_t start{0};
+  size_t span{0};
+  double selectivity{1.0};
+  size_t runLength{8};
+  GapModel gapModel{GapModel::UniformDeterministic};
+  uint64_t seed{42};
+  size_t maxRanges{0};
 };
 
 struct GatherTrace {
-    RowRangeList ranges;
-    size_t selectedRows{0};
-    size_t rangeCountNominal{0};
-    size_t rangeCount{0};
-    size_t runLengthActual{0};
-    size_t gapLength{0};
-    double selectivityAchieved{0.0};
-    bool   clamped{false};
+  RowRangeList ranges;
+  size_t selectedRows{0};
+  size_t rangeCountNominal{0};
+  size_t rangeCount{0};
+  size_t runLengthActual{0};
+  size_t gapLength{0};
+  double selectivityAchieved{0.0};
+  bool clamped{false};
 
-    void expandToRows(std::vector<int32_t>& out) const {
-        out.clear();
-        out.reserve(selectedRows);
-        for (const auto& r : ranges)
-            for (size_t i = r.begin; i < r.end; ++i)
-                out.push_back(static_cast<int32_t>(i));
-    }
+  void expandToRows(std::vector<int32_t>& out) const {
+    out.clear();
+    out.reserve(selectedRows);
+    for (const auto& r : ranges)
+      for (size_t i = r.begin; i < r.end; ++i)
+        out.push_back(static_cast<int32_t>(i));
+  }
 };
 
-inline size_t impliedRangeCount(size_t span, double selectivity, size_t runLength) {
-    if (span == 0) return 0;
-    const size_t rl = std::max<size_t>(1, runLength);
-    const size_t selected = static_cast<size_t>(
-        std::floor(std::clamp(selectivity, 0.0, 1.0) * static_cast<double>(span)));
-    return std::max<size_t>(1, selected / rl);
+inline size_t impliedRangeCount(
+    size_t span, double selectivity, size_t runLength) {
+  if (span == 0) return 0;
+  const size_t rl = std::max<size_t>(1, runLength);
+  const size_t selected = static_cast<size_t>(std::floor(
+      std::clamp(selectivity, 0.0, 1.0) * static_cast<double>(span)));
+  return std::max<size_t>(1, selected / rl);
 }
 
 namespace detail {
 
 inline void mergeAdjacent(RowRangeList& ranges) {
-    if (ranges.size() < 2) return;
-    RowRangeList merged;
-    merged.reserve(ranges.size());
-    merged.push_back(ranges.front());
-    for (size_t i = 1; i < ranges.size(); ++i) {
-        if (ranges[i].begin <= merged.back().end)
-            merged.back().end = std::max(merged.back().end, ranges[i].end);
-        else
-            merged.push_back(ranges[i]);
-    }
-    ranges.swap(merged);
+  if (ranges.size() < 2) return;
+  RowRangeList merged;
+  merged.reserve(ranges.size());
+  merged.push_back(ranges.front());
+  for (size_t i = 1; i < ranges.size(); ++i) {
+    if (ranges[i].begin <= merged.back().end)
+      merged.back().end = std::max(merged.back().end, ranges[i].end);
+    else
+      merged.push_back(ranges[i]);
+  }
+  ranges.swap(merged);
 }
 
 inline void finalize(GatherTrace& t, size_t span) {
-    mergeAdjacent(t.ranges);
-    t.rangeCount = t.ranges.size();
-    t.selectedRows = 0;
-    for (const auto& r : t.ranges) t.selectedRows += r.size();
-    t.selectivityAchieved = span > 0
-        ? static_cast<double>(t.selectedRows) / static_cast<double>(span)
-        : 0.0;
+  mergeAdjacent(t.ranges);
+  t.rangeCount = t.ranges.size();
+  t.selectedRows = 0;
+  for (const auto& r : t.ranges) t.selectedRows += r.size();
+  t.selectivityAchieved = span > 0
+      ? static_cast<double>(t.selectedRows) / static_cast<double>(span)
+      : 0.0;
 }
 
-}  // namespace detail
+} // namespace detail
 
-inline GatherTrace buildGatherTrace(size_t streamLength, const GatherAccessParams& p) {
-    GatherTrace t;
-    if (streamLength == 0 || p.start >= streamLength) return t;
-    const size_t start = p.start;
-    const size_t span = std::min(p.span, streamLength - start);
-    if (span == 0) return t;
-    const double sigma = std::clamp(p.selectivity, 0.0, 1.0);
-    if (sigma <= 0.0) return t;
-    const size_t runLength = std::max<size_t>(1, p.runLength);
+inline GatherTrace buildGatherTrace(
+    size_t streamLength, const GatherAccessParams& p) {
+  GatherTrace t;
+  if (streamLength == 0 || p.start >= streamLength) return t;
+  const size_t start = p.start;
+  const size_t span = std::min(p.span, streamLength - start);
+  if (span == 0) return t;
+  const double sigma = std::clamp(p.selectivity, 0.0, 1.0);
+  if (sigma <= 0.0) return t;
+  const size_t runLength = std::max<size_t>(1, p.runLength);
 
-    if (p.gapModel == GapModel::Geometric) {
-        SelectiveTraceParams sp;
-        sp.selectivity = sigma;
-        sp.meanRunLength = static_cast<double>(runLength);
-        sp.seed = p.seed;
-        sp.maxRanges = p.maxRanges;
-        t.ranges = makeSelectiveTrace(span, sp);
-        for (auto& r : t.ranges) { r.begin += start; r.end += start; }
-        t.rangeCountNominal = impliedRangeCount(span, sigma, runLength);
-        t.runLengthActual = runLength;
-        t.gapLength = static_cast<size_t>(
-            std::llround(static_cast<double>(runLength) * (1.0 / std::max(sigma, 1e-9) - 1.0)));
-        detail::finalize(t, span);
-        t.clamped = p.maxRanges != 0 && t.rangeCount >= p.maxRanges;
-        return t;
-    }
-
-    // Uniform deterministic model
-    const size_t selectedTarget = static_cast<size_t>(
-        std::floor(sigma * static_cast<double>(span)));
-    if (selectedTarget == 0) return t;
-    size_t k = std::max<size_t>(1, selectedTarget / runLength);
-    t.rangeCountNominal = k;
-    if (p.maxRanges != 0 && k > p.maxRanges) { k = p.maxRanges; t.clamped = true; }
-    const size_t gapTotal = span - selectedTarget;
-    auto selBefore = [&](size_t i) { return selectedTarget * i / k; };
-    auto gapBefore = [&](size_t i) { return k > 1 ? gapTotal * i / (k - 1) : size_t{0}; };
-    t.ranges.reserve(k);
-    for (size_t i = 0; i < k; ++i) {
-        const size_t begin = start + selBefore(i) + gapBefore(i);
-        const size_t end = start + selBefore(i + 1) + gapBefore(i);
-        if (end > begin) t.ranges.push_back({begin, end});
-    }
+  if (p.gapModel == GapModel::Geometric) {
+    SelectiveTraceParams sp;
+    sp.selectivity = sigma;
+    sp.meanRunLength = static_cast<double>(runLength);
+    sp.seed = p.seed;
+    sp.maxRanges = p.maxRanges;
+    t.ranges = makeSelectiveTrace(span, sp);
+    for (auto& r : t.ranges) { r.begin += start; r.end += start; }
+    t.rangeCountNominal = impliedRangeCount(span, sigma, runLength);
+    t.runLengthActual = runLength;
+    t.gapLength = static_cast<size_t>(std::llround(
+        static_cast<double>(runLength) *
+        (1.0 / std::max(sigma, 1e-9) - 1.0)));
     detail::finalize(t, span);
-    t.runLengthActual = t.rangeCount > 0 ? t.selectedRows / t.rangeCount : 0;
-    t.gapLength = k > 1 ? gapTotal / (k - 1) : 0;
-    if (t.rangeCount == 1 && t.selectedRows == selectedTarget) t.clamped = false;
+    t.clamped = p.maxRanges != 0 && t.rangeCount >= p.maxRanges;
     return t;
+  }
+
+  const size_t selectedTarget = static_cast<size_t>(
+      std::floor(sigma * static_cast<double>(span)));
+  if (selectedTarget == 0) return t;
+  size_t k = std::max<size_t>(1, selectedTarget / runLength);
+  t.rangeCountNominal = k;
+  if (p.maxRanges != 0 && k > p.maxRanges) {
+    k = p.maxRanges;
+    t.clamped = true;
+  }
+  const size_t gapTotal = span - selectedTarget;
+  auto selBefore = [&](size_t i) { return selectedTarget * i / k; };
+  auto gapBefore = [&](size_t i) {
+    return k > 1 ? gapTotal * i / (k - 1) : size_t{0};
+  };
+  t.ranges.reserve(k);
+  for (size_t i = 0; i < k; ++i) {
+    const size_t begin = start + selBefore(i) + gapBefore(i);
+    const size_t end = start + selBefore(i + 1) + gapBefore(i);
+    if (end > begin) t.ranges.push_back({begin, end});
+  }
+  detail::finalize(t, span);
+  t.runLengthActual = t.rangeCount > 0 ? t.selectedRows / t.rangeCount : 0;
+  t.gapLength = k > 1 ? gapTotal / (k - 1) : 0;
+  if (t.rangeCount == 1 && t.selectedRows == selectedTarget) t.clamped = false;
+  return t;
 }
 
-}  // namespace facebook::nimble::mlidc
+} // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/GatherTraceGen.h
+++ b/dwio/nimble/ML_ID_Compression/GatherTraceGen.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "dwio/nimble/ML_ID_Compression/SelectiveTraceGen.h"
+
+namespace facebook::nimble::mlidc {
+
+enum class GapModel { UniformDeterministic, Geometric };
+
+inline std::string gapModelName(GapModel m) {
+    return m == GapModel::Geometric ? "geometric" : "uniform";
+}
+
+struct GatherAccessParams {
+    size_t   start{0};
+    size_t   span{0};
+    double   selectivity{1.0};
+    size_t   runLength{8};
+    GapModel gapModel{GapModel::UniformDeterministic};
+    uint64_t seed{42};
+    size_t   maxRanges{0};
+};
+
+struct GatherTrace {
+    RowRangeList ranges;
+    size_t selectedRows{0};
+    size_t rangeCountNominal{0};
+    size_t rangeCount{0};
+    size_t runLengthActual{0};
+    size_t gapLength{0};
+    double selectivityAchieved{0.0};
+    bool   clamped{false};
+
+    void expandToRows(std::vector<int32_t>& out) const {
+        out.clear();
+        out.reserve(selectedRows);
+        for (const auto& r : ranges)
+            for (size_t i = r.begin; i < r.end; ++i)
+                out.push_back(static_cast<int32_t>(i));
+    }
+};
+
+inline size_t impliedRangeCount(size_t span, double selectivity, size_t runLength) {
+    if (span == 0) return 0;
+    const size_t rl = std::max<size_t>(1, runLength);
+    const size_t selected = static_cast<size_t>(
+        std::floor(std::clamp(selectivity, 0.0, 1.0) * static_cast<double>(span)));
+    return std::max<size_t>(1, selected / rl);
+}
+
+namespace detail {
+
+inline void mergeAdjacent(RowRangeList& ranges) {
+    if (ranges.size() < 2) return;
+    RowRangeList merged;
+    merged.reserve(ranges.size());
+    merged.push_back(ranges.front());
+    for (size_t i = 1; i < ranges.size(); ++i) {
+        if (ranges[i].begin <= merged.back().end)
+            merged.back().end = std::max(merged.back().end, ranges[i].end);
+        else
+            merged.push_back(ranges[i]);
+    }
+    ranges.swap(merged);
+}
+
+inline void finalize(GatherTrace& t, size_t span) {
+    mergeAdjacent(t.ranges);
+    t.rangeCount = t.ranges.size();
+    t.selectedRows = 0;
+    for (const auto& r : t.ranges) t.selectedRows += r.size();
+    t.selectivityAchieved = span > 0
+        ? static_cast<double>(t.selectedRows) / static_cast<double>(span)
+        : 0.0;
+}
+
+}  // namespace detail
+
+inline GatherTrace buildGatherTrace(size_t streamLength, const GatherAccessParams& p) {
+    GatherTrace t;
+    if (streamLength == 0 || p.start >= streamLength) return t;
+    const size_t start = p.start;
+    const size_t span = std::min(p.span, streamLength - start);
+    if (span == 0) return t;
+    const double sigma = std::clamp(p.selectivity, 0.0, 1.0);
+    if (sigma <= 0.0) return t;
+    const size_t runLength = std::max<size_t>(1, p.runLength);
+
+    if (p.gapModel == GapModel::Geometric) {
+        SelectiveTraceParams sp;
+        sp.selectivity = sigma;
+        sp.meanRunLength = static_cast<double>(runLength);
+        sp.seed = p.seed;
+        sp.maxRanges = p.maxRanges;
+        t.ranges = makeSelectiveTrace(span, sp);
+        for (auto& r : t.ranges) { r.begin += start; r.end += start; }
+        t.rangeCountNominal = impliedRangeCount(span, sigma, runLength);
+        t.runLengthActual = runLength;
+        t.gapLength = static_cast<size_t>(
+            std::llround(static_cast<double>(runLength) * (1.0 / std::max(sigma, 1e-9) - 1.0)));
+        detail::finalize(t, span);
+        t.clamped = p.maxRanges != 0 && t.rangeCount >= p.maxRanges;
+        return t;
+    }
+
+    // Uniform deterministic model
+    const size_t selectedTarget = static_cast<size_t>(
+        std::floor(sigma * static_cast<double>(span)));
+    if (selectedTarget == 0) return t;
+    size_t k = std::max<size_t>(1, selectedTarget / runLength);
+    t.rangeCountNominal = k;
+    if (p.maxRanges != 0 && k > p.maxRanges) { k = p.maxRanges; t.clamped = true; }
+    const size_t gapTotal = span - selectedTarget;
+    auto selBefore = [&](size_t i) { return selectedTarget * i / k; };
+    auto gapBefore = [&](size_t i) { return k > 1 ? gapTotal * i / (k - 1) : size_t{0}; };
+    t.ranges.reserve(k);
+    for (size_t i = 0; i < k; ++i) {
+        const size_t begin = start + selBefore(i) + gapBefore(i);
+        const size_t end = start + selBefore(i + 1) + gapBefore(i);
+        if (end > begin) t.ranges.push_back({begin, end});
+    }
+    detail::finalize(t, span);
+    t.runLengthActual = t.rangeCount > 0 ? t.selectedRows / t.rangeCount : 0;
+    t.gapLength = k > 1 ? gapTotal / (k - 1) : 0;
+    if (t.rangeCount == 1 && t.selectedRows == selectedTarget) t.clamped = false;
+    return t;
+}
+
+}  // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/MeasureLoop.h
+++ b/dwio/nimble/ML_ID_Compression/MeasureLoop.h
@@ -29,64 +29,65 @@ namespace facebook::nimble::mlidc {
 inline void clobber(const void* p) { asm volatile("" : : "r"(p) : "memory"); }
 
 struct MeasureSpec {
-    size_t iterations{5};
-    size_t warmup{2};
+  size_t iterations{5};
+  size_t warmup{2};
 };
 
 struct MeasureResult {
-    TimingSummary time;
-    TimingSummary evict;
-    size_t iterationsRun{};
+  TimingSummary time;
+  TimingSummary evict;
+  size_t iterationsRun{};
 };
 
 template <typename Fn>
-MeasureResult measure(const MeasureSpec& spec,
-                      CacheController& controller,
-                      const EvictionTargets& targets,
-                      Fn&& fn) {
-    using Clock = std::chrono::high_resolution_clock;
+MeasureResult measure(
+    const MeasureSpec& spec,
+    CacheController& controller,
+    const EvictionTargets& targets,
+    Fn&& fn) {
+  using Clock = std::chrono::high_resolution_clock;
 
-    for (size_t i = 0; i < spec.warmup; ++i) {
-        fn();
-        clobber(targets.sink.data());
-    }
+  for (size_t i = 0; i < spec.warmup; ++i) {
+    fn();
+    clobber(targets.sink.data());
+  }
 
-    std::vector<int64_t> timeSamples;
-    std::vector<int64_t> evictSamples;
-    timeSamples.reserve(spec.iterations);
-    evictSamples.reserve(spec.iterations);
+  std::vector<int64_t> timeSamples;
+  std::vector<int64_t> evictSamples;
+  timeSamples.reserve(spec.iterations);
+  evictSamples.reserve(spec.iterations);
 
-    for (size_t i = 0; i < spec.iterations; ++i) {
-        controller.prepare(targets);
+  for (size_t i = 0; i < spec.iterations; ++i) {
+    controller.prepare(targets);
 
-        const auto t0 = Clock::now();
-        fn();
-        const auto t1 = Clock::now();
+    const auto t0 = Clock::now();
+    fn();
+    const auto t1 = Clock::now();
 
-        clobber(targets.sink.data());
-        timeSamples.push_back(
-            std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
-        evictSamples.push_back(controller.lastEvictNs());
-    }
+    clobber(targets.sink.data());
+    timeSamples.push_back(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+    evictSamples.push_back(controller.lastEvictNs());
+  }
 
-    MeasureResult r;
-    r.time = summarize(timeSamples);
-    r.evict = summarize(evictSamples);
-    r.iterationsRun = spec.iterations;
-    return r;
+  MeasureResult r;
+  r.time = summarize(timeSamples);
+  r.evict = summarize(evictSamples);
+  r.iterationsRun = spec.iterations;
+  return r;
 }
 
 inline TimingSummary measureClockOverhead(size_t iterations) {
-    using Clock = std::chrono::high_resolution_clock;
-    std::vector<int64_t> samples;
-    samples.reserve(iterations);
-    for (size_t i = 0; i < iterations; ++i) {
-        const auto t0 = Clock::now();
-        const auto t1 = Clock::now();
-        samples.push_back(
-            std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
-    }
-    return summarize(samples);
+  using Clock = std::chrono::high_resolution_clock;
+  std::vector<int64_t> samples;
+  samples.reserve(iterations);
+  for (size_t i = 0; i < iterations; ++i) {
+    const auto t0 = Clock::now();
+    const auto t1 = Clock::now();
+    samples.push_back(
+        std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+  }
+  return summarize(samples);
 }
 
 } // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/MeasureLoop.h
+++ b/dwio/nimble/ML_ID_Compression/MeasureLoop.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+#include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
+#include "dwio/nimble/ML_ID_Compression/TimingStats.h"
+
+namespace facebook::nimble::mlidc {
+
+inline void clobber(const void* p) { asm volatile("" : : "r"(p) : "memory"); }
+
+struct MeasureSpec {
+    size_t iterations{5};
+    size_t warmup{2};
+};
+
+struct MeasureResult {
+    TimingSummary time;
+    TimingSummary evict;
+    size_t iterationsRun{};
+};
+
+template <typename Fn>
+MeasureResult measure(const MeasureSpec& spec,
+                      CacheController& controller,
+                      const EvictionTargets& targets,
+                      Fn&& fn) {
+    using Clock = std::chrono::high_resolution_clock;
+
+    for (size_t i = 0; i < spec.warmup; ++i) {
+        fn();
+        clobber(targets.sink.data());
+    }
+
+    std::vector<int64_t> timeSamples;
+    std::vector<int64_t> evictSamples;
+    timeSamples.reserve(spec.iterations);
+    evictSamples.reserve(spec.iterations);
+
+    for (size_t i = 0; i < spec.iterations; ++i) {
+        controller.prepare(targets);
+
+        const auto t0 = Clock::now();
+        fn();
+        const auto t1 = Clock::now();
+
+        clobber(targets.sink.data());
+        timeSamples.push_back(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+        evictSamples.push_back(controller.lastEvictNs());
+    }
+
+    MeasureResult r;
+    r.time = summarize(timeSamples);
+    r.evict = summarize(evictSamples);
+    r.iterationsRun = spec.iterations;
+    return r;
+}
+
+inline TimingSummary measureClockOverhead(size_t iterations) {
+    using Clock = std::chrono::high_resolution_clock;
+    std::vector<int64_t> samples;
+    samples.reserve(iterations);
+    for (size_t i = 0; i < iterations; ++i) {
+        const auto t0 = Clock::now();
+        const auto t1 = Clock::now();
+        samples.push_back(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(t1 - t0).count());
+    }
+    return summarize(samples);
+}
+
+} // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/OpenZLBenchTarget.h
+++ b/dwio/nimble/ML_ID_Compression/OpenZLBenchTarget.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <vector>
+
+#include <glog/logging.h>
+
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "openzl/cpp/CCtx.hpp"
+#include "openzl/cpp/Compressor.hpp"
+#include "openzl/cpp/DCtx.hpp"
+#include "openzl/cpp/Input.hpp"
+#include "openzl/cpp/Output.hpp"
+#include "openzl/zl_graphs.h"
+#include "openzl/zl_version.h"
+
+namespace facebook::nimble::mlidc {
+
+template <typename T>
+class OpenZLBenchTarget : public NimbleBenchTargetBase<T> {
+ public:
+  void encode(const Vector<T>& data, const Encoding::Options&) override {
+    count_ = data.size();
+    const size_t srcBytes = count_ * sizeof(T);
+
+    openzl::Compressor compressor;
+    compressor.selectStartingGraph(
+        static_cast<openzl::GraphID>(ZL_StandardGraphID_select_numeric));
+
+    openzl::CCtx cctx;
+    cctx.setParameter(
+        openzl::CParam::FormatVersion,
+        static_cast<int>(ZL_getDefaultEncodingVersion()));
+    cctx.refCompressor(compressor);
+
+    openzl::Input input = openzl::Input::refNumeric(data.data(), count_);
+    compressed_.resize(openzl::compressBound(srcBytes));
+
+    size_t compressedSize = cctx.compressOne(
+        {compressed_.data(), compressed_.size()}, input);
+    compressed_.resize(compressedSize);
+  }
+
+  void materializeAll(T* dst, uint32_t n) override {
+    openzl::DCtx dctx;
+    openzl::Output output = openzl::Output::wrapNumeric(dst, sizeof(T), n);
+    dctx.decompressOne(
+        output,
+        {compressed_.data(), compressed_.size()});
+  }
+
+  void materializeRange(uint32_t, uint32_t, T*) override {
+    LOG(FATAL) << "OpenZL does not support partial decode";
+  }
+
+  void skipThenMaterialize(
+      const std::vector<std::pair<uint32_t, uint32_t>>&,
+      T*) override {
+    LOG(FATAL) << "OpenZL does not support partial decode";
+  }
+
+  size_t payloadSize() const override {
+    return compressed_.size();
+  }
+
+  std::vector<std::span<const std::byte>> internalBuffers() const override {
+    return {{reinterpret_cast<const std::byte*>(compressed_.data()),
+             compressed_.size()}};
+  }
+
+ private:
+  uint32_t count_{0};
+  std::vector<char> compressed_;
+};
+
+template <typename T>
+EncoderEntry<T> buildOpenZLEncoder() {
+  EncoderEntry<T> entry;
+  entry.name = "openzl/auto";
+  entry.family = "OpenZL";
+  entry.variant = "select_numeric";
+  entry.isSequential = true;
+  entry.fastSkip = false;
+  entry.randomAccess = false;
+  entry.factory = [](const Vector<T>& data, const Encoding::Options& opts) {
+    auto target = std::make_unique<OpenZLBenchTarget<T>>();
+    target->encode(data, opts);
+    return std::unique_ptr<NimbleBenchTargetBase<T>>(std::move(target));
+  };
+  return entry;
+}
+
+} // namespace facebook::nimble::mlidc
+
+#endif // NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS

--- a/dwio/nimble/ML_ID_Compression/PointTraceGen.h
+++ b/dwio/nimble/ML_ID_Compression/PointTraceGen.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <numeric>
+#include <random>
+#include <vector>
+
+namespace facebook::nimble::mlidc {
+
+struct PointTraceParams {
+  size_t streamLength{};
+  size_t probes{1u << 16};
+  uint64_t seed{42};
+  bool ascending{false};
+};
+
+struct PointTrace {
+  std::vector<size_t> indices;
+  size_t distinctIndices{};
+  double distinctFraction{};
+};
+
+// Uniform point-lookup trace: a shuffled permutation of [0, streamLength),
+// truncated (and re-shuffled/appended as needed) to exactly `probes` entries.
+inline PointTrace buildPointTrace(const PointTraceParams& p) {
+  PointTrace t;
+  if (p.streamLength == 0 || p.probes == 0) {
+    return t;
+  }
+  const size_t n = p.streamLength;
+  std::mt19937_64 rng(p.seed);
+  t.indices.reserve(p.probes);
+
+  std::vector<size_t> perm(n);
+  std::iota(perm.begin(), perm.end(), size_t{0});
+  std::shuffle(perm.begin(), perm.end(), rng);
+  while (t.indices.size() < p.probes) {
+    const size_t take = std::min(n, p.probes - t.indices.size());
+    t.indices.insert(
+        t.indices.end(), perm.begin(), perm.begin() + static_cast<std::ptrdiff_t>(take));
+    if (t.indices.size() < p.probes) {
+      std::shuffle(perm.begin(), perm.end(), rng);
+    }
+  }
+
+  if (p.ascending) {
+    std::sort(t.indices.begin(), t.indices.end());
+  }
+
+  std::vector<size_t> sorted(t.indices);
+  std::sort(sorted.begin(), sorted.end());
+  sorted.erase(std::unique(sorted.begin(), sorted.end()), sorted.end());
+  t.distinctIndices = sorted.size();
+  t.distinctFraction = static_cast<double>(t.distinctIndices) /
+      static_cast<double>(t.indices.size());
+  return t;
+}
+
+} // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/SelectiveTraceGen.h
+++ b/dwio/nimble/ML_ID_Compression/SelectiveTraceGen.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <random>
+#include <vector>
+
+namespace facebook::nimble::mlidc {
+
+struct RowRange {
+    size_t begin{0};
+    size_t end{0};
+    size_t size() const { return end > begin ? end - begin : 0; }
+};
+using RowRangeList = std::vector<RowRange>;
+
+struct SelectiveTraceParams {
+    double selectivity{0.5};
+    double meanRunLength{8.0};
+    uint64_t seed{42};
+    size_t maxRanges{0};
+};
+
+inline RowRangeList makeSelectiveTrace(size_t n, const SelectiveTraceParams& p) {
+    RowRangeList ranges;
+    if (n == 0 || p.selectivity <= 0.0) return ranges;
+    if (p.selectivity >= 1.0) {
+        ranges.push_back({0, n});
+        return ranges;
+    }
+    const double meanGapLength = p.meanRunLength * (1.0 / p.selectivity - 1.0);
+    std::mt19937_64 rng(p.seed);
+    std::geometric_distribution<size_t> runDist(1.0 / std::max(1.0, p.meanRunLength));
+    std::geometric_distribution<size_t> gapDist(1.0 / std::max(1.0, meanGapLength));
+    size_t pos = 0;
+    while (pos < n) {
+        size_t runLen = std::min(runDist(rng) + 1, n - pos);
+        ranges.push_back({pos, pos + runLen});
+        pos += runLen;
+        if (pos >= n) break;
+        if (p.maxRanges && ranges.size() >= p.maxRanges) break;
+        size_t gapLen = std::min(gapDist(rng) + 1, n - pos);
+        pos += gapLen;
+    }
+    return ranges;
+}
+
+}  // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/SelectiveTraceGen.h
+++ b/dwio/nimble/ML_ID_Compression/SelectiveTraceGen.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -24,41 +25,44 @@
 namespace facebook::nimble::mlidc {
 
 struct RowRange {
-    size_t begin{0};
-    size_t end{0};
-    size_t size() const { return end > begin ? end - begin : 0; }
+  size_t begin{0};
+  size_t end{0};
+  size_t size() const { return end > begin ? end - begin : 0; }
 };
 using RowRangeList = std::vector<RowRange>;
 
 struct SelectiveTraceParams {
-    double selectivity{0.5};
-    double meanRunLength{8.0};
-    uint64_t seed{42};
-    size_t maxRanges{0};
+  double selectivity{0.5};
+  double meanRunLength{8.0};
+  uint64_t seed{42};
+  size_t maxRanges{0};
 };
 
-inline RowRangeList makeSelectiveTrace(size_t n, const SelectiveTraceParams& p) {
-    RowRangeList ranges;
-    if (n == 0 || p.selectivity <= 0.0) return ranges;
-    if (p.selectivity >= 1.0) {
-        ranges.push_back({0, n});
-        return ranges;
-    }
-    const double meanGapLength = p.meanRunLength * (1.0 / p.selectivity - 1.0);
-    std::mt19937_64 rng(p.seed);
-    std::geometric_distribution<size_t> runDist(1.0 / std::max(1.0, p.meanRunLength));
-    std::geometric_distribution<size_t> gapDist(1.0 / std::max(1.0, meanGapLength));
-    size_t pos = 0;
-    while (pos < n) {
-        size_t runLen = std::min(runDist(rng) + 1, n - pos);
-        ranges.push_back({pos, pos + runLen});
-        pos += runLen;
-        if (pos >= n) break;
-        if (p.maxRanges && ranges.size() >= p.maxRanges) break;
-        size_t gapLen = std::min(gapDist(rng) + 1, n - pos);
-        pos += gapLen;
-    }
+inline RowRangeList makeSelectiveTrace(
+    size_t n, const SelectiveTraceParams& p) {
+  RowRangeList ranges;
+  if (n == 0 || p.selectivity <= 0.0) return ranges;
+  if (p.selectivity >= 1.0) {
+    ranges.push_back({0, n});
     return ranges;
+  }
+  const double meanGapLength = p.meanRunLength * (1.0 / p.selectivity - 1.0);
+  std::mt19937_64 rng(p.seed);
+  std::geometric_distribution<size_t> runDist(
+      1.0 / std::max(1.0, p.meanRunLength));
+  std::geometric_distribution<size_t> gapDist(
+      1.0 / std::max(1.0, meanGapLength));
+  size_t pos = 0;
+  while (pos < n) {
+    size_t runLen = std::min(runDist(rng) + 1, n - pos);
+    ranges.push_back({pos, pos + runLen});
+    pos += runLen;
+    if (pos >= n) break;
+    if (p.maxRanges && ranges.size() >= p.maxRanges) break;
+    size_t gapLen = std::min(gapDist(rng) + 1, n - pos);
+    pos += gapLen;
+  }
+  return ranges;
 }
 
-}  // namespace facebook::nimble::mlidc
+} // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/TimingStats.h
+++ b/dwio/nimble/ML_ID_Compression/TimingStats.h
@@ -70,11 +70,9 @@ struct TimingSummary {
   int64_t min_ns{0};
 };
 
-/// Sorts `samples` in place, then returns median, p90, and min.
 inline TimingSummary summarize(std::vector<int64_t>& samples) {
-  std::sort(samples.begin(), samples.end());
   TimingSummary s;
-  s.min_ns = samples.empty() ? 0 : samples.front();
+  s.min_ns = minOf(samples);
   s.median_ns = percentileOf(samples, 0.5);
   s.p90_ns = percentileOf(samples, 0.9);
   return s;

--- a/dwio/nimble/ML_ID_Compression/TimingStats.h
+++ b/dwio/nimble/ML_ID_Compression/TimingStats.h
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+namespace facebook::nimble::mlidc {
+
+// ---------------------------------------------------------------------------
+// Order statistics over timing samples (nanoseconds).
+//
+// Helpers that accept a non-const vector are permitted to reorder it; they use
+// std::nth_element rather than a full sort, so successive calls on the same
+// vector each remain O(n).
+// ---------------------------------------------------------------------------
+
+/// Value at quantile p in [0, 1] by nearest-rank.  Returns 0 for empty input.
+inline int64_t percentileOf(std::vector<int64_t>& v, double p) {
+  if (v.empty()) {
+    return 0;
+  }
+  const double clamped = std::clamp(p, 0.0, 1.0);
+  size_t idx =
+      static_cast<size_t>(clamped * static_cast<double>(v.size() - 1));
+  idx = std::min(idx, v.size() - 1);
+  auto nth = v.begin() + static_cast<std::ptrdiff_t>(idx);
+  std::nth_element(v.begin(), nth, v.end());
+  return *nth;
+}
+
+inline int64_t medianOf(std::vector<int64_t>& v) {
+  return percentileOf(v, 0.5);
+}
+
+inline int64_t minOf(const std::vector<int64_t>& v) {
+  if (v.empty()) {
+    return 0;
+  }
+  return *std::min_element(v.begin(), v.end());
+}
+
+// ---------------------------------------------------------------------------
+// TimingSummary: median, p90, and min for one timed measurement point.
+//
+// Prefer order statistics for latency data — a single descheduled iteration
+// can dominate a mean, but barely moves the median or p90.
+// ---------------------------------------------------------------------------
+struct TimingSummary {
+  int64_t median_ns{0};
+  int64_t p90_ns{0};
+  int64_t min_ns{0};
+};
+
+/// Sorts `samples` in place, then returns median, p90, and min.
+inline TimingSummary summarize(std::vector<int64_t>& samples) {
+  std::sort(samples.begin(), samples.end());
+  TimingSummary s;
+  s.min_ns = samples.empty() ? 0 : samples.front();
+  s.median_ns = percentileOf(samples, 0.5);
+  s.p90_ns = percentileOf(samples, 0.9);
+  return s;
+}
+
+// ---------------------------------------------------------------------------
+// MomentSummary: mean and Bessel-corrected standard deviation over a
+// real-valued sample set.
+//
+// Used for derived quantities (compression ratios, throughputs) that do not
+// suffer from the descheduling outliers that make order statistics preferable
+// for raw latency.  stddev is 0 for a single sample.
+// ---------------------------------------------------------------------------
+struct MomentSummary {
+  double mean{0.0};
+  double stddev{0.0};
+};
+
+inline MomentSummary momentSummary(const std::vector<double>& values) {
+  MomentSummary s;
+  if (values.empty()) {
+    return s;
+  }
+  s.mean = std::accumulate(values.begin(), values.end(), 0.0) /
+      static_cast<double>(values.size());
+  if (values.size() > 1) {
+    double sqSum = 0.0;
+    for (double v : values) {
+      sqSum += (v - s.mean) * (v - s.mean);
+    }
+    s.stddev =
+        std::sqrt(sqSum / static_cast<double>(values.size() - 1));
+  }
+  return s;
+}
+
+} // namespace facebook::nimble::mlidc

--- a/dwio/nimble/ML_ID_Compression/bench_ablation.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_ablation.cpp
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// bench_ablation: progressive encoding-set restriction for SIS sections.
+//
+// SubIntSplit's random-access property is the MIN over its sections. One
+// sequential-access section encoding costs the WHOLE encoding its RA property.
+// This driver varies the allowed encoding set along a ladder and reports, per
+// rung, both the estimated compression and the access-class consequences.
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "dwio/nimble/ML_ID_Compression/AblationPolicy.h"
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/encodings/SubIntSplitSampler.h"
+
+DEFINE_bool(dry_run, false, "Print sweep plan and exit");
+
+namespace facebook::nimble::mlidc {
+namespace {
+
+using Elem = int64_t;
+using namespace facebook::nimble::detail::subintsplit;
+
+std::string encodingTypeName(EncodingType t) {
+  switch (t) {
+    case EncodingType::Trivial: return "Trivial";
+    case EncodingType::FixedBitWidth: return "FixedBitWidth";
+    case EncodingType::Constant: return "Constant";
+    case EncodingType::Dictionary: return "Dictionary";
+    case EncodingType::MainlyConstant: return "MainlyConstant";
+    case EncodingType::RLE: return "RLE";
+    case EncodingType::Varint: return "Varint";
+    default: return "Other";
+  }
+}
+
+std::string formatPlan(const std::vector<SegmentPlan>& segments) {
+  std::ostringstream oss;
+  for (size_t i = 0; i < segments.size(); ++i) {
+    if (i > 0) oss << ";";
+    oss << segments[i].bitStart << "-" << segments[i].bitEnd << ":"
+        << encodingTypeName(segments[i].encoding);
+  }
+  return oss.str();
+}
+
+} // namespace
+} // namespace facebook::nimble::mlidc
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  facebook::velox::memory::MemoryManager::initialize({});
+  using namespace facebook::nimble::mlidc;
+  using namespace facebook::nimble::detail::subintsplit;
+
+  const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
+  const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
+
+  auto datasets = defaultInt64Datasets<Elem>();
+  auto ladder = combinedLadder();
+
+  std::cout << "bench_ablation: " << ladder.size() << " rungs x "
+            << datasets.size() << " datasets, N=" << n << "\n\n";
+
+  if (FLAGS_dry_run) {
+    std::cout << "Ladder:\n";
+    for (size_t i = 0; i < ladder.size(); ++i) {
+      std::cout << "  [" << i << "] " << ladder[i].name << " ("
+                << ladder[i].allowed.size() << " encodings, worst="
+                << accessClassName(ladder[i].worstAllowed) << ")\n";
+    }
+    std::cout << "\nDatasets:\n";
+    for (const auto& d : datasets) std::cout << "  " << d.name << "\n";
+    return 0;
+  }
+
+  std::vector<std::string> csvColumns = {
+      "driver",
+      "dataset",
+      "N",
+      "seed",
+      "sample_size",
+      "rung_name",
+      "rung_index",
+      "segment_count",
+      "total_est_bits",
+      "bits_per_elem_est",
+      "all_sections_ra",
+      "worst_access_class",
+      "cost_model_consistent",
+      "segment_plan",
+      "skipped"};
+  std::string csvPath = FLAGS_mlidc_output_csv.empty()
+      ? "bench_ablation.csv"
+      : FLAGS_mlidc_output_csv;
+  CsvResultWriter csv(csvPath, csvColumns);
+  if (!FLAGS_mlidc_output_manifest.empty()) {
+    writeRunManifest(FLAGS_mlidc_output_manifest);
+  }
+
+  SamplerConfig samplerCfg = defaultSamplerConfig();
+  SelectorConfig selectorCfg = defaultSelectorConfig();
+
+  for (const auto& ds : datasets) {
+    std::cout << "== Dataset: " << ds.name << " ==\n";
+    auto data = ds.generate(n, seed);
+
+    std::vector<uint64_t> samples;
+    sampleIntoU64(
+        std::span<const Elem>(data.data(), n), samples, samplerCfg);
+
+    if (samples.empty()) {
+      std::cerr << "  [SKIP] empty sample\n";
+      continue;
+    }
+
+    for (size_t ri = 0; ri < ladder.size(); ++ri) {
+      const auto& rung = ladder[ri];
+
+      SelectorResult result;
+      bool skipped = false;
+      try {
+        result = detail_ablation::selectSplitsRestricted(
+            samples, 64, n, selectorCfg, rung.allowed);
+      } catch (const std::exception& ex) {
+        std::cerr << "  [SKIP] " << rung.name << ": " << ex.what() << "\n";
+        skipped = true;
+      }
+
+      if (skipped) {
+        csv.beginRow();
+        csv.set("driver", "bench_ablation");
+        csv.set("dataset", ds.name);
+        csv.set("rung_name", rung.name);
+        csv.set("rung_index", static_cast<int64_t>(ri));
+        csv.set("skipped", int64_t{1});
+        csv.endRow();
+        continue;
+      }
+
+      const double bpe = n > 0 ? result.totalCost / static_cast<double>(n) : 0;
+
+      AccessClass worst = AccessClass::PureRA;
+      bool allRA = true;
+      for (const auto& seg : result.segments) {
+        AccessClass ac = accessClassOf(seg.encoding);
+        if (ac > worst) worst = ac;
+        if (ac != AccessClass::PureRA) allRA = false;
+      }
+
+      std::cout << "  " << rung.name << ": " << result.segments.size()
+                << " segments, " << std::fixed << std::setprecision(2) << bpe
+                << " bpe, allRA=" << allRA << "\n";
+
+      csv.beginRow();
+      csv.set("driver", "bench_ablation");
+      csv.set("dataset", ds.name);
+      csv.set("N", static_cast<int64_t>(n));
+      csv.set("seed", static_cast<int64_t>(seed));
+      csv.set("sample_size", static_cast<int64_t>(samples.size()));
+      csv.set("rung_name", rung.name);
+      csv.set("rung_index", static_cast<int64_t>(ri));
+      csv.set(
+          "segment_count",
+          static_cast<int64_t>(result.segments.size()));
+      csv.set("total_est_bits", result.totalCost);
+      csv.set("bits_per_elem_est", bpe);
+      csv.set("all_sections_ra", allRA ? int64_t{1} : int64_t{0});
+      csv.set("worst_access_class", std::string(accessClassName(worst)));
+      csv.set(
+          "cost_model_consistent",
+          rung.costModelConsistent ? int64_t{1} : int64_t{0});
+      csv.set("segment_plan", formatPlan(result.segments));
+      csv.set("skipped", int64_t{0});
+      csv.endRow();
+    }
+    csv.flush();
+  }
+
+  std::cout << "\nResults written to: " << csvPath << "\n";
+  return 0;
+}
+
+#else
+
+#include <iostream>
+int main() {
+  std::cerr << "bench_ablation requires NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS\n";
+  return 1;
+}
+
+#endif

--- a/dwio/nimble/ML_ID_Compression/bench_compression.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_compression.cpp
@@ -25,6 +25,7 @@
 #include <gflags/gflags.h>
 
 #include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/ML_ID_Compression/OpenZLBenchTarget.h"
 
 DEFINE_bool(validate, false, "Round-trip check after each encode");
 DEFINE_bool(dry_run, false, "Print sweep plan and exit");
@@ -47,6 +48,7 @@ int main(int argc, char** argv) {
   const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
 
   auto encoders = buildDefaultEncoders<Elem>();
+  encoders.push_back(buildOpenZLEncoder<Elem>());
   auto datasets = defaultInt64Datasets<Elem>();
 
   std::cout << "bench_compression: " << encoders.size() << " encoders x "

--- a/dwio/nimble/ML_ID_Compression/bench_compression.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_compression.cpp
@@ -14,536 +14,163 @@
  * limitations under the License.
  */
 
-// bench_compression.cpp
-//
-// Phase-1 driver: encoded-size only, no timing.  Proves the encode path works
-// end-to-end across the candidate encodings for ML ID columns.
-//
-// Usage:
-//   bench_compression [--n=<rows>] [--seed=<seed>]
-//                     [--dataset=<name>|all] [--encoder=<name>|all]
-//                     [--output=<file.csv>]
-//                     [--validate] [--dry_run]
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
 
-#include <algorithm>
-#include <array>
 #include <cstdint>
-#include <fstream>
-#include <functional>
 #include <iomanip>
 #include <iostream>
-#include <stdexcept>
 #include <string>
 #include <vector>
 
 #include <gflags/gflags.h>
 
-#include "dwio/nimble/common/Buffer.h"
-#include "dwio/nimble/common/Vector.h"
-#include "dwio/nimble/encodings/DictionaryEncoding.h"
-#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
-#include "dwio/nimble/encodings/RLEEncoding.h"
-#include "dwio/nimble/encodings/TrivialEncoding.h"
-#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
-#include "dwio/nimble/encodings/common/Encoding.h"
-#include "dwio/nimble/encodings/common/EncodingFactory.h"
-#include "dwio/nimble/encodings/tests/TestUtils.h"
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
-#endif
-#include "folly/Random.h"
-#include "velox/common/memory/Memory.h"
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
 
-// ---------------------------------------------------------------------------
-// CLI flags
-// ---------------------------------------------------------------------------
-DEFINE_int32(n, 100000, "Number of elements to generate per dataset");
-DEFINE_int32(seed, 42, "RNG seed (currently informational; folly uses global)");
-DEFINE_string(dataset, "all", "Dataset name to run, or 'all'");
-DEFINE_string(encoder, "all", "Encoder name to run, or 'all'");
-DEFINE_string(output, "", "Path for CSV output (stdout if empty)");
-DEFINE_bool(validate, false, "Decode-and-compare round-trip after each encode");
-DEFINE_bool(dry_run, false, "Print sweep plan and exit without encoding");
+DEFINE_bool(validate, false, "Round-trip check after each encode");
+DEFINE_bool(dry_run, false, "Print sweep plan and exit");
 
 namespace facebook::nimble::mlidc {
+namespace {
 
-using namespace facebook::nimble;
-using namespace facebook::nimble::benchmarks;
-using namespace facebook::nimble::test;
+using Elem = int64_t;
+constexpr size_t kElemSize = sizeof(Elem);
 
-// ---------------------------------------------------------------------------
-// Type-erased encoder entry
-// ---------------------------------------------------------------------------
-struct EncoderEntry {
-  std::string name;
-  std::string family;
-  std::string variant;
-  bool isSequential;
-  bool fastSkip;
-  bool randomAccess;
-
-  // Encode values into a fresh Buffer; return the encoded byte string.
-  // The buffer is passed in so the caller can keep it alive.
-  std::function<std::string(const Vector<int64_t>&, Encoding::Options&, Buffer&)>
-      encodeFn;
-
-  // Decode back from the encoded string; compare with original.
-  // Returns true if round-trip matches.
-  std::function<bool(
-      const std::string& encoded,
-      const Vector<int64_t>& original,
-      Encoding::Options& options)>
-      validateFn;
-};
-
-// ---------------------------------------------------------------------------
-// Type-erased dataset entry
-// ---------------------------------------------------------------------------
-struct DatasetEntry {
-  std::string name;
-  std::function<Vector<int64_t>(int n)> generate;
-};
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-// Seed folly's random engine before generating data so results are
-// reproducible across runs with the same --seed.
-static void seedRng(int seed) {
-  folly::Random::DefaultGenerator rng;
-  rng.seed(static_cast<uint32_t>(seed));
-  // folly::Random itself seeds from /dev/urandom; we just note the seed in
-  // the output for reproducibility metadata.  Full seeding would require
-  // threading a generator through the generators; omitted for Phase 1.
-  (void)rng;
-}
-
-// ---------------------------------------------------------------------------
-// Build the encoder table
-// ---------------------------------------------------------------------------
-static std::vector<EncoderEntry> buildEncoders() {
-  std::vector<EncoderEntry> encoders;
-
-  // Lambda helpers that capture the encoding type statically.
-  auto addEncoder =
-      [&](std::string name,
-          std::string family,
-          std::string variant,
-          bool isSeq,
-          bool fastSkip,
-          bool randAccess,
-          std::function<
-              std::string(const Vector<int64_t>&, Encoding::Options&, Buffer&)>
-              encFn,
-          std::function<bool(
-              const std::string&,
-              const Vector<int64_t>&,
-              Encoding::Options&)> valFn) {
-        encoders.push_back(
-            {std::move(name),
-             std::move(family),
-             std::move(variant),
-             isSeq,
-             fastSkip,
-             randAccess,
-             std::move(encFn),
-             std::move(valFn)});
-      };
-
-  // Common validation lambda factory
-  auto makeValidator = [](Encoding::Options opts) {
-    return [opts](
-               const std::string& encoded,
-               const Vector<int64_t>& original,
-               Encoding::Options& /*options*/) -> bool {
-      auto& pool = benchmarkPool();
-      EncodingFactory factory{opts};
-      auto enc = factory.create(*pool, encoded, nullFactory());
-      std::vector<int64_t> out(original.size());
-      enc->materialize(static_cast<uint32_t>(original.size()), out.data());
-      for (size_t i = 0; i < original.size(); ++i) {
-        if (out[i] != original[i]) {
-          return false;
-        }
-      }
-      return true;
-    };
-  };
-
-  // --- Trivial ---
-  addEncoder(
-      "Trivial",
-      "Baseline",
-      "trivial",
-      /*isSeq=*/true,
-      /*fastSkip=*/true,
-      /*randAccess=*/false,
-      [](const Vector<int64_t>& data, Encoding::Options& opts, Buffer& buf) {
-        return std::string{
-            Encoder<TrivialEncoding<int64_t>>::encode(
-                buf, data, CompressionType::Uncompressed, opts)};
-      },
-      makeValidator({}));
-
-  // --- FixedBitWidth ---
-  addEncoder(
-      "FixedBitWidth",
-      "Baseline",
-      "fbw",
-      true,
-      true,
-      false,
-      [](const Vector<int64_t>& data, Encoding::Options& opts, Buffer& buf) {
-        return std::string{
-            Encoder<FixedBitWidthEncoding<int64_t>>::encode(
-                buf, data, CompressionType::Uncompressed, opts)};
-      },
-      makeValidator({}));
-
-  // --- Dictionary ---
-  addEncoder(
-      "Dictionary",
-      "Baseline",
-      "dict",
-      true,
-      false,
-      false,
-      [](const Vector<int64_t>& data, Encoding::Options& opts, Buffer& buf) {
-        return std::string{
-            Encoder<DictionaryEncoding<int64_t>>::encode(
-                buf, data, CompressionType::Uncompressed, opts)};
-      },
-      makeValidator({}));
-
-  // --- RLE ---
-  addEncoder(
-      "RLE",
-      "Baseline",
-      "rle",
-      true,
-      true,
-      false,
-      [](const Vector<int64_t>& data, Encoding::Options& opts, Buffer& buf) {
-        return std::string{
-            Encoder<RLEEncoding<int64_t>>::encode(
-                buf, data, CompressionType::Uncompressed, opts)};
-      },
-      makeValidator({}));
-
-  // --- FPE variants (index types 0..3) ---
-  const std::array<std::string, 4> fpeVariantNames = {
-      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
-  const std::array<bool, 4> fpeRandomAccess = {false, true, true, true};
-  const std::array<bool, 4> fpeFastSkip = {false, true, true, true};
-
-  for (int idx = 0; idx < 4; ++idx) {
-    addEncoder(
-        "FPE/" + fpeVariantNames[idx],
-        "FrequencyPartition",
-        fpeVariantNames[idx],
-        /*isSeq=*/true,
-        fpeFastSkip[idx],
-        fpeRandomAccess[idx],
-        [idx](
-            const Vector<int64_t>& data,
-            Encoding::Options& opts,
-            Buffer& buf) {
-          opts.frequencyPartitionIndex = static_cast<uint8_t>(idx);
-          return std::string{
-              Encoder<FrequencyPartitionEncoding<int64_t>>::encode(
-                  buf, data, CompressionType::Uncompressed, opts)};
-        },
-        [idx](
-            const std::string& encoded,
-            const Vector<int64_t>& original,
-            Encoding::Options& /*opts*/) -> bool {
-          // NoIndex (idx 0) reorders by frequency with no restoration
-          // index, so round-trip to original order is not possible.
-          if (idx == 0) {
-            return true;
-          }
-          auto& pool = benchmarkPool();
-          Encoding::Options decodeOpts;
-          decodeOpts.frequencyPartitionIndex = static_cast<uint8_t>(idx);
-          FrequencyPartitionEncoding<int64_t> enc{
-              *pool, encoded, nullFactory(), decodeOpts};
-          std::vector<int64_t> out(original.size());
-          enc.materialize(
-              static_cast<uint32_t>(original.size()), out.data());
-          for (size_t i = 0; i < original.size(); ++i) {
-            if (out[i] != original[i]) {
-              return false;
-            }
-          }
-          return true;
-        });
-  }
-
-#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
-  // --- SubIntSplit with realNestedSelection ---
-  // NOTE: EncodingFactory does NOT dispatch SubIntSplit, so validation must
-  // go through test::Encoder<E>::createEncoding() rather than the factory.
-  addEncoder(
-      "SIS/realNested",
-      "SubIntSplit",
-      "real_nested",
-      /*isSeq=*/false,
-      /*fastSkip=*/false,
-      /*randAccess=*/false,
-      [](const Vector<int64_t>& data, Encoding::Options& opts, Buffer& buf) {
-        return std::string{
-            Encoder<SubIntSplitEncoding<int64_t>>::encode(
-                buf,
-                data,
-                CompressionType::Uncompressed,
-                opts,
-                /*realNestedSelection=*/true)};
-      },
-      [](const std::string& encoded,
-         const Vector<int64_t>& original,
-         Encoding::Options& /*opts*/) -> bool {
-        auto& pool = benchmarkPool();
-        // Construct directly — EncodingFactory cannot dispatch SubIntSplit.
-        SubIntSplitEncoding<int64_t> enc{*pool, encoded, nullFactory()};
-        std::vector<int64_t> out(original.size());
-        enc.materialize(static_cast<uint32_t>(original.size()), out.data());
-        for (size_t i = 0; i < original.size(); ++i) {
-          if (out[i] != original[i]) {
-            return false;
-          }
-        }
-        return true;
-      });
-#endif
-
-  return encoders;
-}
-
-// ---------------------------------------------------------------------------
-// Build the dataset table
-// ---------------------------------------------------------------------------
-static std::vector<DatasetEntry> buildDatasets() {
-  return {
-      {"UniformRandom",
-       [](int n) {
-         auto& pool = benchmarkPool();
-         Vector<int64_t> data{pool.get()};
-         data.resize(static_cast<uint32_t>(n));
-         for (int i = 0; i < n; ++i) {
-           data[i] = static_cast<int64_t>(folly::Random::secureRand64());
-         }
-         return data;
-       }},
-      {"LowCardinality16",
-       [](int n) {
-         return makeLowCardinality<int64_t>(16, static_cast<uint32_t>(n));
-       }},
-      {"RunLength",
-       [](int n) {
-         return makeRunLength<int64_t>(static_cast<uint32_t>(n));
-       }},
-      {"Increasing",
-       [](int n) {
-         return makeIncreasing<int64_t>(static_cast<uint32_t>(n));
-       }},
-      {"Narrow20",
-       [](int n) {
-         return makeNarrow<int64_t>(20, static_cast<uint32_t>(n));
-       }},
-  };
-}
-
-// ---------------------------------------------------------------------------
-// CSV output
-// ---------------------------------------------------------------------------
-static void writeCsvHeader(std::ostream& out) {
-  out << "driver,dataset,encoding,family,variant,is_sequential,fast_skip,"
-         "random_access,N,seed,payload_bytes,compression_ratio,"
-         "bits_per_element,skipped\n";
-}
-
-static void writeCsvRow(
-    std::ostream& out,
-    const std::string& dataset,
-    const EncoderEntry& enc,
-    int n,
-    int seed,
-    size_t payloadBytes,
-    double ratio,
-    double bitsPerElem,
-    bool skipped) {
-  out << "bench_compression" << ',' << dataset << ',' << enc.name << ','
-      << enc.family << ',' << enc.variant << ','
-      << (enc.isSequential ? "true" : "false") << ','
-      << (enc.fastSkip ? "true" : "false") << ','
-      << (enc.randomAccess ? "true" : "false") << ',' << n << ',' << seed
-      << ',' << payloadBytes << ',' << std::fixed << std::setprecision(4)
-      << ratio << ',' << std::fixed << std::setprecision(4) << bitsPerElem
-      << ',' << (skipped ? "true" : "false") << '\n';
-}
-
+} // namespace
 } // namespace facebook::nimble::mlidc
 
-// ---------------------------------------------------------------------------
-// main
-// ---------------------------------------------------------------------------
 int main(int argc, char** argv) {
-  gflags::ParseCommandLineFlags(&argc, &argv, /*remove_flags=*/true);
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
   facebook::velox::memory::MemoryManager::initialize({});
-
   using namespace facebook::nimble::mlidc;
 
-  const int n = FLAGS_n;
-  const int seed = FLAGS_seed;
+  const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
+  const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
 
-  auto encoders = buildEncoders();
-  auto datasets = buildDatasets();
+  auto encoders = buildDefaultEncoders<Elem>();
+  auto datasets = defaultInt64Datasets<Elem>();
 
-  // Apply --encoder / --dataset filters
-  if (FLAGS_encoder != "all") {
-    encoders.erase(
-        std::remove_if(
-            encoders.begin(),
-            encoders.end(),
-            [&](const EncoderEntry& e) { return e.name != FLAGS_encoder; }),
-        encoders.end());
-    if (encoders.empty()) {
-      std::cerr << "Unknown encoder: " << FLAGS_encoder << "\n";
-      return 1;
-    }
-  }
-  if (FLAGS_dataset != "all") {
-    datasets.erase(
-        std::remove_if(
-            datasets.begin(),
-            datasets.end(),
-            [&](const DatasetEntry& d) { return d.name != FLAGS_dataset; }),
-        datasets.end());
-    if (datasets.empty()) {
-      std::cerr << "Unknown dataset: " << FLAGS_dataset << "\n";
-      return 1;
-    }
-  }
+  std::cout << "bench_compression: " << encoders.size() << " encoders x "
+            << datasets.size() << " datasets, N=" << n << "\n\n";
 
-  // --dry-run: just print the sweep plan
   if (FLAGS_dry_run) {
-    std::cout << "Sweep plan: " << datasets.size() << " dataset(s) x "
-              << encoders.size() << " encoder(s), N=" << n << ", seed=" << seed
-              << "\n\nDatasets:\n";
-    for (const auto& d : datasets) {
+    std::cout << "Encoders:\n";
+    for (const auto& e : encoders)
+      std::cout << "  " << e.name << " [" << e.family << "]\n";
+    std::cout << "\nDatasets:\n";
+    for (const auto& d : datasets)
       std::cout << "  " << d.name << "\n";
-    }
-    std::cout << "\nEncoders:\n";
-    for (const auto& e : encoders) {
-      std::cout << "  " << e.name << " [" << e.family << "/" << e.variant
-                << "]\n";
-    }
     return 0;
   }
 
-  seedRng(seed);
-
-  // Open output stream
-  std::ofstream fileOut;
-  std::ostream* csvOut = &std::cout;
-  if (!FLAGS_output.empty()) {
-    fileOut.open(FLAGS_output);
-    if (!fileOut) {
-      std::cerr << "Cannot open output file: " << FLAGS_output << "\n";
-      return 1;
-    }
-    csvOut = &fileOut;
+  std::vector<std::string> csvColumns = {
+      "driver",     "dataset",    "encoding",   "family",
+      "variant",    "is_sequential", "N",        "seed",
+      "payload_bytes", "raw_bytes", "compression_ratio",
+      "bits_per_elem", "skipped"};
+  std::string csvPath = FLAGS_mlidc_output_csv.empty()
+      ? "bench_compression.csv"
+      : FLAGS_mlidc_output_csv;
+  CsvResultWriter csv(csvPath, csvColumns);
+  if (!FLAGS_mlidc_output_manifest.empty()) {
+    writeRunManifest(FLAGS_mlidc_output_manifest);
   }
-
-  writeCsvHeader(*csvOut);
 
   int validateFailures = 0;
 
   for (const auto& ds : datasets) {
-    // Generate data once per dataset
-    auto data = ds.generate(n);
-    const size_t rawBytes = static_cast<size_t>(n) * sizeof(int64_t);
+    std::cout << "== Dataset: " << ds.name << " ==\n";
+    auto data = ds.generate(n, seed);
+    const size_t rawBytes = static_cast<size_t>(n) * kElemSize;
 
-    for (auto& enc : encoders) {
-      // Each encode gets a fresh buffer (must outlive the string_view)
-      facebook::nimble::Buffer buf{
-          *facebook::nimble::benchmarks::benchmarkPool()};
+    for (const auto& enc : encoders) {
       facebook::nimble::Encoding::Options opts;
-
-      std::string encoded;
+      std::unique_ptr<NimbleBenchTargetBase<Elem>> target;
       bool skipped = false;
-
       try {
-        encoded = enc.encodeFn(data, opts, buf);
+        target = enc.factory(data, opts);
       } catch (const std::exception& ex) {
-        std::cerr << "[SKIP] " << enc.name << " / " << ds.name << ": "
-                  << ex.what() << "\n";
-        skipped = true;
-      } catch (...) {
-        std::cerr << "[SKIP] " << enc.name << " / " << ds.name
-                  << ": unknown exception\n";
+        std::cerr << "  [SKIP] " << enc.name << ": " << ex.what() << "\n";
         skipped = true;
       }
-
       if (skipped) {
-        writeCsvRow(
-            *csvOut, ds.name, enc, n, seed, 0, 0.0, 0.0, /*skipped=*/true);
+        csv.beginRow();
+        csv.set("driver", "bench_compression");
+        csv.set("dataset", ds.name);
+        csv.set("encoding", enc.name);
+        csv.set("skipped", int64_t{1});
+        csv.endRow();
         continue;
       }
 
-      const size_t payloadBytes = encoded.size();
-      const double ratio =
-          rawBytes > 0 ? static_cast<double>(payloadBytes) / rawBytes : 0.0;
-      const double bitsPerElem =
-          n > 0 ? (static_cast<double>(payloadBytes) * 8.0) / n : 0.0;
+      const size_t payloadBytes = target->payloadSize();
+      const double ratio = rawBytes > 0
+          ? static_cast<double>(payloadBytes) / static_cast<double>(rawBytes)
+          : 0.0;
+      const double bpe = n > 0
+          ? static_cast<double>(payloadBytes) * 8.0 / static_cast<double>(n)
+          : 0.0;
 
-      // Optional round-trip validation
-      if (FLAGS_validate) {
-        bool ok = false;
-        try {
-          ok = enc.validateFn(encoded, data, opts);
-        } catch (const std::exception& ex) {
-          std::cerr << "[VALIDATE EXCEPTION] " << enc.name << " / " << ds.name
-                    << ": " << ex.what() << "\n";
+      if (FLAGS_validate && enc.variant != "fpe_noindex") {
+        std::vector<Elem> check(n);
+        target->materializeAll(check.data(), n);
+        bool ok = true;
+        for (uint32_t i = 0; i < n; ++i) {
+          if (check[i] != data[i]) {
+            ok = false;
+            break;
+          }
         }
         if (!ok) {
-          std::cerr << "[VALIDATE FAIL] " << enc.name << " / " << ds.name
+          std::cerr << "  [VALIDATE FAIL] " << enc.name << " / " << ds.name
                     << "\n";
           ++validateFailures;
-          // Exclude from output; mark skipped
-          writeCsvRow(
-              *csvOut,
-              ds.name,
-              enc,
-              n,
-              seed,
-              0,
-              0.0,
-              0.0,
-              /*skipped=*/true);
+          csv.beginRow();
+          csv.set("driver", "bench_compression");
+          csv.set("dataset", ds.name);
+          csv.set("encoding", enc.name);
+          csv.set("skipped", int64_t{1});
+          csv.endRow();
           continue;
         }
       }
 
-      writeCsvRow(
-          *csvOut,
-          ds.name,
-          enc,
-          n,
-          seed,
-          payloadBytes,
-          ratio,
-          bitsPerElem,
-          /*skipped=*/false);
+      std::cout << "  " << enc.name << ": " << payloadBytes << " B, "
+                << std::fixed << std::setprecision(2) << bpe << " bpe\n";
+
+      csv.beginRow();
+      csv.set("driver", "bench_compression");
+      csv.set("dataset", ds.name);
+      csv.set("encoding", enc.name);
+      csv.set("family", enc.family);
+      csv.set("variant", enc.variant);
+      csv.set("is_sequential", enc.isSequential ? int64_t{1} : int64_t{0});
+      csv.set("N", static_cast<int64_t>(n));
+      csv.set("seed", static_cast<int64_t>(seed));
+      csv.set("payload_bytes", static_cast<int64_t>(payloadBytes));
+      csv.set("raw_bytes", static_cast<int64_t>(rawBytes));
+      csv.set("compression_ratio", ratio);
+      csv.set("bits_per_elem", bpe);
+      csv.set("skipped", int64_t{0});
+      csv.endRow();
     }
+    csv.flush();
   }
 
+  std::cout << "\nResults written to: " << csvPath << "\n";
   if (validateFailures > 0) {
-    std::cerr << validateFailures
-              << " validation failure(s); see rows with skipped=true.\n";
+    std::cerr << validateFailures << " validation failure(s)\n";
     return 2;
   }
   return 0;
 }
+
+#else
+
+#include <iostream>
+int main() {
+  std::cerr
+      << "bench_compression requires NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS\n";
+  return 1;
+}
+
+#endif

--- a/dwio/nimble/ML_ID_Compression/bench_compression.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_compression.cpp
@@ -1,0 +1,549 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// bench_compression.cpp
+//
+// Phase-1 driver: encoded-size only, no timing.  Proves the encode path works
+// end-to-end across the candidate encodings for ML ID columns.
+//
+// Usage:
+//   bench_compression [--n=<rows>] [--seed=<seed>]
+//                     [--dataset=<name>|all] [--encoder=<name>|all]
+//                     [--output=<file.csv>]
+//                     [--validate] [--dry_run]
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <fstream>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "dwio/nimble/common/Buffer.h"
+#include "dwio/nimble/common/Vector.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/benchmarks/BenchmarkUtils.h"
+#include "dwio/nimble/encodings/common/Encoding.h"
+#include "dwio/nimble/encodings/common/EncodingFactory.h"
+#include "dwio/nimble/encodings/tests/TestUtils.h"
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
+#endif
+#include "folly/Random.h"
+#include "velox/common/memory/Memory.h"
+
+// ---------------------------------------------------------------------------
+// CLI flags
+// ---------------------------------------------------------------------------
+DEFINE_int32(n, 100000, "Number of elements to generate per dataset");
+DEFINE_int32(seed, 42, "RNG seed (currently informational; folly uses global)");
+DEFINE_string(dataset, "all", "Dataset name to run, or 'all'");
+DEFINE_string(encoder, "all", "Encoder name to run, or 'all'");
+DEFINE_string(output, "", "Path for CSV output (stdout if empty)");
+DEFINE_bool(validate, false, "Decode-and-compare round-trip after each encode");
+DEFINE_bool(dry_run, false, "Print sweep plan and exit without encoding");
+
+namespace facebook::nimble::mlidc {
+
+using namespace facebook::nimble;
+using namespace facebook::nimble::benchmarks;
+using namespace facebook::nimble::test;
+
+// ---------------------------------------------------------------------------
+// Type-erased encoder entry
+// ---------------------------------------------------------------------------
+struct EncoderEntry {
+  std::string name;
+  std::string family;
+  std::string variant;
+  bool isSequential;
+  bool fastSkip;
+  bool randomAccess;
+
+  // Encode values into a fresh Buffer; return the encoded byte string.
+  // The buffer is passed in so the caller can keep it alive.
+  std::function<std::string(const Vector<int64_t>&, Encoding::Options&, Buffer&)>
+      encodeFn;
+
+  // Decode back from the encoded string; compare with original.
+  // Returns true if round-trip matches.
+  std::function<bool(
+      const std::string& encoded,
+      const Vector<int64_t>& original,
+      Encoding::Options& options)>
+      validateFn;
+};
+
+// ---------------------------------------------------------------------------
+// Type-erased dataset entry
+// ---------------------------------------------------------------------------
+struct DatasetEntry {
+  std::string name;
+  std::function<Vector<int64_t>(int n)> generate;
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Seed folly's random engine before generating data so results are
+// reproducible across runs with the same --seed.
+static void seedRng(int seed) {
+  folly::Random::DefaultGenerator rng;
+  rng.seed(static_cast<uint32_t>(seed));
+  // folly::Random itself seeds from /dev/urandom; we just note the seed in
+  // the output for reproducibility metadata.  Full seeding would require
+  // threading a generator through the generators; omitted for Phase 1.
+  (void)rng;
+}
+
+// ---------------------------------------------------------------------------
+// Build the encoder table
+// ---------------------------------------------------------------------------
+static std::vector<EncoderEntry> buildEncoders() {
+  std::vector<EncoderEntry> encoders;
+
+  // Lambda helpers that capture the encoding type statically.
+  auto addEncoder =
+      [&](std::string name,
+          std::string family,
+          std::string variant,
+          bool isSeq,
+          bool fastSkip,
+          bool randAccess,
+          std::function<
+              std::string(const Vector<int64_t>&, Encoding::Options&, Buffer&)>
+              encFn,
+          std::function<bool(
+              const std::string&,
+              const Vector<int64_t>&,
+              Encoding::Options&)> valFn) {
+        encoders.push_back(
+            {std::move(name),
+             std::move(family),
+             std::move(variant),
+             isSeq,
+             fastSkip,
+             randAccess,
+             std::move(encFn),
+             std::move(valFn)});
+      };
+
+  // Common validation lambda factory
+  auto makeValidator = [](Encoding::Options opts) {
+    return [opts](
+               const std::string& encoded,
+               const Vector<int64_t>& original,
+               Encoding::Options& /*options*/) -> bool {
+      auto& pool = benchmarkPool();
+      EncodingFactory factory{opts};
+      auto enc = factory.create(*pool, encoded, nullFactory());
+      std::vector<int64_t> out(original.size());
+      enc->materialize(static_cast<uint32_t>(original.size()), out.data());
+      for (size_t i = 0; i < original.size(); ++i) {
+        if (out[i] != original[i]) {
+          return false;
+        }
+      }
+      return true;
+    };
+  };
+
+  // --- Trivial ---
+  addEncoder(
+      "Trivial",
+      "Baseline",
+      "trivial",
+      /*isSeq=*/true,
+      /*fastSkip=*/true,
+      /*randAccess=*/false,
+      [](const Vector<int64_t>& data, Encoding::Options& opts, Buffer& buf) {
+        return std::string{
+            Encoder<TrivialEncoding<int64_t>>::encode(
+                buf, data, CompressionType::Uncompressed, opts)};
+      },
+      makeValidator({}));
+
+  // --- FixedBitWidth ---
+  addEncoder(
+      "FixedBitWidth",
+      "Baseline",
+      "fbw",
+      true,
+      true,
+      false,
+      [](const Vector<int64_t>& data, Encoding::Options& opts, Buffer& buf) {
+        return std::string{
+            Encoder<FixedBitWidthEncoding<int64_t>>::encode(
+                buf, data, CompressionType::Uncompressed, opts)};
+      },
+      makeValidator({}));
+
+  // --- Dictionary ---
+  addEncoder(
+      "Dictionary",
+      "Baseline",
+      "dict",
+      true,
+      false,
+      false,
+      [](const Vector<int64_t>& data, Encoding::Options& opts, Buffer& buf) {
+        return std::string{
+            Encoder<DictionaryEncoding<int64_t>>::encode(
+                buf, data, CompressionType::Uncompressed, opts)};
+      },
+      makeValidator({}));
+
+  // --- RLE ---
+  addEncoder(
+      "RLE",
+      "Baseline",
+      "rle",
+      true,
+      true,
+      false,
+      [](const Vector<int64_t>& data, Encoding::Options& opts, Buffer& buf) {
+        return std::string{
+            Encoder<RLEEncoding<int64_t>>::encode(
+                buf, data, CompressionType::Uncompressed, opts)};
+      },
+      makeValidator({}));
+
+  // --- FPE variants (index types 0..3) ---
+  const std::array<std::string, 4> fpeVariantNames = {
+      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
+  const std::array<bool, 4> fpeRandomAccess = {false, true, true, true};
+  const std::array<bool, 4> fpeFastSkip = {false, true, true, true};
+
+  for (int idx = 0; idx < 4; ++idx) {
+    addEncoder(
+        "FPE/" + fpeVariantNames[idx],
+        "FrequencyPartition",
+        fpeVariantNames[idx],
+        /*isSeq=*/true,
+        fpeFastSkip[idx],
+        fpeRandomAccess[idx],
+        [idx](
+            const Vector<int64_t>& data,
+            Encoding::Options& opts,
+            Buffer& buf) {
+          opts.frequencyPartitionIndex = static_cast<uint8_t>(idx);
+          return std::string{
+              Encoder<FrequencyPartitionEncoding<int64_t>>::encode(
+                  buf, data, CompressionType::Uncompressed, opts)};
+        },
+        [idx](
+            const std::string& encoded,
+            const Vector<int64_t>& original,
+            Encoding::Options& /*opts*/) -> bool {
+          // NoIndex (idx 0) reorders by frequency with no restoration
+          // index, so round-trip to original order is not possible.
+          if (idx == 0) {
+            return true;
+          }
+          auto& pool = benchmarkPool();
+          Encoding::Options decodeOpts;
+          decodeOpts.frequencyPartitionIndex = static_cast<uint8_t>(idx);
+          FrequencyPartitionEncoding<int64_t> enc{
+              *pool, encoded, nullFactory(), decodeOpts};
+          std::vector<int64_t> out(original.size());
+          enc.materialize(
+              static_cast<uint32_t>(original.size()), out.data());
+          for (size_t i = 0; i < original.size(); ++i) {
+            if (out[i] != original[i]) {
+              return false;
+            }
+          }
+          return true;
+        });
+  }
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+  // --- SubIntSplit with realNestedSelection ---
+  // NOTE: EncodingFactory does NOT dispatch SubIntSplit, so validation must
+  // go through test::Encoder<E>::createEncoding() rather than the factory.
+  addEncoder(
+      "SIS/realNested",
+      "SubIntSplit",
+      "real_nested",
+      /*isSeq=*/false,
+      /*fastSkip=*/false,
+      /*randAccess=*/false,
+      [](const Vector<int64_t>& data, Encoding::Options& opts, Buffer& buf) {
+        return std::string{
+            Encoder<SubIntSplitEncoding<int64_t>>::encode(
+                buf,
+                data,
+                CompressionType::Uncompressed,
+                opts,
+                /*realNestedSelection=*/true)};
+      },
+      [](const std::string& encoded,
+         const Vector<int64_t>& original,
+         Encoding::Options& /*opts*/) -> bool {
+        auto& pool = benchmarkPool();
+        // Construct directly — EncodingFactory cannot dispatch SubIntSplit.
+        SubIntSplitEncoding<int64_t> enc{*pool, encoded, nullFactory()};
+        std::vector<int64_t> out(original.size());
+        enc.materialize(static_cast<uint32_t>(original.size()), out.data());
+        for (size_t i = 0; i < original.size(); ++i) {
+          if (out[i] != original[i]) {
+            return false;
+          }
+        }
+        return true;
+      });
+#endif
+
+  return encoders;
+}
+
+// ---------------------------------------------------------------------------
+// Build the dataset table
+// ---------------------------------------------------------------------------
+static std::vector<DatasetEntry> buildDatasets() {
+  return {
+      {"UniformRandom",
+       [](int n) {
+         auto& pool = benchmarkPool();
+         Vector<int64_t> data{pool.get()};
+         data.resize(static_cast<uint32_t>(n));
+         for (int i = 0; i < n; ++i) {
+           data[i] = static_cast<int64_t>(folly::Random::secureRand64());
+         }
+         return data;
+       }},
+      {"LowCardinality16",
+       [](int n) {
+         return makeLowCardinality<int64_t>(16, static_cast<uint32_t>(n));
+       }},
+      {"RunLength",
+       [](int n) {
+         return makeRunLength<int64_t>(static_cast<uint32_t>(n));
+       }},
+      {"Increasing",
+       [](int n) {
+         return makeIncreasing<int64_t>(static_cast<uint32_t>(n));
+       }},
+      {"Narrow20",
+       [](int n) {
+         return makeNarrow<int64_t>(20, static_cast<uint32_t>(n));
+       }},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CSV output
+// ---------------------------------------------------------------------------
+static void writeCsvHeader(std::ostream& out) {
+  out << "driver,dataset,encoding,family,variant,is_sequential,fast_skip,"
+         "random_access,N,seed,payload_bytes,compression_ratio,"
+         "bits_per_element,skipped\n";
+}
+
+static void writeCsvRow(
+    std::ostream& out,
+    const std::string& dataset,
+    const EncoderEntry& enc,
+    int n,
+    int seed,
+    size_t payloadBytes,
+    double ratio,
+    double bitsPerElem,
+    bool skipped) {
+  out << "bench_compression" << ',' << dataset << ',' << enc.name << ','
+      << enc.family << ',' << enc.variant << ','
+      << (enc.isSequential ? "true" : "false") << ','
+      << (enc.fastSkip ? "true" : "false") << ','
+      << (enc.randomAccess ? "true" : "false") << ',' << n << ',' << seed
+      << ',' << payloadBytes << ',' << std::fixed << std::setprecision(4)
+      << ratio << ',' << std::fixed << std::setprecision(4) << bitsPerElem
+      << ',' << (skipped ? "true" : "false") << '\n';
+}
+
+} // namespace facebook::nimble::mlidc
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, /*remove_flags=*/true);
+  facebook::velox::memory::MemoryManager::initialize({});
+
+  using namespace facebook::nimble::mlidc;
+
+  const int n = FLAGS_n;
+  const int seed = FLAGS_seed;
+
+  auto encoders = buildEncoders();
+  auto datasets = buildDatasets();
+
+  // Apply --encoder / --dataset filters
+  if (FLAGS_encoder != "all") {
+    encoders.erase(
+        std::remove_if(
+            encoders.begin(),
+            encoders.end(),
+            [&](const EncoderEntry& e) { return e.name != FLAGS_encoder; }),
+        encoders.end());
+    if (encoders.empty()) {
+      std::cerr << "Unknown encoder: " << FLAGS_encoder << "\n";
+      return 1;
+    }
+  }
+  if (FLAGS_dataset != "all") {
+    datasets.erase(
+        std::remove_if(
+            datasets.begin(),
+            datasets.end(),
+            [&](const DatasetEntry& d) { return d.name != FLAGS_dataset; }),
+        datasets.end());
+    if (datasets.empty()) {
+      std::cerr << "Unknown dataset: " << FLAGS_dataset << "\n";
+      return 1;
+    }
+  }
+
+  // --dry-run: just print the sweep plan
+  if (FLAGS_dry_run) {
+    std::cout << "Sweep plan: " << datasets.size() << " dataset(s) x "
+              << encoders.size() << " encoder(s), N=" << n << ", seed=" << seed
+              << "\n\nDatasets:\n";
+    for (const auto& d : datasets) {
+      std::cout << "  " << d.name << "\n";
+    }
+    std::cout << "\nEncoders:\n";
+    for (const auto& e : encoders) {
+      std::cout << "  " << e.name << " [" << e.family << "/" << e.variant
+                << "]\n";
+    }
+    return 0;
+  }
+
+  seedRng(seed);
+
+  // Open output stream
+  std::ofstream fileOut;
+  std::ostream* csvOut = &std::cout;
+  if (!FLAGS_output.empty()) {
+    fileOut.open(FLAGS_output);
+    if (!fileOut) {
+      std::cerr << "Cannot open output file: " << FLAGS_output << "\n";
+      return 1;
+    }
+    csvOut = &fileOut;
+  }
+
+  writeCsvHeader(*csvOut);
+
+  int validateFailures = 0;
+
+  for (const auto& ds : datasets) {
+    // Generate data once per dataset
+    auto data = ds.generate(n);
+    const size_t rawBytes = static_cast<size_t>(n) * sizeof(int64_t);
+
+    for (auto& enc : encoders) {
+      // Each encode gets a fresh buffer (must outlive the string_view)
+      facebook::nimble::Buffer buf{
+          *facebook::nimble::benchmarks::benchmarkPool()};
+      facebook::nimble::Encoding::Options opts;
+
+      std::string encoded;
+      bool skipped = false;
+
+      try {
+        encoded = enc.encodeFn(data, opts, buf);
+      } catch (const std::exception& ex) {
+        std::cerr << "[SKIP] " << enc.name << " / " << ds.name << ": "
+                  << ex.what() << "\n";
+        skipped = true;
+      } catch (...) {
+        std::cerr << "[SKIP] " << enc.name << " / " << ds.name
+                  << ": unknown exception\n";
+        skipped = true;
+      }
+
+      if (skipped) {
+        writeCsvRow(
+            *csvOut, ds.name, enc, n, seed, 0, 0.0, 0.0, /*skipped=*/true);
+        continue;
+      }
+
+      const size_t payloadBytes = encoded.size();
+      const double ratio =
+          rawBytes > 0 ? static_cast<double>(payloadBytes) / rawBytes : 0.0;
+      const double bitsPerElem =
+          n > 0 ? (static_cast<double>(payloadBytes) * 8.0) / n : 0.0;
+
+      // Optional round-trip validation
+      if (FLAGS_validate) {
+        bool ok = false;
+        try {
+          ok = enc.validateFn(encoded, data, opts);
+        } catch (const std::exception& ex) {
+          std::cerr << "[VALIDATE EXCEPTION] " << enc.name << " / " << ds.name
+                    << ": " << ex.what() << "\n";
+        }
+        if (!ok) {
+          std::cerr << "[VALIDATE FAIL] " << enc.name << " / " << ds.name
+                    << "\n";
+          ++validateFailures;
+          // Exclude from output; mark skipped
+          writeCsvRow(
+              *csvOut,
+              ds.name,
+              enc,
+              n,
+              seed,
+              0,
+              0.0,
+              0.0,
+              /*skipped=*/true);
+          continue;
+        }
+      }
+
+      writeCsvRow(
+          *csvOut,
+          ds.name,
+          enc,
+          n,
+          seed,
+          payloadBytes,
+          ratio,
+          bitsPerElem,
+          /*skipped=*/false);
+    }
+  }
+
+  if (validateFailures > 0) {
+    std::cerr << validateFailures
+              << " validation failure(s); see rows with skipped=true.\n";
+    return 2;
+  }
+  return 0;
+}

--- a/dwio/nimble/ML_ID_Compression/bench_costmodel_oracle.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_costmodel_oracle.cpp
@@ -1,0 +1,641 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// bench_costmodel_oracle: validates SubIntSplit's cost-model-driven DP
+// selector against an "oracle" that actually encodes each candidate bit
+// range with every candidate encoding and measures real byte counts.
+//
+// For every dataset this driver: samples the stream, builds an oracle grid
+// (measured bytes per [l..r] range per encoding) and a cost-model grid
+// (bestCostBits() estimates for the same ranges), runs both AutoSIS's
+// selectSplits() DP and a simple unconstrained oracle DP, and reports
+// per-cell agreement (top-1 accuracy, Spearman rho, mean |rel err|) plus
+// plan-level regret between the cost model's choice and the oracle optimum.
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <limits>
+#include <numeric>
+#include <span>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+
+#include "dwio/nimble/encodings/ConstantEncoding.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/MainlyConstantEncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitCostModels.h"
+#include "dwio/nimble/encodings/SubIntSplitMetrics.h"
+#include "dwio/nimble/encodings/SubIntSplitSampler.h"
+#include "dwio/nimble/encodings/SubIntSplitSelector.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+#include "dwio/nimble/encodings/VarintEncoding.h"
+
+DEFINE_bool(validate, false, "Sanity-check oracle encode calls do not throw");
+DEFINE_bool(dry_run, false, "Print sweep plan and exit");
+
+namespace facebook::nimble::mlidc {
+namespace {
+
+using namespace facebook::nimble::detail::subintsplit;
+
+using Elem = int64_t;
+constexpr int kBits = 64;
+
+struct CandidateEncoding {
+  std::string name;
+  EncodingType type;
+};
+
+// Try to encode `sectionData` with EncodingT; return byte count, or SIZE_MAX
+// on failure (throws, e.g. Constant on non-constant data).
+template <typename EncodingT>
+size_t tryEncode(const Vector<Elem>& sectionData) {
+  try {
+    auto& pool = benchmarks::benchmarkPool();
+    Buffer buf{*pool};
+    facebook::nimble::Encoding::Options opts;
+    auto encoded = test::Encoder<EncodingT>::encode(
+        buf, sectionData, CompressionType::Uncompressed, opts);
+    return encoded.size();
+  } catch (...) {
+    return std::numeric_limits<size_t>::max();
+  }
+}
+
+// Dispatch oracle encode by EncodingType (only the 7 candidates we track).
+size_t oracleEncodeBytes(EncodingType type, const Vector<Elem>& sectionData) {
+  switch (type) {
+    case EncodingType::Trivial:
+      return tryEncode<TrivialEncoding<Elem>>(sectionData);
+    case EncodingType::FixedBitWidth:
+      return tryEncode<FixedBitWidthEncoding<Elem>>(sectionData);
+    case EncodingType::Constant:
+      return tryEncode<ConstantEncoding<Elem>>(sectionData);
+    case EncodingType::MainlyConstant:
+      return tryEncode<MainlyConstantEncoding<Elem>>(sectionData);
+    case EncodingType::Dictionary:
+      return tryEncode<DictionaryEncoding<Elem>>(sectionData);
+    case EncodingType::RLE:
+      return tryEncode<RLEEncoding<Elem>>(sectionData);
+    case EncodingType::Varint:
+      return tryEncode<VarintEncoding<Elem>>(sectionData);
+    default:
+      return std::numeric_limits<size_t>::max();
+  }
+}
+
+std::vector<CandidateEncoding> candidateEncodings() {
+  return {
+      {"Trivial", EncodingType::Trivial},
+      {"FixedBitWidth", EncodingType::FixedBitWidth},
+      {"Constant", EncodingType::Constant},
+      {"MainlyConstant", EncodingType::MainlyConstant},
+      {"Dictionary", EncodingType::Dictionary},
+      {"RLE", EncodingType::RLE},
+      {"Varint", EncodingType::Varint},
+  };
+}
+
+struct OracleResult {
+  size_t bytes{std::numeric_limits<size_t>::max()};
+};
+
+struct OracleCell {
+  size_t bestBytes{std::numeric_limits<size_t>::max()};
+  EncodingType bestEncoding{EncodingType::Trivial};
+  std::vector<OracleResult> results; // parallel to candidateEncodings()
+};
+
+struct ModelCell {
+  double bestBits{std::numeric_limits<double>::infinity()};
+  EncodingType bestEncoding{EncodingType::Trivial};
+  std::vector<double> estBits; // parallel to candidateEncodings(), per-encoding
+};
+
+// Spearman rank correlation between two equal-length rank vectors (1-based
+// dense ranks are fine; ties broken by encounter order, matching the
+// playground's approach).
+double spearmanRho(
+    const std::vector<double>& a,
+    const std::vector<double>& b) {
+  const size_t n = a.size();
+  if (n < 3) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  auto rankOf = [n](const std::vector<double>& v) {
+    std::vector<size_t> idx(n);
+    std::iota(idx.begin(), idx.end(), 0);
+    std::sort(
+        idx.begin(), idx.end(), [&](size_t i, size_t j) { return v[i] < v[j]; });
+    std::vector<double> rank(n);
+    for (size_t r = 0; r < n; ++r) {
+      rank[idx[r]] = static_cast<double>(r);
+    }
+    return rank;
+  };
+  auto ra = rankOf(a);
+  auto rb = rankOf(b);
+  double sumSqDiff = 0.0;
+  for (size_t i = 0; i < n; ++i) {
+    const double d = ra[i] - rb[i];
+    sumSqDiff += d * d;
+  }
+  const double nd = static_cast<double>(n);
+  return 1.0 - (6.0 * sumSqDiff) / (nd * (nd * nd - 1.0));
+}
+
+// Simple unconstrained oracle DP over the measured grid: minimises total
+// measured bytes, no split penalty.
+struct OracleSegment {
+  int bitStart{0};
+  int bitEnd{0};
+  EncodingType encoding{EncodingType::Trivial};
+  size_t bytes{0};
+};
+
+struct OracleDpResult {
+  std::vector<OracleSegment> segments;
+  size_t totalBytes{0};
+};
+
+OracleDpResult oracleDp(
+    const std::vector<std::vector<OracleCell>>& grid,
+    int sz) {
+  std::vector<double> dp(sz + 1, std::numeric_limits<double>::infinity());
+  std::vector<int> prev(sz + 1, -1);
+  dp[0] = 0.0;
+  for (int i = 1; i <= sz; ++i) {
+    for (int j = 0; j < i; ++j) {
+      const auto& cell = grid[j][i - 1];
+      if (cell.bestBytes == std::numeric_limits<size_t>::max()) {
+        continue;
+      }
+      const double candidate = dp[j] + static_cast<double>(cell.bestBytes);
+      if (candidate < dp[i]) {
+        dp[i] = candidate;
+        prev[i] = j;
+      }
+    }
+  }
+  OracleDpResult result;
+  if (!std::isfinite(dp[sz])) {
+    return result;
+  }
+  result.totalBytes = static_cast<size_t>(dp[sz]);
+  int idx = sz;
+  while (idx > 0) {
+    const int start = prev[idx];
+    if (start < 0) {
+      break;
+    }
+    const auto& cell = grid[start][idx - 1];
+    result.segments.push_back(
+        {start, idx - 1, cell.bestEncoding, cell.bestBytes});
+    idx = start;
+  }
+  std::reverse(result.segments.begin(), result.segments.end());
+  return result;
+}
+
+} // namespace
+} // namespace facebook::nimble::mlidc
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  facebook::velox::memory::MemoryManager::initialize({});
+
+  using namespace facebook::nimble;
+  using namespace facebook::nimble::mlidc;
+  using namespace facebook::nimble::detail::subintsplit;
+
+  const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
+  const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
+
+  auto datasets = defaultInt64Datasets<Elem>();
+  auto candidates = candidateEncodings();
+
+  std::cout << "bench_costmodel_oracle: " << datasets.size()
+            << " datasets, N=" << n << ", kBits=" << kBits << "\n\n";
+
+  if (FLAGS_dry_run) {
+    std::cout << "Datasets:\n";
+    for (const auto& d : datasets) {
+      std::cout << "  " << d.name << "\n";
+    }
+    std::cout << "Candidate encodings:\n";
+    for (const auto& c : candidates) {
+      std::cout << "  " << c.name << "\n";
+    }
+    return 0;
+  }
+
+  std::vector<std::string> csvColumns = {
+      "driver",
+      "dataset",
+      "N",
+      "seed",
+      "sample_size",
+      "min_segment_width",
+      "l",
+      "r",
+      "width",
+      "encoding",
+      "has_cost_model",
+      "est_bits",
+      "actual_bytes",
+      "actual_bits_per_elem",
+      "rel_err",
+      "model_rank",
+      "actual_rank",
+      "is_model_pick",
+      "is_oracle_pick",
+      "plan_type",
+      "plan_segment_count",
+      "plan_total_sample_bytes",
+      "top1_accuracy",
+      "spearman_rho",
+      "mean_abs_rel_err",
+      "regret_sample_bytes",
+      "skipped"};
+
+  std::string csvPath = FLAGS_mlidc_output_csv.empty()
+      ? "bench_costmodel_oracle.csv"
+      : FLAGS_mlidc_output_csv;
+  CsvResultWriter csv(csvPath, csvColumns);
+
+  if (!FLAGS_mlidc_output_manifest.empty()) {
+    writeRunManifest(FLAGS_mlidc_output_manifest);
+  }
+
+  SamplerConfig samplerCfg = defaultSamplerConfig();
+  SelectorConfig selectorCfg = defaultSelectorConfig();
+  const MetricFlags requiredFlags = allCostModelRequiredFlags();
+
+  for (const auto& ds : datasets) {
+    std::cout << "== Dataset: " << ds.name << " ==\n";
+    auto data = ds.generate(n, seed);
+
+    std::vector<uint64_t> samples;
+    sampleIntoU64(
+        std::span<const Elem>(data.data(), data.size()), samples, samplerCfg);
+    const size_t sampleSize = samples.size();
+    if (sampleSize == 0) {
+      std::cerr << "  [SKIP] empty sample\n";
+      continue;
+    }
+
+    // -----------------------------------------------------------------
+    // Build oracle grid + cost model grid over [l..r], 0 <= l <= r < kBits.
+    // -----------------------------------------------------------------
+    std::vector<std::vector<OracleCell>> oracleGrid(
+        kBits, std::vector<OracleCell>(kBits));
+    std::vector<std::vector<ModelCell>> modelGrid(
+        kBits, std::vector<ModelCell>(kBits));
+
+    MetricCollector collector;
+    BitRangeExtractor extractor(samples);
+    auto& pool = benchmarks::benchmarkPool();
+
+    int cellCount = 0;
+    int agreeCount = 0;
+    double spearmanSum = 0.0;
+    int spearmanCount = 0;
+    double relErrSum = 0.0;
+    int relErrCount = 0;
+
+    for (int l = 0; l < kBits; ++l) {
+      extractor.reset(l);
+      for (int r = l; r < kBits; ++r) {
+        extractor.extend(r);
+        const std::vector<uint64_t>& sectionU64 = extractor.values();
+        const int width = r - l + 1;
+
+        // Convert to Vector<int64_t> for oracle encoding.
+        Vector<Elem> sectionData{pool.get()};
+        sectionData.resize(sectionU64.size());
+        for (size_t i = 0; i < sectionU64.size(); ++i) {
+          sectionData[i] = static_cast<Elem>(sectionU64[i]);
+        }
+
+        // Cost model metrics + per-encoding estimates.
+        const SegmentMetrics metrics = collector.compute(sectionU64, requiredFlags);
+        EncodingType modelBestEnc = EncodingType::Trivial;
+        const double modelBestBits =
+            bestCostBits(metrics, sampleSize, width, modelBestEnc);
+
+        ModelCell& mc = modelGrid[l][r];
+        mc.bestBits = modelBestBits;
+        mc.bestEncoding = modelBestEnc;
+        mc.estBits.resize(candidates.size());
+        for (size_t ci = 0; ci < candidates.size(); ++ci) {
+          double bits;
+          switch (candidates[ci].type) {
+            case EncodingType::Trivial:
+              bits = trivialCostBits(metrics, sampleSize, width);
+              break;
+            case EncodingType::FixedBitWidth:
+              bits = fixedBitWidthCostBits(metrics, sampleSize, width);
+              break;
+            case EncodingType::Constant:
+              bits = constantCostBits(metrics, sampleSize, width);
+              break;
+            case EncodingType::MainlyConstant:
+              bits = mainlyConstantCostBits(metrics, sampleSize, width);
+              break;
+            case EncodingType::Dictionary:
+              bits = dictionaryCostBits(metrics, sampleSize, width);
+              break;
+            case EncodingType::RLE:
+              bits = rleCostBits(metrics, sampleSize, width);
+              break;
+            case EncodingType::Varint:
+              bits = varintCostBits(metrics, sampleSize, width);
+              break;
+            default:
+              bits = std::numeric_limits<double>::infinity();
+          }
+          mc.estBits[ci] = bits;
+        }
+
+        // Oracle: actually encode with each candidate, measure bytes.
+        OracleCell& oc = oracleGrid[l][r];
+        oc.results.resize(candidates.size());
+        for (size_t ci = 0; ci < candidates.size(); ++ci) {
+          const size_t bytes =
+              oracleEncodeBytes(candidates[ci].type, sectionData);
+          oc.results[ci].bytes = bytes;
+          if (bytes < oc.bestBytes) {
+            oc.bestBytes = bytes;
+            oc.bestEncoding = candidates[ci].type;
+          }
+        }
+
+        // Per-cell comparisons.
+        ++cellCount;
+        if (oc.bestBytes != std::numeric_limits<size_t>::max() &&
+            oc.bestEncoding == mc.bestEncoding) {
+          ++agreeCount;
+        }
+
+        // Rank vectors over usable candidates (finite model estimate AND
+        // successful oracle encode) for Spearman rho.
+        std::vector<double> modelVals;
+        std::vector<double> actualVals;
+        for (size_t ci = 0; ci < candidates.size(); ++ci) {
+          const bool modelUsable = std::isfinite(mc.estBits[ci]);
+          const bool actualUsable =
+              oc.results[ci].bytes != std::numeric_limits<size_t>::max();
+          if (modelUsable && actualUsable) {
+            modelVals.push_back(mc.estBits[ci]);
+            actualVals.push_back(static_cast<double>(oc.results[ci].bytes));
+          }
+        }
+        double rho = std::numeric_limits<double>::quiet_NaN();
+        if (modelVals.size() >= 3) {
+          rho = spearmanRho(modelVals, actualVals);
+          if (std::isfinite(rho)) {
+            spearmanSum += rho;
+            ++spearmanCount;
+          }
+        }
+
+        // Compute ranks for CSV emission (1 = best/lowest).
+        std::vector<size_t> modelOrder(candidates.size());
+        std::iota(modelOrder.begin(), modelOrder.end(), 0);
+        std::sort(modelOrder.begin(), modelOrder.end(), [&](size_t a, size_t b) {
+          return mc.estBits[a] < mc.estBits[b];
+        });
+        std::vector<int> modelRank(candidates.size(), -1);
+        for (size_t rk = 0; rk < modelOrder.size(); ++rk) {
+          modelRank[modelOrder[rk]] = static_cast<int>(rk) + 1;
+        }
+
+        std::vector<size_t> actualOrder(candidates.size());
+        std::iota(actualOrder.begin(), actualOrder.end(), 0);
+        std::sort(
+            actualOrder.begin(), actualOrder.end(), [&](size_t a, size_t b) {
+              return oc.results[a].bytes < oc.results[b].bytes;
+            });
+        std::vector<int> actualRank(candidates.size(), -1);
+        for (size_t rk = 0; rk < actualOrder.size(); ++rk) {
+          actualRank[actualOrder[rk]] = static_cast<int>(rk) + 1;
+        }
+
+        for (size_t ci = 0; ci < candidates.size(); ++ci) {
+          const bool hasCostModel = std::isfinite(mc.estBits[ci]);
+          const bool oracleOk =
+              oc.results[ci].bytes != std::numeric_limits<size_t>::max();
+
+          csv.beginRow();
+          csv.set("driver", "bench_costmodel_oracle");
+          csv.set("dataset", ds.name);
+          csv.set("N", static_cast<int64_t>(n));
+          csv.set("seed", static_cast<int64_t>(seed));
+          csv.set("sample_size", static_cast<int64_t>(sampleSize));
+          csv.set(
+              "min_segment_width",
+              static_cast<int64_t>(selectorCfg.minSegmentWidth));
+          csv.set("l", static_cast<int64_t>(l));
+          csv.set("r", static_cast<int64_t>(r));
+          csv.set("width", static_cast<int64_t>(width));
+          csv.set("encoding", candidates[ci].name);
+          csv.set("has_cost_model", hasCostModel ? int64_t{1} : int64_t{0});
+          if (hasCostModel) {
+            csv.set("est_bits", mc.estBits[ci]);
+          }
+          if (oracleOk) {
+            csv.set(
+                "actual_bytes", static_cast<int64_t>(oc.results[ci].bytes));
+            const double bitsPerElem = sampleSize > 0
+                ? static_cast<double>(oc.results[ci].bytes) * 8.0 /
+                    static_cast<double>(sampleSize)
+                : 0.0;
+            csv.set("actual_bits_per_elem", bitsPerElem);
+            if (hasCostModel && oc.results[ci].bytes > 0) {
+              const double relErr =
+                  (mc.estBits[ci] -
+                   static_cast<double>(oc.results[ci].bytes) * 8.0) /
+                  (static_cast<double>(oc.results[ci].bytes) * 8.0);
+              csv.set("rel_err", relErr);
+              relErrSum += std::fabs(relErr);
+              ++relErrCount;
+            }
+          }
+          if (modelRank[ci] > 0) {
+            csv.set("model_rank", static_cast<int64_t>(modelRank[ci]));
+          }
+          if (actualRank[ci] > 0) {
+            csv.set("actual_rank", static_cast<int64_t>(actualRank[ci]));
+          }
+          csv.set(
+              "is_model_pick",
+              (hasCostModel && candidates[ci].type == mc.bestEncoding)
+                  ? int64_t{1}
+                  : int64_t{0});
+          csv.set(
+              "is_oracle_pick",
+              (oracleOk && candidates[ci].type == oc.bestEncoding)
+                  ? int64_t{1}
+                  : int64_t{0});
+          if (std::isfinite(rho) && ci == 0) {
+            csv.set("spearman_rho", rho);
+          }
+          csv.set("skipped", int64_t{0});
+          csv.endRow();
+        }
+      }
+    }
+    csv.flush();
+
+    const double top1Accuracy =
+        cellCount > 0 ? static_cast<double>(agreeCount) / cellCount : 0.0;
+    const double meanRho =
+        spearmanCount > 0 ? spearmanSum / spearmanCount : 0.0;
+    const double meanAbsRelErr =
+        relErrCount > 0 ? relErrSum / relErrCount : 0.0;
+
+    std::cout << "  top1_accuracy=" << top1Accuracy
+              << " mean_spearman_rho=" << meanRho
+              << " mean_abs_rel_err=" << meanAbsRelErr << "\n";
+
+    // -----------------------------------------------------------------
+    // Plan comparison: AutoSIS DP (cost-model driven) vs oracle DP.
+    // -----------------------------------------------------------------
+    SelectorResult autoResult =
+        selectSplits(samples, kBits, sampleSize, selectorCfg);
+    OracleDpResult oracleResult = oracleDp(oracleGrid, kBits);
+
+    // Regret: sum over AutoSIS's chosen segments of (measured bytes for the
+    // AutoSIS pick) minus (oracle's best bytes for that same [l..r] range).
+    size_t autoTotalSampleBytes = 0;
+    size_t regretBytes = 0;
+    for (const auto& seg : autoResult.segments) {
+      const auto& cell = oracleGrid[seg.bitStart][seg.bitEnd];
+      size_t autoBytesForPick = std::numeric_limits<size_t>::max();
+      for (size_t ci = 0; ci < candidates.size(); ++ci) {
+        if (candidates[ci].type == seg.encoding) {
+          autoBytesForPick = cell.results[ci].bytes;
+          break;
+        }
+      }
+      if (autoBytesForPick == std::numeric_limits<size_t>::max()) {
+        continue;
+      }
+      autoTotalSampleBytes += autoBytesForPick;
+      if (cell.bestBytes != std::numeric_limits<size_t>::max() &&
+          autoBytesForPick > cell.bestBytes) {
+        regretBytes += (autoBytesForPick - cell.bestBytes);
+      }
+
+      csv.beginRow();
+      csv.set("driver", "bench_costmodel_oracle");
+      csv.set("dataset", ds.name);
+      csv.set("N", static_cast<int64_t>(n));
+      csv.set("seed", static_cast<int64_t>(seed));
+      csv.set("sample_size", static_cast<int64_t>(sampleSize));
+      csv.set("l", static_cast<int64_t>(seg.bitStart));
+      csv.set("r", static_cast<int64_t>(seg.bitEnd));
+      csv.set("width", static_cast<int64_t>(seg.bitEnd - seg.bitStart + 1));
+      for (const auto& c : candidates) {
+        if (c.type == seg.encoding) {
+          csv.set("encoding", c.name);
+          break;
+        }
+      }
+      csv.set("actual_bytes", static_cast<int64_t>(autoBytesForPick));
+      csv.set("plan_type", "autosis");
+      csv.set(
+          "plan_segment_count",
+          static_cast<int64_t>(autoResult.segments.size()));
+      csv.set("skipped", int64_t{0});
+      csv.endRow();
+    }
+
+    for (const auto& seg : oracleResult.segments) {
+      csv.beginRow();
+      csv.set("driver", "bench_costmodel_oracle");
+      csv.set("dataset", ds.name);
+      csv.set("N", static_cast<int64_t>(n));
+      csv.set("seed", static_cast<int64_t>(seed));
+      csv.set("sample_size", static_cast<int64_t>(sampleSize));
+      csv.set("l", static_cast<int64_t>(seg.bitStart));
+      csv.set("r", static_cast<int64_t>(seg.bitEnd));
+      csv.set("width", static_cast<int64_t>(seg.bitEnd - seg.bitStart + 1));
+      for (const auto& c : candidates) {
+        if (c.type == seg.encoding) {
+          csv.set("encoding", c.name);
+          break;
+        }
+      }
+      csv.set("actual_bytes", static_cast<int64_t>(seg.bytes));
+      csv.set("plan_type", "oracle");
+      csv.set(
+          "plan_segment_count",
+          static_cast<int64_t>(oracleResult.segments.size()));
+      csv.set("skipped", int64_t{0});
+      csv.endRow();
+    }
+
+    // Summary row for this dataset.
+    csv.beginRow();
+    csv.set("driver", "bench_costmodel_oracle");
+    csv.set("dataset", ds.name);
+    csv.set("N", static_cast<int64_t>(n));
+    csv.set("seed", static_cast<int64_t>(seed));
+    csv.set("sample_size", static_cast<int64_t>(sampleSize));
+    csv.set(
+        "min_segment_width", static_cast<int64_t>(selectorCfg.minSegmentWidth));
+    csv.set("plan_type", "summary");
+    csv.set(
+        "plan_total_sample_bytes", static_cast<int64_t>(autoTotalSampleBytes));
+    csv.set("top1_accuracy", top1Accuracy);
+    csv.set("spearman_rho", meanRho);
+    csv.set("mean_abs_rel_err", meanAbsRelErr);
+    csv.set("regret_sample_bytes", static_cast<int64_t>(regretBytes));
+    csv.set("skipped", int64_t{0});
+    csv.endRow();
+    csv.flush();
+
+    std::cout << "  AutoSIS plan: " << autoResult.segments.size()
+              << " segments, sample_bytes=" << autoTotalSampleBytes << "\n";
+    std::cout << "  Oracle plan:  " << oracleResult.segments.size()
+              << " segments, sample_bytes=" << oracleResult.totalBytes
+              << "  regret=" << regretBytes << "\n";
+  }
+
+  std::cout << "\nResults written to: " << csvPath << "\n";
+  return 0;
+}
+
+#else
+
+#include <iostream>
+int main() {
+  std::cerr
+      << "bench_costmodel_oracle requires NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS\n";
+  return 1;
+}
+
+#endif

--- a/dwio/nimble/ML_ID_Compression/bench_decode_bulk.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_decode_bulk.cpp
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <algorithm>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
+#include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
+
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+
+DEFINE_string(cache_state, "hot", "hot | cold-payload | cold-all");
+DEFINE_bool(validate, false, "Round-trip check before measuring");
+DEFINE_bool(dry_run, false, "Print sweep plan and exit");
+
+namespace facebook::nimble::mlidc {
+namespace {
+
+using Elem = int64_t;
+constexpr size_t kElemSize = sizeof(Elem);
+
+bool parseCacheState(const std::string& text, CacheState& out) {
+  if (text == "hot") {
+    out = CacheState::Hot;
+    return true;
+  }
+  if (text == "cold-payload") {
+    out = CacheState::ColdPayload;
+    return true;
+  }
+  if (text == "cold-all") {
+    out = CacheState::ColdAll;
+    return true;
+  }
+  return false;
+}
+
+std::vector<EncoderEntry<Elem>> buildEncoders() {
+  std::vector<EncoderEntry<Elem>> encoders;
+
+  encoders.push_back(
+      makeEncoderEntry<TrivialEncoding<Elem>>(
+          "Trivial", "Baseline", "trivial", true, true, false));
+  encoders.push_back(
+      makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
+          "FixedBitWidth", "Baseline", "fbw", true, true, false));
+  encoders.push_back(
+      makeEncoderEntry<DictionaryEncoding<Elem>>(
+          "Dictionary", "Baseline", "dict", true, false, false));
+  encoders.push_back(
+      makeEncoderEntry<RLEEncoding<Elem>>(
+          "RLE", "Baseline", "rle", true, true, false));
+
+  const std::array<std::string, 4> fpeNames = {
+      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
+  const std::array<bool, 4> fpeRA = {false, true, true, true};
+  const std::array<bool, 4> fpeSkip = {false, true, true, true};
+
+  for (int idx = 0; idx < 4; ++idx) {
+    EncoderEntry<Elem> entry;
+    entry.name = "FPE/" + fpeNames[idx];
+    entry.family = "FrequencyPartition";
+    entry.variant = fpeNames[idx];
+    entry.isSequential = true;
+    entry.fastSkip = fpeSkip[idx];
+    entry.randomAccess = fpeRA[idx];
+    entry.factory = [idx](const Vector<Elem>& data,
+                          const Encoding::Options& opts) {
+      auto impl =
+          std::make_unique<NimbleBenchTargetImpl<
+              FrequencyPartitionEncoding<Elem>>>();
+      Encoding::Options o = opts;
+      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
+      impl->target.encode(data, o);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+
+  {
+    EncoderEntry<Elem> entry;
+    entry.name = "SIS/realNested";
+    entry.family = "SubIntSplit";
+    entry.variant = "real_nested";
+    entry.isSequential = false;
+    entry.fastSkip = false;
+    entry.randomAccess = false;
+    entry.factory = [](const Vector<Elem>& data,
+                       const Encoding::Options& opts) {
+      auto impl =
+          std::make_unique<NimbleBenchTargetImpl<
+              SubIntSplitEncoding<Elem>>>();
+      impl->target.encode(data, opts, /*realNestedSelection=*/true);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+
+  return encoders;
+}
+
+} // namespace
+} // namespace facebook::nimble::mlidc
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  facebook::velox::memory::MemoryManager::initialize({});
+
+  using namespace facebook::nimble::mlidc;
+
+  const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
+  const size_t iters = static_cast<size_t>(FLAGS_mlidc_iters);
+  const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
+
+  CacheState cacheState{};
+  if (!parseCacheState(FLAGS_cache_state, cacheState)) {
+    std::cerr << "Unknown --cache_state: " << FLAGS_cache_state
+              << " (expected hot|cold-payload|cold-all)\n";
+    return 1;
+  }
+
+  auto encoders = buildEncoders();
+  auto datasets = defaultInt64Datasets<Elem>();
+
+  const CacheTopology topo = CacheTopology::detect();
+
+  CachePolicy policy;
+  policy.state = cacheState;
+  try {
+    CacheController(policy, topo);
+  } catch (const std::exception& e) {
+    std::cerr << "ERROR: " << e.what() << "\n";
+    return 1;
+  }
+
+  std::cout << "bench_decode_bulk: " << encoders.size() << " encoders x "
+            << datasets.size() << " datasets, N=" << n
+            << ", iters=" << iters << ", cache=" << cacheStateName(cacheState)
+            << "\n  " << topo.describe() << "\n\n";
+
+  if (FLAGS_dry_run) {
+    std::cout << "Encoders:\n";
+    for (const auto& e : encoders)
+      std::cout << "  " << e.name << " [" << e.family << "]\n";
+    std::cout << "\nDatasets:\n";
+    for (const auto& d : datasets)
+      std::cout << "  " << d.name << "\n";
+    return 0;
+  }
+
+  std::vector<std::string> csvColumns = {
+      "driver",     "dataset",          "encoding",    "family",
+      "variant",    "is_sequential",    "fast_skip",   "random_access",
+      "N",          "seed",             "cache_state", "evict_method",
+      "evict_ns",   "payload_bytes",    "compression_ratio",
+      "iterations", "warmup",           "time_ns",     "time_p90_ns",
+      "time_min_ns", "decode_Meps",     "decode_MBps", "skipped"};
+
+  std::string csvPath = FLAGS_mlidc_output_csv.empty()
+      ? "bench_decode_bulk.csv"
+      : FLAGS_mlidc_output_csv;
+  CsvResultWriter csv(csvPath, csvColumns);
+
+  if (!FLAGS_mlidc_output_manifest.empty()) {
+    writeRunManifest(FLAGS_mlidc_output_manifest);
+  }
+
+  std::vector<Elem> sink(n, Elem{});
+  int validateFailures = 0;
+
+  MeasureSpec spec;
+  spec.iterations = iters;
+  spec.warmup = 2;
+
+  for (const auto& ds : datasets) {
+    std::cout << "== Dataset: " << ds.name << " ==\n";
+    auto data = ds.generate(n, seed);
+    const size_t rawBytes = static_cast<size_t>(n) * kElemSize;
+
+    for (const auto& enc : encoders) {
+      facebook::nimble::Encoding::Options opts;
+      std::unique_ptr<NimbleBenchTargetBase<Elem>> target;
+      bool skipped = false;
+
+      try {
+        target = enc.factory(data, opts);
+      } catch (const std::exception& ex) {
+        std::cerr << "  [SKIP] " << enc.name << ": " << ex.what() << "\n";
+        skipped = true;
+      }
+
+      if (skipped) {
+        csv.beginRow();
+        csv.set("driver", "bench_decode_bulk");
+        csv.set("dataset", ds.name);
+        csv.set("encoding", enc.name);
+        csv.set("skipped", int64_t{1});
+        csv.endRow();
+        continue;
+      }
+
+      const size_t payloadBytes = target->payloadSize();
+      const double ratio = rawBytes > 0
+          ? static_cast<double>(payloadBytes) / static_cast<double>(rawBytes)
+          : 0.0;
+
+      if (FLAGS_validate && enc.variant != "fpe_noindex") {
+        std::vector<Elem> check(n);
+        target->materializeAll(check.data(), n);
+        bool ok = true;
+        for (uint32_t i = 0; i < n; ++i) {
+          if (check[i] != data[i]) {
+            ok = false;
+            break;
+          }
+        }
+        if (!ok) {
+          std::cerr << "  [VALIDATE FAIL] " << enc.name << " / " << ds.name
+                    << "\n";
+          ++validateFailures;
+          csv.beginRow();
+          csv.set("driver", "bench_decode_bulk");
+          csv.set("dataset", ds.name);
+          csv.set("encoding", enc.name);
+          csv.set("skipped", int64_t{1});
+          csv.endRow();
+          continue;
+        }
+      }
+
+      CachePolicy cellPolicy;
+      cellPolicy.state = cacheState;
+      CacheController controller(cellPolicy, topo);
+
+      auto bufs = target->internalBuffers();
+      EvictionTargets targets;
+      if (!bufs.empty()) {
+        targets.payload = bufs[0];
+      }
+      targets.sink = std::span<std::byte>(
+          reinterpret_cast<std::byte*>(sink.data()),
+          static_cast<size_t>(n) * kElemSize);
+      if (bufs.size() > 1) {
+        targets.codecInternal.assign(bufs.begin() + 1, bufs.end());
+      }
+
+      auto result = measure(spec, controller, targets, [&]() {
+        target->materializeAll(sink.data(), n);
+      });
+
+      const double timeNs = static_cast<double>(result.time.median_ns);
+      const double meps =
+          timeNs > 0.0 ? static_cast<double>(n) / timeNs * 1e3 : 0.0;
+      const double mbps = timeNs > 0.0
+          ? static_cast<double>(n * kElemSize) / timeNs * 1e3
+          : 0.0;
+
+      std::cout << "  " << enc.name << ": " << payloadBytes << " B, "
+                << std::fixed << std::setprecision(1) << meps << " Melem/s\n";
+
+      csv.beginRow();
+      csv.set("driver", "bench_decode_bulk");
+      csv.set("dataset", ds.name);
+      csv.set("encoding", enc.name);
+      csv.set("family", enc.family);
+      csv.set("variant", enc.variant);
+      csv.set("is_sequential", enc.isSequential ? int64_t{1} : int64_t{0});
+      csv.set("fast_skip", enc.fastSkip ? int64_t{1} : int64_t{0});
+      csv.set("random_access", enc.randomAccess ? int64_t{1} : int64_t{0});
+      csv.set("N", static_cast<int64_t>(n));
+      csv.set("seed", static_cast<int64_t>(seed));
+      csv.set(
+          "cache_state",
+          std::string(cacheStateName(controller.effectivePolicy().state)));
+      csv.set(
+          "evict_method",
+          std::string(
+              evictMethodName(controller.effectivePolicy().method)));
+      csv.set("evict_ns", result.evict.median_ns);
+      csv.set("payload_bytes", static_cast<int64_t>(payloadBytes));
+      csv.set("compression_ratio", ratio);
+      csv.set("iterations", static_cast<int64_t>(iters));
+      csv.set("warmup", static_cast<int64_t>(spec.warmup));
+      csv.set("time_ns", result.time.median_ns);
+      csv.set("time_p90_ns", result.time.p90_ns);
+      csv.set("time_min_ns", result.time.min_ns);
+      csv.set("decode_Meps", meps);
+      csv.set("decode_MBps", mbps);
+      csv.set("skipped", int64_t{0});
+      csv.endRow();
+      csv.flush();
+    }
+  }
+
+  std::cout << "\nResults written to: " << csvPath << "\n";
+
+  if (validateFailures > 0) {
+    std::cerr << validateFailures << " validation failure(s)\n";
+    return 2;
+  }
+  return 0;
+}
+
+#else
+
+#include <iostream>
+int main() {
+  std::cerr << "bench_decode_bulk requires NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS\n";
+  return 1;
+}
+
+#endif

--- a/dwio/nimble/ML_ID_Compression/bench_decode_bulk.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_decode_bulk.cpp
@@ -29,13 +29,6 @@
 #include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
 #include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
 
-#include "dwio/nimble/encodings/DictionaryEncoding.h"
-#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
-#include "dwio/nimble/encodings/RLEEncoding.h"
-#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
-#include "dwio/nimble/encodings/TrivialEncoding.h"
-
 DEFINE_string(cache_state, "hot", "hot | cold-payload | cold-all");
 DEFINE_bool(validate, false, "Round-trip check before measuring");
 DEFINE_bool(dry_run, false, "Print sweep plan and exit");
@@ -45,86 +38,6 @@ namespace {
 
 using Elem = int64_t;
 constexpr size_t kElemSize = sizeof(Elem);
-
-bool parseCacheState(const std::string& text, CacheState& out) {
-  if (text == "hot") {
-    out = CacheState::Hot;
-    return true;
-  }
-  if (text == "cold-payload") {
-    out = CacheState::ColdPayload;
-    return true;
-  }
-  if (text == "cold-all") {
-    out = CacheState::ColdAll;
-    return true;
-  }
-  return false;
-}
-
-std::vector<EncoderEntry<Elem>> buildEncoders() {
-  std::vector<EncoderEntry<Elem>> encoders;
-
-  encoders.push_back(
-      makeEncoderEntry<TrivialEncoding<Elem>>(
-          "Trivial", "Baseline", "trivial", true, true, false));
-  encoders.push_back(
-      makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
-          "FixedBitWidth", "Baseline", "fbw", true, true, false));
-  encoders.push_back(
-      makeEncoderEntry<DictionaryEncoding<Elem>>(
-          "Dictionary", "Baseline", "dict", true, false, false));
-  encoders.push_back(
-      makeEncoderEntry<RLEEncoding<Elem>>(
-          "RLE", "Baseline", "rle", true, true, false));
-
-  const std::array<std::string, 4> fpeNames = {
-      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
-  const std::array<bool, 4> fpeRA = {false, true, true, true};
-  const std::array<bool, 4> fpeSkip = {false, true, true, true};
-
-  for (int idx = 0; idx < 4; ++idx) {
-    EncoderEntry<Elem> entry;
-    entry.name = "FPE/" + fpeNames[idx];
-    entry.family = "FrequencyPartition";
-    entry.variant = fpeNames[idx];
-    entry.isSequential = true;
-    entry.fastSkip = fpeSkip[idx];
-    entry.randomAccess = fpeRA[idx];
-    entry.factory = [idx](const Vector<Elem>& data,
-                          const Encoding::Options& opts) {
-      auto impl =
-          std::make_unique<NimbleBenchTargetImpl<
-              FrequencyPartitionEncoding<Elem>>>();
-      Encoding::Options o = opts;
-      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
-      impl->target.encode(data, o);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-
-  {
-    EncoderEntry<Elem> entry;
-    entry.name = "SIS/realNested";
-    entry.family = "SubIntSplit";
-    entry.variant = "real_nested";
-    entry.isSequential = false;
-    entry.fastSkip = false;
-    entry.randomAccess = false;
-    entry.factory = [](const Vector<Elem>& data,
-                       const Encoding::Options& opts) {
-      auto impl =
-          std::make_unique<NimbleBenchTargetImpl<
-              SubIntSplitEncoding<Elem>>>();
-      impl->target.encode(data, opts, /*realNestedSelection=*/true);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-
-  return encoders;
-}
 
 } // namespace
 } // namespace facebook::nimble::mlidc
@@ -146,7 +59,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  auto encoders = buildEncoders();
+  auto encoders = buildDefaultEncoders<Elem>();
   auto datasets = defaultInt64Datasets<Elem>();
 
   const CacheTopology topo = CacheTopology::detect();

--- a/dwio/nimble/ML_ID_Compression/bench_decode_bulk.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_decode_bulk.cpp
@@ -26,6 +26,7 @@
 #include <gflags/gflags.h>
 
 #include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/ML_ID_Compression/OpenZLBenchTarget.h"
 #include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
 #include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
 
@@ -60,6 +61,7 @@ int main(int argc, char** argv) {
   }
 
   auto encoders = buildDefaultEncoders<Elem>();
+  encoders.push_back(buildOpenZLEncoder<Elem>());
   auto datasets = defaultInt64Datasets<Elem>();
 
   const CacheTopology topo = CacheTopology::detect();

--- a/dwio/nimble/ML_ID_Compression/bench_decode_gather.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_decode_gather.cpp
@@ -1,0 +1,327 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "dwio/nimble/ML_ID_Compression/Axes.h"
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
+#include "dwio/nimble/ML_ID_Compression/GatherTraceGen.h"
+#include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
+
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+
+DEFINE_int32(selectivity_steps, 8, "Steps in the selectivity axis");
+DEFINE_int32(run_length_steps, 6, "Steps in the run-length axis");
+DEFINE_string(cache_state, "hot", "hot | cold-payload | cold-all");
+DEFINE_bool(validate, false, "Round-trip check before measuring");
+DEFINE_bool(dry_run, false, "Print sweep plan and exit");
+
+namespace facebook::nimble::mlidc {
+namespace {
+
+using Elem = int64_t;
+constexpr size_t kElemSize = sizeof(Elem);
+
+bool parseCacheState(const std::string& text, CacheState& out) {
+  if (text == "hot") { out = CacheState::Hot; return true; }
+  if (text == "cold-payload") { out = CacheState::ColdPayload; return true; }
+  if (text == "cold-all") { out = CacheState::ColdAll; return true; }
+  return false;
+}
+
+std::vector<std::pair<uint32_t, uint32_t>> toRanges(const GatherTrace& t) {
+  std::vector<std::pair<uint32_t, uint32_t>> ranges;
+  ranges.reserve(t.ranges.size());
+  for (const auto& r : t.ranges)
+    ranges.emplace_back(
+        static_cast<uint32_t>(r.begin), static_cast<uint32_t>(r.size()));
+  return ranges;
+}
+
+std::vector<EncoderEntry<Elem>> buildEncoders() {
+  std::vector<EncoderEntry<Elem>> encoders;
+  encoders.push_back(makeEncoderEntry<TrivialEncoding<Elem>>(
+      "Trivial", "Baseline", "trivial", true, true, false));
+  encoders.push_back(makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
+      "FixedBitWidth", "Baseline", "fbw", true, true, false));
+  encoders.push_back(makeEncoderEntry<DictionaryEncoding<Elem>>(
+      "Dictionary", "Baseline", "dict", true, false, false));
+  encoders.push_back(makeEncoderEntry<RLEEncoding<Elem>>(
+      "RLE", "Baseline", "rle", true, true, false));
+  const std::array<std::string, 4> fpeNames = {
+      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
+  const std::array<bool, 4> fpeRA = {false, true, true, true};
+  const std::array<bool, 4> fpeSkip = {false, true, true, true};
+  for (int idx = 0; idx < 4; ++idx) {
+    EncoderEntry<Elem> entry;
+    entry.name = "FPE/" + fpeNames[idx];
+    entry.family = "FrequencyPartition";
+    entry.variant = fpeNames[idx];
+    entry.isSequential = true;
+    entry.fastSkip = fpeSkip[idx];
+    entry.randomAccess = fpeRA[idx];
+    entry.factory = [idx](const Vector<Elem>& data,
+                          const Encoding::Options& opts) {
+      auto impl = std::make_unique<
+          NimbleBenchTargetImpl<FrequencyPartitionEncoding<Elem>>>();
+      Encoding::Options o = opts;
+      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
+      impl->target.encode(data, o);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+  {
+    EncoderEntry<Elem> entry;
+    entry.name = "SIS/realNested";
+    entry.family = "SubIntSplit";
+    entry.variant = "real_nested";
+    entry.isSequential = false;
+    entry.fastSkip = false;
+    entry.randomAccess = false;
+    entry.factory = [](const Vector<Elem>& data,
+                       const Encoding::Options& opts) {
+      auto impl = std::make_unique<
+          NimbleBenchTargetImpl<SubIntSplitEncoding<Elem>>>();
+      impl->target.encode(data, opts, /*realNestedSelection=*/true);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+  return encoders;
+}
+
+} // namespace
+} // namespace facebook::nimble::mlidc
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  facebook::velox::memory::MemoryManager::initialize({});
+  using namespace facebook::nimble::mlidc;
+
+  const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
+  const size_t iters = static_cast<size_t>(FLAGS_mlidc_iters);
+  const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
+
+  CacheState cacheState{};
+  if (!parseCacheState(FLAGS_cache_state, cacheState)) {
+    std::cerr << "Unknown --cache_state: " << FLAGS_cache_state
+              << " (expected hot|cold-payload|cold-all)\n";
+    return 1;
+  }
+
+  const auto selectivityAxis =
+      linSpaced(0.05, 1.0, static_cast<size_t>(FLAGS_selectivity_steps));
+  const auto runLengthAxis = logSpaced(
+      1, std::max<size_t>(1, n / 4), static_cast<size_t>(FLAGS_run_length_steps));
+
+  auto encoders = buildEncoders();
+  auto datasets = defaultInt64Datasets<Elem>();
+  const CacheTopology topo = CacheTopology::detect();
+
+  CachePolicy policy;
+  policy.state = cacheState;
+  try {
+    CacheController(policy, topo);
+  } catch (const std::exception& e) {
+    std::cerr << "ERROR: " << e.what() << "\n";
+    return 1;
+  }
+
+  std::cout << "bench_decode_gather: " << encoders.size() << " encoders x "
+            << datasets.size() << " datasets, N=" << n
+            << ", selectivity_steps=" << selectivityAxis.size()
+            << ", run_length_steps=" << runLengthAxis.size()
+            << ", iters=" << iters << ", cache=" << cacheStateName(cacheState)
+            << "\n  " << topo.describe() << "\n\n";
+
+  if (FLAGS_dry_run) {
+    std::cout << "Encoders:\n";
+    for (const auto& e : encoders) std::cout << "  " << e.name << "\n";
+    std::cout << "Datasets:\n";
+    for (const auto& d : datasets) std::cout << "  " << d.name << "\n";
+    return 0;
+  }
+
+  std::vector<std::string> csvColumns = {
+      "driver", "dataset", "encoding", "family", "variant", "is_sequential",
+      "N", "seed", "cache_state", "evict_method", "evict_ns",
+      "payload_bytes", "compression_ratio", "iterations", "warmup",
+      "selectivity", "run_length", "selectivity_achieved", "range_count",
+      "selected_rows", "gap_model", "time_ns", "time_p90_ns", "time_min_ns",
+      "gather_Meps", "skipped"};
+  std::string csvPath = FLAGS_mlidc_output_csv.empty()
+      ? "bench_decode_gather.csv"
+      : FLAGS_mlidc_output_csv;
+  CsvResultWriter csv(csvPath, csvColumns);
+  if (!FLAGS_mlidc_output_manifest.empty())
+    writeRunManifest(FLAGS_mlidc_output_manifest);
+
+  std::vector<Elem> sink(n, Elem{});
+  int validateFailures = 0;
+  MeasureSpec spec;
+  spec.iterations = iters;
+  spec.warmup = 2;
+
+  auto writeSkipRow = [&](const std::string& ds, const std::string& enc) {
+    csv.beginRow();
+    csv.set("driver", "bench_decode_gather");
+    csv.set("dataset", ds);
+    csv.set("encoding", enc);
+    csv.set("skipped", int64_t{1});
+    csv.endRow();
+  };
+
+  for (const auto& ds : datasets) {
+    auto data = ds.generate(n, seed);
+    const size_t rawBytes = static_cast<size_t>(n) * kElemSize;
+
+    for (const auto& enc : encoders) {
+      facebook::nimble::Encoding::Options opts;
+      std::unique_ptr<NimbleBenchTargetBase<Elem>> target;
+      bool skipped = false;
+      try {
+        target = enc.factory(data, opts);
+      } catch (const std::exception& ex) {
+        std::cerr << "  [SKIP] " << enc.name << ": " << ex.what() << "\n";
+        skipped = true;
+      }
+      if (skipped) { writeSkipRow(ds.name, enc.name); continue; }
+
+      const size_t payloadBytes = target->payloadSize();
+      const double ratio = rawBytes > 0
+          ? static_cast<double>(payloadBytes) / static_cast<double>(rawBytes)
+          : 0.0;
+
+      if (FLAGS_validate && enc.variant != "fpe_noindex") {
+        GatherAccessParams vp{
+            .start = 0, .span = n, .selectivity = 0.3, .runLength = 4,
+            .gapModel = GapModel::UniformDeterministic, .seed = seed};
+        auto trace = buildGatherTrace(n, vp);
+        auto ranges = toRanges(trace);
+        std::vector<Elem> check(trace.selectedRows);
+        target->skipThenMaterialize(ranges, check.data());
+        bool ok = true;
+        size_t idx = 0;
+        for (const auto& r : trace.ranges)
+          for (size_t i = r.begin; i < r.end; ++i, ++idx)
+            if (check[idx] != data[i]) ok = false;
+        if (!ok) {
+          std::cerr << "  [VALIDATE FAIL] " << enc.name << " / " << ds.name
+                    << "\n";
+          ++validateFailures;
+          writeSkipRow(ds.name, enc.name);
+          continue;
+        }
+      }
+
+      CachePolicy cellPolicy;
+      cellPolicy.state = cacheState;
+      CacheController controller(cellPolicy, topo);
+      auto bufs = target->internalBuffers();
+      EvictionTargets targets;
+      if (!bufs.empty()) targets.payload = bufs[0];
+      targets.sink = std::span<std::byte>(
+          reinterpret_cast<std::byte*>(sink.data()),
+          static_cast<size_t>(n) * kElemSize);
+      if (bufs.size() > 1)
+        targets.codecInternal.assign(bufs.begin() + 1, bufs.end());
+
+      for (double sigma : selectivityAxis) {
+        for (size_t rl : runLengthAxis) {
+          GatherAccessParams p{
+              .start = 0, .span = n, .selectivity = sigma, .runLength = rl,
+              .gapModel = GapModel::UniformDeterministic, .seed = seed};
+          auto trace = buildGatherTrace(n, p);
+          if (trace.selectedRows == 0) continue;
+          auto ranges = toRanges(trace);
+
+          auto result = measure(spec, controller, targets, [&]() {
+            target->skipThenMaterialize(ranges, sink.data());
+          });
+
+          const double timeNs = static_cast<double>(result.time.median_ns);
+          const double meps = timeNs > 0.0
+              ? static_cast<double>(trace.selectedRows) / timeNs * 1e3
+              : 0.0;
+
+          csv.beginRow();
+          csv.set("driver", "bench_decode_gather");
+          csv.set("dataset", ds.name);
+          csv.set("encoding", enc.name);
+          csv.set("family", enc.family);
+          csv.set("variant", enc.variant);
+          csv.set("is_sequential", enc.isSequential ? int64_t{1} : int64_t{0});
+          csv.set("N", static_cast<int64_t>(n));
+          csv.set("seed", static_cast<int64_t>(seed));
+          csv.set("cache_state",
+              std::string(cacheStateName(controller.effectivePolicy().state)));
+          csv.set("evict_method", std::string(
+              evictMethodName(controller.effectivePolicy().method)));
+          csv.set("evict_ns", result.evict.median_ns);
+          csv.set("payload_bytes", static_cast<int64_t>(payloadBytes));
+          csv.set("compression_ratio", ratio);
+          csv.set("iterations", static_cast<int64_t>(iters));
+          csv.set("warmup", static_cast<int64_t>(spec.warmup));
+          csv.set("selectivity", sigma);
+          csv.set("run_length", static_cast<int64_t>(rl));
+          csv.set("selectivity_achieved", trace.selectivityAchieved);
+          csv.set("range_count", static_cast<int64_t>(trace.rangeCount));
+          csv.set("selected_rows", static_cast<int64_t>(trace.selectedRows));
+          csv.set("gap_model", std::string(gapModelName(p.gapModel)));
+          csv.set("time_ns", result.time.median_ns);
+          csv.set("time_p90_ns", result.time.p90_ns);
+          csv.set("time_min_ns", result.time.min_ns);
+          csv.set("gather_Meps", meps);
+          csv.set("skipped", int64_t{0});
+          csv.endRow();
+        }
+      }
+      csv.flush();
+    }
+  }
+
+  std::cout << "Results written to: " << csvPath << "\n";
+  if (validateFailures > 0) {
+    std::cerr << validateFailures << " validation failure(s)\n";
+    return 2;
+  }
+  return 0;
+}
+
+#else
+
+#include <iostream>
+int main() {
+  std::cerr
+      << "bench_decode_gather requires NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS\n";
+  return 1;
+}
+
+#endif

--- a/dwio/nimble/ML_ID_Compression/bench_decode_gather.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_decode_gather.cpp
@@ -29,13 +29,6 @@
 #include "dwio/nimble/ML_ID_Compression/GatherTraceGen.h"
 #include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
 
-#include "dwio/nimble/encodings/DictionaryEncoding.h"
-#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
-#include "dwio/nimble/encodings/RLEEncoding.h"
-#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
-#include "dwio/nimble/encodings/TrivialEncoding.h"
-
 DEFINE_int32(selectivity_steps, 8, "Steps in the selectivity axis");
 DEFINE_int32(run_length_steps, 6, "Steps in the run-length axis");
 DEFINE_string(cache_state, "hot", "hot | cold-payload | cold-all");
@@ -48,13 +41,6 @@ namespace {
 using Elem = int64_t;
 constexpr size_t kElemSize = sizeof(Elem);
 
-bool parseCacheState(const std::string& text, CacheState& out) {
-  if (text == "hot") { out = CacheState::Hot; return true; }
-  if (text == "cold-payload") { out = CacheState::ColdPayload; return true; }
-  if (text == "cold-all") { out = CacheState::ColdAll; return true; }
-  return false;
-}
-
 std::vector<std::pair<uint32_t, uint32_t>> toRanges(const GatherTrace& t) {
   std::vector<std::pair<uint32_t, uint32_t>> ranges;
   ranges.reserve(t.ranges.size());
@@ -62,59 +48,6 @@ std::vector<std::pair<uint32_t, uint32_t>> toRanges(const GatherTrace& t) {
     ranges.emplace_back(
         static_cast<uint32_t>(r.begin), static_cast<uint32_t>(r.size()));
   return ranges;
-}
-
-std::vector<EncoderEntry<Elem>> buildEncoders() {
-  std::vector<EncoderEntry<Elem>> encoders;
-  encoders.push_back(makeEncoderEntry<TrivialEncoding<Elem>>(
-      "Trivial", "Baseline", "trivial", true, true, false));
-  encoders.push_back(makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
-      "FixedBitWidth", "Baseline", "fbw", true, true, false));
-  encoders.push_back(makeEncoderEntry<DictionaryEncoding<Elem>>(
-      "Dictionary", "Baseline", "dict", true, false, false));
-  encoders.push_back(makeEncoderEntry<RLEEncoding<Elem>>(
-      "RLE", "Baseline", "rle", true, true, false));
-  const std::array<std::string, 4> fpeNames = {
-      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
-  const std::array<bool, 4> fpeRA = {false, true, true, true};
-  const std::array<bool, 4> fpeSkip = {false, true, true, true};
-  for (int idx = 0; idx < 4; ++idx) {
-    EncoderEntry<Elem> entry;
-    entry.name = "FPE/" + fpeNames[idx];
-    entry.family = "FrequencyPartition";
-    entry.variant = fpeNames[idx];
-    entry.isSequential = true;
-    entry.fastSkip = fpeSkip[idx];
-    entry.randomAccess = fpeRA[idx];
-    entry.factory = [idx](const Vector<Elem>& data,
-                          const Encoding::Options& opts) {
-      auto impl = std::make_unique<
-          NimbleBenchTargetImpl<FrequencyPartitionEncoding<Elem>>>();
-      Encoding::Options o = opts;
-      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
-      impl->target.encode(data, o);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-  {
-    EncoderEntry<Elem> entry;
-    entry.name = "SIS/realNested";
-    entry.family = "SubIntSplit";
-    entry.variant = "real_nested";
-    entry.isSequential = false;
-    entry.fastSkip = false;
-    entry.randomAccess = false;
-    entry.factory = [](const Vector<Elem>& data,
-                       const Encoding::Options& opts) {
-      auto impl = std::make_unique<
-          NimbleBenchTargetImpl<SubIntSplitEncoding<Elem>>>();
-      impl->target.encode(data, opts, /*realNestedSelection=*/true);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-  return encoders;
 }
 
 } // namespace
@@ -141,7 +74,7 @@ int main(int argc, char** argv) {
   const auto runLengthAxis = logSpaced(
       1, std::max<size_t>(1, n / 4), static_cast<size_t>(FLAGS_run_length_steps));
 
-  auto encoders = buildEncoders();
+  auto encoders = buildDefaultEncoders<Elem>();
   auto datasets = defaultInt64Datasets<Elem>();
   const CacheTopology topo = CacheTopology::detect();
 

--- a/dwio/nimble/ML_ID_Compression/bench_decode_point.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_decode_point.cpp
@@ -1,0 +1,316 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
+#include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
+#include "dwio/nimble/ML_ID_Compression/PointTraceGen.h"
+
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+
+DEFINE_int32(probes, 65536, "Number of point lookups per measurement");
+DEFINE_string(cache_state, "hot", "hot | cold-payload | cold-all");
+DEFINE_bool(validate, false, "Round-trip check before measuring");
+DEFINE_bool(dry_run, false, "Print sweep plan and exit");
+
+namespace facebook::nimble::mlidc {
+namespace {
+
+using Elem = int64_t;
+constexpr size_t kElemSize = sizeof(Elem);
+
+bool parseCacheState(const std::string& text, CacheState& out) {
+  if (text == "hot") { out = CacheState::Hot; return true; }
+  if (text == "cold-payload") { out = CacheState::ColdPayload; return true; }
+  if (text == "cold-all") { out = CacheState::ColdAll; return true; }
+  return false;
+}
+
+std::vector<EncoderEntry<Elem>> buildEncoders() {
+  std::vector<EncoderEntry<Elem>> encoders;
+  encoders.push_back(makeEncoderEntry<TrivialEncoding<Elem>>(
+      "Trivial", "Baseline", "trivial", true, true, false));
+  encoders.push_back(makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
+      "FixedBitWidth", "Baseline", "fbw", true, true, false));
+  encoders.push_back(makeEncoderEntry<DictionaryEncoding<Elem>>(
+      "Dictionary", "Baseline", "dict", true, false, false));
+  encoders.push_back(makeEncoderEntry<RLEEncoding<Elem>>(
+      "RLE", "Baseline", "rle", true, true, false));
+
+  const std::array<std::string, 4> fpeNames = {
+      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
+  const std::array<bool, 4> fpeRA = {false, true, true, true};
+  const std::array<bool, 4> fpeSkip = {false, true, true, true};
+  for (int idx = 0; idx < 4; ++idx) {
+    EncoderEntry<Elem> entry;
+    entry.name = "FPE/" + fpeNames[idx];
+    entry.family = "FrequencyPartition";
+    entry.variant = fpeNames[idx];
+    entry.isSequential = true;
+    entry.fastSkip = fpeSkip[idx];
+    entry.randomAccess = fpeRA[idx];
+    entry.factory = [idx](const Vector<Elem>& data,
+                          const Encoding::Options& opts) {
+      auto impl = std::make_unique<
+          NimbleBenchTargetImpl<FrequencyPartitionEncoding<Elem>>>();
+      Encoding::Options o = opts;
+      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
+      impl->target.encode(data, o);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+
+  {
+    EncoderEntry<Elem> entry;
+    entry.name = "SIS/realNested";
+    entry.family = "SubIntSplit";
+    entry.variant = "real_nested";
+    entry.isSequential = false;
+    entry.fastSkip = false;
+    entry.randomAccess = false;
+    entry.factory = [](const Vector<Elem>& data,
+                       const Encoding::Options& opts) {
+      auto impl =
+          std::make_unique<NimbleBenchTargetImpl<SubIntSplitEncoding<Elem>>>();
+      impl->target.encode(data, opts, /*realNestedSelection=*/true);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+  return encoders;
+}
+
+} // namespace
+} // namespace facebook::nimble::mlidc
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  facebook::velox::memory::MemoryManager::initialize({});
+  using namespace facebook::nimble::mlidc;
+
+  const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
+  const size_t iters = static_cast<size_t>(FLAGS_mlidc_iters);
+  const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
+  const size_t probes = static_cast<size_t>(std::max(1, FLAGS_probes));
+
+  CacheState cacheState{};
+  if (!parseCacheState(FLAGS_cache_state, cacheState)) {
+    std::cerr << "Unknown --cache_state: " << FLAGS_cache_state
+              << " (expected hot|cold-payload|cold-all)\n";
+    return 1;
+  }
+
+  auto encoders = buildEncoders();
+  auto datasets = defaultInt64Datasets<Elem>();
+  const CacheTopology topo = CacheTopology::detect();
+
+  CachePolicy policy;
+  policy.state = cacheState;
+  try {
+    CacheController(policy, topo);
+  } catch (const std::exception& e) {
+    std::cerr << "ERROR: " << e.what() << "\n";
+    return 1;
+  }
+
+  std::cout << "bench_decode_point: " << encoders.size() << " encoders x "
+            << datasets.size() << " datasets, N=" << n
+            << ", probes=" << probes << ", iters=" << iters
+            << ", cache=" << cacheStateName(cacheState) << "\n  "
+            << topo.describe() << "\n\n";
+
+  if (FLAGS_dry_run) {
+    std::cout << "Encoders:\n";
+    for (const auto& e : encoders)
+      std::cout << "  " << e.name << " [" << e.family << "]\n";
+    std::cout << "\nDatasets:\n";
+    for (const auto& d : datasets) std::cout << "  " << d.name << "\n";
+    return 0;
+  }
+
+  std::vector<std::string> csvColumns = {
+      "driver",          "dataset",         "encoding",        "family",
+      "variant",         "is_sequential",   "N",               "seed",
+      "cache_state",     "evict_method",    "payload_bytes",   "compression_ratio",
+      "iterations",      "warmup",          "probes",          "distinct_probes",
+      "distinct_fraction", "time_ns",       "time_p90_ns",     "time_min_ns",
+      "ns_per_probe",    "Mprobes_ps",      "clock_overhead_ns", "emulated_point_read",
+      "skipped"};
+  std::string csvPath = FLAGS_mlidc_output_csv.empty()
+      ? "bench_decode_point.csv"
+      : FLAGS_mlidc_output_csv;
+  CsvResultWriter csv(csvPath, csvColumns);
+  if (!FLAGS_mlidc_output_manifest.empty())
+    writeRunManifest(FLAGS_mlidc_output_manifest);
+
+  const TimingSummary clockOverhead = measureClockOverhead(1000);
+
+  PointTraceParams traceParams;
+  traceParams.streamLength = n;
+  traceParams.probes = probes;
+  traceParams.seed = seed;
+  traceParams.ascending = false;
+  const PointTrace trace = buildPointTrace(traceParams);
+
+  Elem sink{};
+  int validateFailures = 0;
+  MeasureSpec spec;
+  spec.iterations = iters;
+  spec.warmup = 2;
+
+  auto writeSkipRow = [&](const std::string& ds, const std::string& enc) {
+    csv.beginRow();
+    csv.set("driver", "bench_decode_point");
+    csv.set("dataset", ds);
+    csv.set("encoding", enc);
+    csv.set("skipped", int64_t{1});
+    csv.endRow();
+  };
+
+  for (const auto& ds : datasets) {
+    std::cout << "== Dataset: " << ds.name << " ==\n";
+    auto data = ds.generate(n, seed);
+    const size_t rawBytes = static_cast<size_t>(n) * kElemSize;
+
+    for (const auto& enc : encoders) {
+      facebook::nimble::Encoding::Options opts;
+      std::unique_ptr<NimbleBenchTargetBase<Elem>> target;
+      bool skipped = false;
+      try {
+        target = enc.factory(data, opts);
+      } catch (const std::exception& ex) {
+        std::cerr << "  [SKIP] " << enc.name << ": " << ex.what() << "\n";
+        skipped = true;
+      }
+      if (skipped) { writeSkipRow(ds.name, enc.name); continue; }
+
+      const size_t payloadBytes = target->payloadSize();
+      const double ratio = rawBytes > 0
+          ? static_cast<double>(payloadBytes) / static_cast<double>(rawBytes)
+          : 0.0;
+
+      if (FLAGS_validate && enc.variant != "fpe_noindex") {
+        bool ok = true;
+        Elem check{};
+        for (size_t idx : trace.indices) {
+          target->materializeRange(static_cast<uint32_t>(idx), 1, &check);
+          ok = check == data[idx];
+          if (!ok) break;
+        }
+        if (!ok) {
+          std::cerr << "  [VALIDATE FAIL] " << enc.name << " / " << ds.name
+                    << "\n";
+          ++validateFailures;
+          writeSkipRow(ds.name, enc.name);
+          continue;
+        }
+      }
+
+      CachePolicy cellPolicy;
+      cellPolicy.state = cacheState;
+      CacheController controller(cellPolicy, topo);
+      auto bufs = target->internalBuffers();
+      EvictionTargets targets;
+      if (!bufs.empty()) targets.payload = bufs[0];
+      targets.sink = std::span<std::byte>(
+          reinterpret_cast<std::byte*>(&sink), kElemSize);
+      if (bufs.size() > 1)
+        targets.codecInternal.assign(bufs.begin() + 1, bufs.end());
+
+      auto result = measure(spec, controller, targets, [&]() {
+        for (size_t idx : trace.indices)
+          target->materializeRange(static_cast<uint32_t>(idx), 1, &sink);
+      });
+
+      const double timeNs = static_cast<double>(result.time.median_ns);
+      const double nsPerProbe =
+          probes > 0 ? timeNs / static_cast<double>(probes) : 0.0;
+      const double mProbesPerSec = timeNs > 0.0
+          ? static_cast<double>(probes) / timeNs * 1e3
+          : 0.0;
+
+      csv.beginRow();
+      csv.set("driver", "bench_decode_point");
+      csv.set("dataset", ds.name);
+      csv.set("encoding", enc.name);
+      csv.set("family", enc.family);
+      csv.set("variant", enc.variant);
+      csv.set("is_sequential", enc.isSequential ? int64_t{1} : int64_t{0});
+      csv.set("N", static_cast<int64_t>(n));
+      csv.set("seed", static_cast<int64_t>(seed));
+      csv.set("cache_state",
+          std::string(cacheStateName(controller.effectivePolicy().state)));
+      csv.set("evict_method", std::string(
+          evictMethodName(controller.effectivePolicy().method)));
+      csv.set("payload_bytes", static_cast<int64_t>(payloadBytes));
+      csv.set("compression_ratio", ratio);
+      csv.set("iterations", static_cast<int64_t>(iters));
+      csv.set("warmup", static_cast<int64_t>(spec.warmup));
+      csv.set("probes", static_cast<int64_t>(probes));
+      csv.set("distinct_probes", static_cast<int64_t>(trace.distinctIndices));
+      csv.set("distinct_fraction", trace.distinctFraction);
+      csv.set("time_ns", result.time.median_ns);
+      csv.set("time_p90_ns", result.time.p90_ns);
+      csv.set("time_min_ns", result.time.min_ns);
+      csv.set("ns_per_probe", nsPerProbe);
+      csv.set("Mprobes_ps", mProbesPerSec);
+      csv.set("clock_overhead_ns", clockOverhead.median_ns);
+      csv.set("emulated_point_read", int64_t{1});
+      csv.set("skipped", int64_t{0});
+      csv.endRow();
+      csv.flush();
+      std::cout << "  " << enc.name << ": " << payloadBytes << " B, "
+                << nsPerProbe << " ns/probe\n";
+    }
+  }
+
+  std::cout << "\nResults written to: " << csvPath << "\n";
+  if (validateFailures > 0) {
+    std::cerr << validateFailures << " validation failure(s)\n";
+    return 2;
+  }
+  return 0;
+}
+
+#else
+
+#include <iostream>
+int main() {
+  std::cerr
+      << "bench_decode_point requires NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS\n";
+  return 1;
+}
+
+#endif

--- a/dwio/nimble/ML_ID_Compression/bench_decode_point.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_decode_point.cpp
@@ -32,13 +32,6 @@
 #include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
 #include "dwio/nimble/ML_ID_Compression/PointTraceGen.h"
 
-#include "dwio/nimble/encodings/DictionaryEncoding.h"
-#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
-#include "dwio/nimble/encodings/RLEEncoding.h"
-#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
-#include "dwio/nimble/encodings/TrivialEncoding.h"
-
 DEFINE_int32(probes, 65536, "Number of point lookups per measurement");
 DEFINE_string(cache_state, "hot", "hot | cold-payload | cold-all");
 DEFINE_bool(validate, false, "Round-trip check before measuring");
@@ -49,68 +42,6 @@ namespace {
 
 using Elem = int64_t;
 constexpr size_t kElemSize = sizeof(Elem);
-
-bool parseCacheState(const std::string& text, CacheState& out) {
-  if (text == "hot") { out = CacheState::Hot; return true; }
-  if (text == "cold-payload") { out = CacheState::ColdPayload; return true; }
-  if (text == "cold-all") { out = CacheState::ColdAll; return true; }
-  return false;
-}
-
-std::vector<EncoderEntry<Elem>> buildEncoders() {
-  std::vector<EncoderEntry<Elem>> encoders;
-  encoders.push_back(makeEncoderEntry<TrivialEncoding<Elem>>(
-      "Trivial", "Baseline", "trivial", true, true, false));
-  encoders.push_back(makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
-      "FixedBitWidth", "Baseline", "fbw", true, true, false));
-  encoders.push_back(makeEncoderEntry<DictionaryEncoding<Elem>>(
-      "Dictionary", "Baseline", "dict", true, false, false));
-  encoders.push_back(makeEncoderEntry<RLEEncoding<Elem>>(
-      "RLE", "Baseline", "rle", true, true, false));
-
-  const std::array<std::string, 4> fpeNames = {
-      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
-  const std::array<bool, 4> fpeRA = {false, true, true, true};
-  const std::array<bool, 4> fpeSkip = {false, true, true, true};
-  for (int idx = 0; idx < 4; ++idx) {
-    EncoderEntry<Elem> entry;
-    entry.name = "FPE/" + fpeNames[idx];
-    entry.family = "FrequencyPartition";
-    entry.variant = fpeNames[idx];
-    entry.isSequential = true;
-    entry.fastSkip = fpeSkip[idx];
-    entry.randomAccess = fpeRA[idx];
-    entry.factory = [idx](const Vector<Elem>& data,
-                          const Encoding::Options& opts) {
-      auto impl = std::make_unique<
-          NimbleBenchTargetImpl<FrequencyPartitionEncoding<Elem>>>();
-      Encoding::Options o = opts;
-      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
-      impl->target.encode(data, o);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-
-  {
-    EncoderEntry<Elem> entry;
-    entry.name = "SIS/realNested";
-    entry.family = "SubIntSplit";
-    entry.variant = "real_nested";
-    entry.isSequential = false;
-    entry.fastSkip = false;
-    entry.randomAccess = false;
-    entry.factory = [](const Vector<Elem>& data,
-                       const Encoding::Options& opts) {
-      auto impl =
-          std::make_unique<NimbleBenchTargetImpl<SubIntSplitEncoding<Elem>>>();
-      impl->target.encode(data, opts, /*realNestedSelection=*/true);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-  return encoders;
-}
 
 } // namespace
 } // namespace facebook::nimble::mlidc
@@ -132,7 +63,7 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  auto encoders = buildEncoders();
+  auto encoders = buildDefaultEncoders<Elem>();
   auto datasets = defaultInt64Datasets<Elem>();
   const CacheTopology topo = CacheTopology::detect();
 

--- a/dwio/nimble/ML_ID_Compression/bench_decode_range.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_decode_range.cpp
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
+#include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
+
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+
+DEFINE_int32(grid, 16, "Grid resolution per axis; ~grid^2/2 cells in triangle");
+DEFINE_string(cache_state, "hot", "hot | cold-payload | cold-all");
+DEFINE_bool(validate, false, "Round-trip check before measuring");
+DEFINE_bool(dry_run, false, "Print sweep plan and exit");
+
+namespace facebook::nimble::mlidc {
+namespace {
+
+using Elem = int64_t;
+constexpr size_t kElemSize = sizeof(Elem);
+
+bool parseCacheState(const std::string& text, CacheState& out) {
+  if (text == "hot") { out = CacheState::Hot; return true; }
+  if (text == "cold-payload") { out = CacheState::ColdPayload; return true; }
+  if (text == "cold-all") { out = CacheState::ColdAll; return true; }
+  return false;
+}
+
+struct Cell { size_t a{}; size_t b{}; };
+
+Cell resolveCell(double aFrac, double bFrac, size_t n) {
+  Cell c;
+  c.a = static_cast<size_t>(std::llround(aFrac * static_cast<double>(n)));
+  c.b = std::max<size_t>(
+      1, static_cast<size_t>(std::llround(bFrac * static_cast<double>(n))));
+  if (c.a >= n) c.a = n - 1;
+  if (c.a + c.b > n) c.b = n - c.a;
+  return c;
+}
+
+std::vector<EncoderEntry<Elem>> buildEncoders() {
+  std::vector<EncoderEntry<Elem>> encoders;
+  encoders.push_back(makeEncoderEntry<TrivialEncoding<Elem>>(
+      "Trivial", "Baseline", "trivial", true, true, false));
+  encoders.push_back(makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
+      "FixedBitWidth", "Baseline", "fbw", true, true, false));
+  encoders.push_back(makeEncoderEntry<DictionaryEncoding<Elem>>(
+      "Dictionary", "Baseline", "dict", true, false, false));
+  encoders.push_back(makeEncoderEntry<RLEEncoding<Elem>>(
+      "RLE", "Baseline", "rle", true, true, false));
+
+  const std::array<std::string, 4> fpeNames = {
+      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
+  const std::array<bool, 4> fpeRA = {false, true, true, true};
+  const std::array<bool, 4> fpeSkip = {false, true, true, true};
+  for (int idx = 0; idx < 4; ++idx) {
+    EncoderEntry<Elem> entry;
+    entry.name = "FPE/" + fpeNames[idx];
+    entry.family = "FrequencyPartition";
+    entry.variant = fpeNames[idx];
+    entry.isSequential = true;
+    entry.fastSkip = fpeSkip[idx];
+    entry.randomAccess = fpeRA[idx];
+    entry.factory = [idx](const Vector<Elem>& data,
+                          const Encoding::Options& opts) {
+      auto impl = std::make_unique<
+          NimbleBenchTargetImpl<FrequencyPartitionEncoding<Elem>>>();
+      Encoding::Options o = opts;
+      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
+      impl->target.encode(data, o);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+
+  {
+    EncoderEntry<Elem> entry;
+    entry.name = "SIS/realNested";
+    entry.family = "SubIntSplit";
+    entry.variant = "real_nested";
+    entry.isSequential = false;
+    entry.fastSkip = false;
+    entry.randomAccess = false;
+    entry.factory = [](const Vector<Elem>& data,
+                       const Encoding::Options& opts) {
+      auto impl =
+          std::make_unique<NimbleBenchTargetImpl<SubIntSplitEncoding<Elem>>>();
+      impl->target.encode(data, opts, /*realNestedSelection=*/true);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+  return encoders;
+}
+
+} // namespace
+} // namespace facebook::nimble::mlidc
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  facebook::velox::memory::MemoryManager::initialize({});
+  using namespace facebook::nimble::mlidc;
+
+  const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
+  const size_t iters = static_cast<size_t>(FLAGS_mlidc_iters);
+  const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
+  const size_t grid = static_cast<size_t>(std::max(1, FLAGS_grid));
+
+  CacheState cacheState{};
+  if (!parseCacheState(FLAGS_cache_state, cacheState)) {
+    std::cerr << "Unknown --cache_state: " << FLAGS_cache_state
+              << " (expected hot|cold-payload|cold-all)\n";
+    return 1;
+  }
+
+  std::vector<double> aFracs, bFracs;
+  for (size_t i = 0; i < grid; ++i)
+    aFracs.push_back(static_cast<double>(i) / static_cast<double>(grid));
+  for (size_t j = 1; j <= grid; ++j)
+    bFracs.push_back(static_cast<double>(j) / static_cast<double>(grid));
+  size_t cellCount = 0;
+  for (double a : aFracs)
+    for (double b : bFracs)
+      if (a + b <= 1.0 + 1e-9) ++cellCount;
+
+  auto encoders = buildEncoders();
+  auto datasets = defaultInt64Datasets<Elem>();
+  const CacheTopology topo = CacheTopology::detect();
+
+  CachePolicy policy;
+  policy.state = cacheState;
+  try {
+    CacheController(policy, topo);
+  } catch (const std::exception& e) {
+    std::cerr << "ERROR: " << e.what() << "\n";
+    return 1;
+  }
+
+  std::cout << "bench_decode_range: " << encoders.size() << " encoders x "
+            << datasets.size() << " datasets, N=" << n << ", grid=" << grid
+            << " (" << cellCount << " cells), iters=" << iters
+            << ", cache=" << cacheStateName(cacheState) << "\n  "
+            << topo.describe() << "\n\n";
+
+  if (FLAGS_dry_run) {
+    std::cout << "Encoders:\n";
+    for (const auto& e : encoders)
+      std::cout << "  " << e.name << " [" << e.family << "]\n";
+    std::cout << "\nDatasets:\n";
+    for (const auto& d : datasets) std::cout << "  " << d.name << "\n";
+    return 0;
+  }
+
+  std::vector<std::string> csvColumns = {
+      "driver",      "dataset",     "encoding",       "family",
+      "variant",     "is_sequential", "fast_skip",    "random_access",
+      "N",           "seed",        "cache_state",    "evict_method",
+      "evict_ns",    "payload_bytes", "compression_ratio",
+      "iterations",  "warmup",      "contract",       "A_frac",
+      "B_frac",      "A",           "B",              "time_ns",
+      "time_p90_ns", "time_min_ns", "elem_Meps",      "input_MBps",
+      "skipped"};
+  std::string csvPath = FLAGS_mlidc_output_csv.empty()
+      ? "bench_decode_range.csv"
+      : FLAGS_mlidc_output_csv;
+  CsvResultWriter csv(csvPath, csvColumns);
+  if (!FLAGS_mlidc_output_manifest.empty())
+    writeRunManifest(FLAGS_mlidc_output_manifest);
+
+  std::vector<Elem> sink(n, Elem{});
+  int validateFailures = 0;
+  MeasureSpec spec;
+  spec.iterations = iters;
+  spec.warmup = 2;
+
+  auto writeSkipRow = [&](const std::string& ds, const std::string& enc) {
+    csv.beginRow();
+    csv.set("driver", "bench_decode_range");
+    csv.set("dataset", ds);
+    csv.set("encoding", enc);
+    csv.set("skipped", int64_t{1});
+    csv.endRow();
+  };
+
+  for (const auto& ds : datasets) {
+    std::cout << "== Dataset: " << ds.name << " ==\n";
+    auto data = ds.generate(n, seed);
+    const size_t rawBytes = static_cast<size_t>(n) * kElemSize;
+
+    for (const auto& enc : encoders) {
+      facebook::nimble::Encoding::Options opts;
+      std::unique_ptr<NimbleBenchTargetBase<Elem>> target;
+      bool skipped = false;
+      try {
+        target = enc.factory(data, opts);
+      } catch (const std::exception& ex) {
+        std::cerr << "  [SKIP] " << enc.name << ": " << ex.what() << "\n";
+        skipped = true;
+      }
+      if (skipped) { writeSkipRow(ds.name, enc.name); continue; }
+
+      const size_t payloadBytes = target->payloadSize();
+      const double ratio = rawBytes > 0
+          ? static_cast<double>(payloadBytes) / static_cast<double>(rawBytes)
+          : 0.0;
+
+      if (FLAGS_validate && enc.variant != "fpe_noindex") {
+        bool ok = true;
+        std::vector<Elem> check;
+        for (double aFrac : aFracs) {
+          Cell c = resolveCell(aFrac, bFracs.front(), n);
+          check.assign(c.b, Elem{});
+          target->materializeRange(
+              static_cast<uint32_t>(c.a), static_cast<uint32_t>(c.b),
+              check.data());
+          for (size_t i = 0; i < c.b && ok; ++i)
+            ok = check[i] == data[c.a + i];
+          if (!ok) break;
+        }
+        if (!ok) {
+          std::cerr << "  [VALIDATE FAIL] " << enc.name << " / " << ds.name
+                    << "\n";
+          ++validateFailures;
+          writeSkipRow(ds.name, enc.name);
+          continue;
+        }
+      }
+
+      CachePolicy cellPolicy;
+      cellPolicy.state = cacheState;
+      CacheController controller(cellPolicy, topo);
+      auto bufs = target->internalBuffers();
+      EvictionTargets targets;
+      if (!bufs.empty()) targets.payload = bufs[0];
+      targets.sink = std::span<std::byte>(
+          reinterpret_cast<std::byte*>(sink.data()),
+          static_cast<size_t>(n) * kElemSize);
+      if (bufs.size() > 1)
+        targets.codecInternal.assign(bufs.begin() + 1, bufs.end());
+
+      for (double aFrac : aFracs) {
+        for (double bFrac : bFracs) {
+          if (aFrac + bFrac > 1.0 + 1e-9) continue;
+          const Cell c = resolveCell(aFrac, bFrac, n);
+
+          auto result = measure(spec, controller, targets, [&]() {
+            target->materializeRange(
+                static_cast<uint32_t>(c.a), static_cast<uint32_t>(c.b),
+                sink.data());
+          });
+
+          const double timeNs = static_cast<double>(result.time.median_ns);
+          const double elemMeps =
+              timeNs > 0.0 ? static_cast<double>(c.b) / timeNs * 1e3 : 0.0;
+          const double inputBytes = enc.isSequential
+              ? static_cast<double>(payloadBytes)
+              : static_cast<double>(c.b) * static_cast<double>(payloadBytes) /
+                  static_cast<double>(n);
+          const double inputMBps =
+              timeNs > 0.0 ? inputBytes / timeNs * 1e3 : 0.0;
+
+          csv.beginRow();
+          csv.set("driver", "bench_decode_range");
+          csv.set("dataset", ds.name);
+          csv.set("encoding", enc.name);
+          csv.set("family", enc.family);
+          csv.set("variant", enc.variant);
+          csv.set("is_sequential", enc.isSequential ? int64_t{1} : int64_t{0});
+          csv.set("fast_skip", enc.fastSkip ? int64_t{1} : int64_t{0});
+          csv.set("random_access", enc.randomAccess ? int64_t{1} : int64_t{0});
+          csv.set("N", static_cast<int64_t>(n));
+          csv.set("seed", static_cast<int64_t>(seed));
+          csv.set("cache_state",
+              std::string(cacheStateName(controller.effectivePolicy().state)));
+          csv.set("evict_method", std::string(
+              evictMethodName(controller.effectivePolicy().method)));
+          csv.set("evict_ns", result.evict.median_ns);
+          csv.set("payload_bytes", static_cast<int64_t>(payloadBytes));
+          csv.set("compression_ratio", ratio);
+          csv.set("iterations", static_cast<int64_t>(iters));
+          csv.set("warmup", static_cast<int64_t>(spec.warmup));
+          csv.set("contract", std::string("range_into"));
+          csv.set("A_frac", aFrac);
+          csv.set("B_frac", bFrac);
+          csv.set("A", static_cast<int64_t>(c.a));
+          csv.set("B", static_cast<int64_t>(c.b));
+          csv.set("time_ns", result.time.median_ns);
+          csv.set("time_p90_ns", result.time.p90_ns);
+          csv.set("time_min_ns", result.time.min_ns);
+          csv.set("elem_Meps", elemMeps);
+          csv.set("input_MBps", inputMBps);
+          csv.set("skipped", int64_t{0});
+          csv.endRow();
+        }
+      }
+      csv.flush();
+      std::cout << "  " << enc.name << ": " << payloadBytes << " B, "
+                << cellCount << " cells swept\n";
+    }
+  }
+
+  std::cout << "\nResults written to: " << csvPath << "\n";
+  if (validateFailures > 0) {
+    std::cerr << validateFailures << " validation failure(s)\n";
+    return 2;
+  }
+  return 0;
+}
+
+#else
+
+#include <iostream>
+int main() {
+  std::cerr
+      << "bench_decode_range requires NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS\n";
+  return 1;
+}
+
+#endif

--- a/dwio/nimble/ML_ID_Compression/bench_decode_range.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_decode_range.cpp
@@ -30,13 +30,6 @@
 #include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
 #include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
 
-#include "dwio/nimble/encodings/DictionaryEncoding.h"
-#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
-#include "dwio/nimble/encodings/RLEEncoding.h"
-#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
-#include "dwio/nimble/encodings/TrivialEncoding.h"
-
 DEFINE_int32(grid, 16, "Grid resolution per axis; ~grid^2/2 cells in triangle");
 DEFINE_string(cache_state, "hot", "hot | cold-payload | cold-all");
 DEFINE_bool(validate, false, "Round-trip check before measuring");
@@ -48,13 +41,6 @@ namespace {
 using Elem = int64_t;
 constexpr size_t kElemSize = sizeof(Elem);
 
-bool parseCacheState(const std::string& text, CacheState& out) {
-  if (text == "hot") { out = CacheState::Hot; return true; }
-  if (text == "cold-payload") { out = CacheState::ColdPayload; return true; }
-  if (text == "cold-all") { out = CacheState::ColdAll; return true; }
-  return false;
-}
-
 struct Cell { size_t a{}; size_t b{}; };
 
 Cell resolveCell(double aFrac, double bFrac, size_t n) {
@@ -65,61 +51,6 @@ Cell resolveCell(double aFrac, double bFrac, size_t n) {
   if (c.a >= n) c.a = n - 1;
   if (c.a + c.b > n) c.b = n - c.a;
   return c;
-}
-
-std::vector<EncoderEntry<Elem>> buildEncoders() {
-  std::vector<EncoderEntry<Elem>> encoders;
-  encoders.push_back(makeEncoderEntry<TrivialEncoding<Elem>>(
-      "Trivial", "Baseline", "trivial", true, true, false));
-  encoders.push_back(makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
-      "FixedBitWidth", "Baseline", "fbw", true, true, false));
-  encoders.push_back(makeEncoderEntry<DictionaryEncoding<Elem>>(
-      "Dictionary", "Baseline", "dict", true, false, false));
-  encoders.push_back(makeEncoderEntry<RLEEncoding<Elem>>(
-      "RLE", "Baseline", "rle", true, true, false));
-
-  const std::array<std::string, 4> fpeNames = {
-      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
-  const std::array<bool, 4> fpeRA = {false, true, true, true};
-  const std::array<bool, 4> fpeSkip = {false, true, true, true};
-  for (int idx = 0; idx < 4; ++idx) {
-    EncoderEntry<Elem> entry;
-    entry.name = "FPE/" + fpeNames[idx];
-    entry.family = "FrequencyPartition";
-    entry.variant = fpeNames[idx];
-    entry.isSequential = true;
-    entry.fastSkip = fpeSkip[idx];
-    entry.randomAccess = fpeRA[idx];
-    entry.factory = [idx](const Vector<Elem>& data,
-                          const Encoding::Options& opts) {
-      auto impl = std::make_unique<
-          NimbleBenchTargetImpl<FrequencyPartitionEncoding<Elem>>>();
-      Encoding::Options o = opts;
-      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
-      impl->target.encode(data, o);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-
-  {
-    EncoderEntry<Elem> entry;
-    entry.name = "SIS/realNested";
-    entry.family = "SubIntSplit";
-    entry.variant = "real_nested";
-    entry.isSequential = false;
-    entry.fastSkip = false;
-    entry.randomAccess = false;
-    entry.factory = [](const Vector<Elem>& data,
-                       const Encoding::Options& opts) {
-      auto impl =
-          std::make_unique<NimbleBenchTargetImpl<SubIntSplitEncoding<Elem>>>();
-      impl->target.encode(data, opts, /*realNestedSelection=*/true);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-  return encoders;
 }
 
 } // namespace
@@ -152,7 +83,7 @@ int main(int argc, char** argv) {
     for (double b : bFracs)
       if (a + b <= 1.0 + 1e-9) ++cellCount;
 
-  auto encoders = buildEncoders();
+  auto encoders = buildDefaultEncoders<Elem>();
   auto datasets = defaultInt64Datasets<Elem>();
   const CacheTopology topo = CacheTopology::detect();
 

--- a/dwio/nimble/ML_ID_Compression/bench_encode.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_encode.cpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <array>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
+#include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
+
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+
+DEFINE_bool(validate, false, "Round-trip check after encoding");
+DEFINE_bool(dry_run, false, "Print sweep plan and exit");
+
+namespace facebook::nimble::mlidc {
+namespace {
+
+using Elem = int64_t;
+constexpr size_t kElemSize = sizeof(Elem);
+
+std::vector<EncoderEntry<Elem>> buildEncoders() {
+  std::vector<EncoderEntry<Elem>> encoders;
+
+  encoders.push_back(
+      makeEncoderEntry<TrivialEncoding<Elem>>(
+          "Trivial", "Baseline", "trivial", true, true, false));
+  encoders.push_back(
+      makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
+          "FixedBitWidth", "Baseline", "fbw", true, true, false));
+  encoders.push_back(
+      makeEncoderEntry<DictionaryEncoding<Elem>>(
+          "Dictionary", "Baseline", "dict", true, false, false));
+  encoders.push_back(
+      makeEncoderEntry<RLEEncoding<Elem>>(
+          "RLE", "Baseline", "rle", true, true, false));
+
+  const std::array<std::string, 4> fpeNames = {
+      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
+  const std::array<bool, 4> fpeRA = {false, true, true, true};
+  const std::array<bool, 4> fpeSkip = {false, true, true, true};
+
+  for (int idx = 0; idx < 4; ++idx) {
+    EncoderEntry<Elem> entry;
+    entry.name = "FPE/" + fpeNames[idx];
+    entry.family = "FrequencyPartition";
+    entry.variant = fpeNames[idx];
+    entry.isSequential = true;
+    entry.fastSkip = fpeSkip[idx];
+    entry.randomAccess = fpeRA[idx];
+    entry.factory = [idx](const Vector<Elem>& data,
+                          const Encoding::Options& opts) {
+      auto impl =
+          std::make_unique<NimbleBenchTargetImpl<
+              FrequencyPartitionEncoding<Elem>>>();
+      Encoding::Options o = opts;
+      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
+      impl->target.encode(data, o);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+
+  {
+    EncoderEntry<Elem> entry;
+    entry.name = "SIS/realNested";
+    entry.family = "SubIntSplit";
+    entry.variant = "real_nested";
+    entry.isSequential = false;
+    entry.fastSkip = false;
+    entry.randomAccess = false;
+    entry.factory = [](const Vector<Elem>& data,
+                       const Encoding::Options& opts) {
+      auto impl =
+          std::make_unique<NimbleBenchTargetImpl<
+              SubIntSplitEncoding<Elem>>>();
+      impl->target.encode(data, opts, /*realNestedSelection=*/true);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+
+  return encoders;
+}
+
+} // namespace
+} // namespace facebook::nimble::mlidc
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  facebook::velox::memory::MemoryManager::initialize({});
+
+  using namespace facebook::nimble::mlidc;
+
+  const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
+  const size_t iters = static_cast<size_t>(FLAGS_mlidc_iters);
+  const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
+
+  auto encoders = buildEncoders();
+  auto datasets = defaultInt64Datasets<Elem>();
+
+  const CacheTopology topo = CacheTopology::detect();
+
+  std::cout << "bench_encode: " << encoders.size() << " encoders x "
+            << datasets.size() << " datasets, N=" << n
+            << ", iters=" << iters << "\n  " << topo.describe() << "\n\n";
+
+  if (FLAGS_dry_run) {
+    std::cout << "Encoders:\n";
+    for (const auto& e : encoders)
+      std::cout << "  " << e.name << " [" << e.family << "]\n";
+    std::cout << "\nDatasets:\n";
+    for (const auto& d : datasets)
+      std::cout << "  " << d.name << "\n";
+    return 0;
+  }
+
+  std::vector<std::string> csvColumns = {
+      "driver",     "dataset",       "encoding",    "family",
+      "variant",    "is_sequential", "N",           "seed",
+      "payload_bytes", "compression_ratio", "iterations", "warmup",
+      "time_ns",    "time_p90_ns",   "time_min_ns", "encode_Meps",
+      "encode_MBps", "skipped"};
+
+  std::string csvPath =
+      FLAGS_mlidc_output_csv.empty() ? "bench_encode.csv" : FLAGS_mlidc_output_csv;
+  CsvResultWriter csv(csvPath, csvColumns);
+
+  if (!FLAGS_mlidc_output_manifest.empty()) {
+    writeRunManifest(FLAGS_mlidc_output_manifest);
+  }
+
+  int validateFailures = 0;
+
+  MeasureSpec spec;
+  spec.iterations = iters;
+  spec.warmup = 2;
+
+  CachePolicy hotPolicy;
+  hotPolicy.state = CacheState::Hot;
+  EvictionTargets emptyTargets;
+
+  for (const auto& ds : datasets) {
+    std::cout << "== Dataset: " << ds.name << " ==\n";
+    auto data = ds.generate(n, seed);
+    const size_t rawBytes = static_cast<size_t>(n) * kElemSize;
+
+    for (const auto& enc : encoders) {
+      facebook::nimble::Encoding::Options opts;
+      std::unique_ptr<NimbleBenchTargetBase<Elem>> target;
+
+      CacheController controller(hotPolicy, topo);
+
+      try {
+        auto result = measure(spec, controller, emptyTargets, [&]() {
+          target = enc.factory(data, opts);
+        });
+
+        const size_t payloadBytes = target->payloadSize();
+        const double ratio = rawBytes > 0
+            ? static_cast<double>(payloadBytes) / static_cast<double>(rawBytes)
+            : 0.0;
+
+        if (FLAGS_validate && enc.variant != "fpe_noindex") {
+          std::vector<Elem> check(n);
+          target->materializeAll(check.data(), n);
+          for (uint32_t i = 0; i < n; ++i) {
+            if (check[i] != data[i]) {
+              throw std::runtime_error("round-trip mismatch");
+            }
+          }
+        }
+
+        const double timeNs = static_cast<double>(result.time.median_ns);
+        const double meps =
+            timeNs > 0.0 ? static_cast<double>(n) / timeNs * 1e3 : 0.0;
+        const double mbps = timeNs > 0.0
+            ? static_cast<double>(rawBytes) / timeNs * 1e3
+            : 0.0;
+
+        std::cout << "  " << enc.name << ": " << payloadBytes << " B, "
+                  << std::fixed << std::setprecision(1) << meps
+                  << " Melem/s\n";
+
+        csv.beginRow();
+        csv.set("driver", "bench_encode");
+        csv.set("dataset", ds.name);
+        csv.set("encoding", enc.name);
+        csv.set("family", enc.family);
+        csv.set("variant", enc.variant);
+        csv.set("is_sequential", enc.isSequential ? int64_t{1} : int64_t{0});
+        csv.set("N", static_cast<int64_t>(n));
+        csv.set("seed", static_cast<int64_t>(seed));
+        csv.set("payload_bytes", static_cast<int64_t>(payloadBytes));
+        csv.set("compression_ratio", ratio);
+        csv.set("iterations", static_cast<int64_t>(iters));
+        csv.set("warmup", static_cast<int64_t>(spec.warmup));
+        csv.set("time_ns", result.time.median_ns);
+        csv.set("time_p90_ns", result.time.p90_ns);
+        csv.set("time_min_ns", result.time.min_ns);
+        csv.set("encode_Meps", meps);
+        csv.set("encode_MBps", mbps);
+        csv.set("skipped", int64_t{0});
+        csv.endRow();
+      } catch (const std::exception& ex) {
+        std::cerr << "  [SKIP] " << enc.name << ": " << ex.what() << "\n";
+        if (FLAGS_validate) {
+          ++validateFailures;
+        }
+        csv.beginRow();
+        csv.set("driver", "bench_encode");
+        csv.set("dataset", ds.name);
+        csv.set("encoding", enc.name);
+        csv.set("skipped", int64_t{1});
+        csv.endRow();
+      }
+      csv.flush();
+    }
+  }
+
+  std::cout << "\nResults written to: " << csvPath << "\n";
+
+  if (validateFailures > 0) {
+    std::cerr << validateFailures << " validation failure(s)\n";
+    return 2;
+  }
+  return 0;
+}
+
+#else
+
+#include <iostream>
+int main() {
+  std::cerr << "bench_encode requires NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS\n";
+  return 1;
+}
+
+#endif

--- a/dwio/nimble/ML_ID_Compression/bench_encode.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_encode.cpp
@@ -28,13 +28,6 @@
 #include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
 #include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
 
-#include "dwio/nimble/encodings/DictionaryEncoding.h"
-#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
-#include "dwio/nimble/encodings/RLEEncoding.h"
-#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
-#include "dwio/nimble/encodings/TrivialEncoding.h"
-
 DEFINE_bool(validate, false, "Round-trip check after encoding");
 DEFINE_bool(dry_run, false, "Print sweep plan and exit");
 
@@ -43,70 +36,6 @@ namespace {
 
 using Elem = int64_t;
 constexpr size_t kElemSize = sizeof(Elem);
-
-std::vector<EncoderEntry<Elem>> buildEncoders() {
-  std::vector<EncoderEntry<Elem>> encoders;
-
-  encoders.push_back(
-      makeEncoderEntry<TrivialEncoding<Elem>>(
-          "Trivial", "Baseline", "trivial", true, true, false));
-  encoders.push_back(
-      makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
-          "FixedBitWidth", "Baseline", "fbw", true, true, false));
-  encoders.push_back(
-      makeEncoderEntry<DictionaryEncoding<Elem>>(
-          "Dictionary", "Baseline", "dict", true, false, false));
-  encoders.push_back(
-      makeEncoderEntry<RLEEncoding<Elem>>(
-          "RLE", "Baseline", "rle", true, true, false));
-
-  const std::array<std::string, 4> fpeNames = {
-      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
-  const std::array<bool, 4> fpeRA = {false, true, true, true};
-  const std::array<bool, 4> fpeSkip = {false, true, true, true};
-
-  for (int idx = 0; idx < 4; ++idx) {
-    EncoderEntry<Elem> entry;
-    entry.name = "FPE/" + fpeNames[idx];
-    entry.family = "FrequencyPartition";
-    entry.variant = fpeNames[idx];
-    entry.isSequential = true;
-    entry.fastSkip = fpeSkip[idx];
-    entry.randomAccess = fpeRA[idx];
-    entry.factory = [idx](const Vector<Elem>& data,
-                          const Encoding::Options& opts) {
-      auto impl =
-          std::make_unique<NimbleBenchTargetImpl<
-              FrequencyPartitionEncoding<Elem>>>();
-      Encoding::Options o = opts;
-      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
-      impl->target.encode(data, o);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-
-  {
-    EncoderEntry<Elem> entry;
-    entry.name = "SIS/realNested";
-    entry.family = "SubIntSplit";
-    entry.variant = "real_nested";
-    entry.isSequential = false;
-    entry.fastSkip = false;
-    entry.randomAccess = false;
-    entry.factory = [](const Vector<Elem>& data,
-                       const Encoding::Options& opts) {
-      auto impl =
-          std::make_unique<NimbleBenchTargetImpl<
-              SubIntSplitEncoding<Elem>>>();
-      impl->target.encode(data, opts, /*realNestedSelection=*/true);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-
-  return encoders;
-}
 
 } // namespace
 } // namespace facebook::nimble::mlidc
@@ -121,7 +50,7 @@ int main(int argc, char** argv) {
   const size_t iters = static_cast<size_t>(FLAGS_mlidc_iters);
   const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
 
-  auto encoders = buildEncoders();
+  auto encoders = buildDefaultEncoders<Elem>();
   auto datasets = defaultInt64Datasets<Elem>();
 
   const CacheTopology topo = CacheTopology::detect();

--- a/dwio/nimble/ML_ID_Compression/bench_encode.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_encode.cpp
@@ -25,6 +25,7 @@
 #include <gflags/gflags.h>
 
 #include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/ML_ID_Compression/OpenZLBenchTarget.h"
 #include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
 #include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
 
@@ -51,6 +52,7 @@ int main(int argc, char** argv) {
   const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
 
   auto encoders = buildDefaultEncoders<Elem>();
+  encoders.push_back(buildOpenZLEncoder<Elem>());
   auto datasets = defaultInt64Datasets<Elem>();
 
   const CacheTopology topo = CacheTopology::detect();

--- a/dwio/nimble/ML_ID_Compression/bench_index_oracle.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_index_oracle.cpp
@@ -66,22 +66,6 @@ std::vector<IndexTypeEntry> indexTypes = {
     {"EliasFano", 3, true},
 };
 
-bool parseCacheState(const std::string& text, CacheState& out) {
-  if (text == "hot") {
-    out = CacheState::Hot;
-    return true;
-  }
-  if (text == "cold-payload") {
-    out = CacheState::ColdPayload;
-    return true;
-  }
-  if (text == "cold-all") {
-    out = CacheState::ColdAll;
-    return true;
-  }
-  return false;
-}
-
 std::vector<double> buildLambdaSweep() {
   std::vector<double> lambdas;
   for (int e = -6; e <= 2; ++e) {

--- a/dwio/nimble/ML_ID_Compression/bench_index_oracle.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_index_oracle.cpp
@@ -1,0 +1,449 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// bench_index_oracle: sweeps the 4 FrequencyPartitionEncoding index types
+// (NoIndex, PerTierBitmaps, TierTagArray, EliasFano) across datasets and
+// reports payload bytes, bulk decode throughput, point-lookup latency, the
+// Pareto frontier over (bytes, point_ns), and a scalarised oracle
+// J = bytes + lambda * point_ns for a log-spaced lambda sweep.
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/ML_ID_Compression/CachePolicy.h"
+#include "dwio/nimble/ML_ID_Compression/MeasureLoop.h"
+#include "dwio/nimble/ML_ID_Compression/PointTraceGen.h"
+
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+
+DEFINE_int32(probes, 16384, "Number of point lookups per measurement");
+DEFINE_string(cache_state, "hot", "hot | cold-payload | cold-all");
+DEFINE_bool(validate, false, "Round-trip check before measuring");
+DEFINE_bool(dry_run, false, "Print sweep plan and exit");
+
+namespace facebook::nimble::mlidc {
+namespace {
+
+using Elem = int64_t;
+constexpr size_t kElemSize = sizeof(Elem);
+constexpr double kNaN = std::numeric_limits<double>::quiet_NaN();
+
+struct IndexTypeEntry {
+  std::string name;
+  uint8_t idx;
+  bool randomAccess;
+};
+
+std::vector<IndexTypeEntry> indexTypes = {
+    {"NoIndex", 0, false},
+    {"PerTierBitmaps", 1, true},
+    {"TierTagArray", 2, true},
+    {"EliasFano", 3, true},
+};
+
+bool parseCacheState(const std::string& text, CacheState& out) {
+  if (text == "hot") {
+    out = CacheState::Hot;
+    return true;
+  }
+  if (text == "cold-payload") {
+    out = CacheState::ColdPayload;
+    return true;
+  }
+  if (text == "cold-all") {
+    out = CacheState::ColdAll;
+    return true;
+  }
+  return false;
+}
+
+std::vector<double> buildLambdaSweep() {
+  std::vector<double> lambdas;
+  for (int e = -6; e <= 2; ++e) {
+    lambdas.push_back(std::pow(10.0, e));
+  }
+  return lambdas;
+}
+
+// One measured cell: (dataset, index_type) pair.
+struct Cell {
+  std::string indexTypeName;
+  uint8_t idx{};
+  bool randomAccess{};
+  bool viable{};
+  bool skipped{};
+  size_t payloadBytes{};
+  double bulkNs{kNaN};
+  double pointNs{kNaN}; // ns per probe; NaN if not viable
+  bool onFrontier{false};
+};
+
+// A point is Pareto-optimal (over viable cells) when no other viable cell has
+// bytes <= this and pointNs <= this, with at least one strict inequality.
+void computeParetoFrontier(std::vector<Cell>& cells) {
+  for (auto& c : cells) {
+    c.onFrontier = false;
+    if (!c.viable) {
+      continue;
+    }
+    bool dominated = false;
+    for (const auto& other : cells) {
+      if (!other.viable || &other == &c) {
+        continue;
+      }
+      const bool notWorseBytes = other.payloadBytes <= c.payloadBytes;
+      const bool notWorseLatency = other.pointNs <= c.pointNs;
+      const bool strictlyBetter =
+          (other.payloadBytes < c.payloadBytes) || (other.pointNs < c.pointNs);
+      if (notWorseBytes && notWorseLatency && strictlyBetter) {
+        dominated = true;
+        break;
+      }
+    }
+    c.onFrontier = !dominated;
+  }
+}
+
+} // namespace
+} // namespace facebook::nimble::mlidc
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  facebook::velox::memory::MemoryManager::initialize({});
+  using namespace facebook::nimble::mlidc;
+  using facebook::nimble::FrequencyPartitionEncoding;
+
+  const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
+  const size_t iters = static_cast<size_t>(FLAGS_mlidc_iters);
+  const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
+  const size_t probes = static_cast<size_t>(std::max(1, FLAGS_probes));
+
+  CacheState cacheState{};
+  if (!parseCacheState(FLAGS_cache_state, cacheState)) {
+    std::cerr << "Unknown --cache_state: " << FLAGS_cache_state
+               << " (expected hot|cold-payload|cold-all)\n";
+    return 1;
+  }
+
+  auto datasets = defaultInt64Datasets<Elem>();
+  const std::vector<double> lambdas = buildLambdaSweep();
+  const CacheTopology topo = CacheTopology::detect();
+
+  CachePolicy policy;
+  policy.state = cacheState;
+  try {
+    CacheController(policy, topo);
+  } catch (const std::exception& e) {
+    std::cerr << "ERROR: " << e.what() << "\n";
+    return 1;
+  }
+
+  std::cout << "bench_index_oracle: " << indexTypes.size()
+             << " index types x " << datasets.size() << " datasets, N=" << n
+             << ", probes=" << probes << ", iters=" << iters
+             << ", cache=" << cacheStateName(cacheState) << "\n  "
+             << topo.describe() << "\n\n";
+
+  if (FLAGS_dry_run) {
+    std::cout << "Index types:\n";
+    for (const auto& it : indexTypes) {
+      std::cout << "  " << it.name << " (idx=" << static_cast<int>(it.idx)
+                 << ", random_access=" << it.randomAccess << ")\n";
+    }
+    std::cout << "\nDatasets:\n";
+    for (const auto& d : datasets) {
+      std::cout << "  " << d.name << "\n";
+    }
+    std::cout << "\nLambdas:\n";
+    for (double l : lambdas) {
+      std::cout << "  " << l << "\n";
+    }
+    return 0;
+  }
+
+  std::vector<std::string> csvColumns = {
+      "driver",         "dataset",           "index_type",   "N",
+      "seed",           "cache_state",       "payload_bytes", "random_access",
+      "viable",         "bulk_ns",           "point_ns",     "probes",
+      "on_pareto_frontier", "lambda_ns_per_byte", "objective_J", "oracle_pick",
+      "regret_bytes",   "regret_ns",         "skipped"};
+  std::string csvPath = FLAGS_mlidc_output_csv.empty()
+      ? "bench_index_oracle.csv"
+      : FLAGS_mlidc_output_csv;
+  CsvResultWriter csv(csvPath, csvColumns);
+  if (!FLAGS_mlidc_output_manifest.empty()) {
+    writeRunManifest(FLAGS_mlidc_output_manifest);
+  }
+
+  Elem sink{};
+  std::vector<Elem> bulkSink(n, Elem{});
+  int validateFailures = 0;
+
+  MeasureSpec spec;
+  spec.iterations = iters;
+  spec.warmup = 2;
+
+  PointTraceParams traceParams;
+  traceParams.streamLength = n;
+  traceParams.probes = probes;
+  traceParams.seed = seed;
+  traceParams.ascending = false;
+  const PointTrace trace = buildPointTrace(traceParams);
+
+  for (const auto& ds : datasets) {
+    std::cout << "== Dataset: " << ds.name << " ==\n";
+    auto data = ds.generate(n, seed);
+
+    std::vector<Cell> cells;
+    cells.reserve(indexTypes.size());
+
+    for (const auto& it : indexTypes) {
+      Cell cell;
+      cell.indexTypeName = it.name;
+      cell.idx = it.idx;
+      cell.randomAccess = it.randomAccess;
+
+      std::unique_ptr<NimbleBenchTargetBase<Elem>> target;
+      bool skipped = false;
+      try {
+        auto impl = std::make_unique<
+            NimbleBenchTargetImpl<FrequencyPartitionEncoding<Elem>>>();
+        facebook::nimble::Encoding::Options o;
+        o.frequencyPartitionIndex = it.idx;
+        impl->target.encode(data, o);
+        target = std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+      } catch (const std::exception& ex) {
+        std::cerr << "  [SKIP] " << it.name << ": " << ex.what() << "\n";
+        skipped = true;
+      }
+
+      if (skipped) {
+        cell.skipped = true;
+        cells.push_back(cell);
+        csv.beginRow();
+        csv.set("driver", "bench_index_oracle");
+        csv.set("dataset", ds.name);
+        csv.set("index_type", it.name);
+        csv.set("skipped", int64_t{1});
+        csv.endRow();
+        continue;
+      }
+
+      cell.payloadBytes = target->payloadSize();
+
+      // Validation: RA index types only. NoIndex cannot be validated (no
+      // original-order recovery).
+      if (FLAGS_validate && it.idx >= 1) {
+        bool ok = true;
+        Elem check{};
+        for (size_t idx : trace.indices) {
+          target->materializeRange(static_cast<uint32_t>(idx), 1, &check);
+          if (check != data[idx]) {
+            ok = false;
+            break;
+          }
+        }
+        if (!ok) {
+          std::cerr << "  [VALIDATE FAIL] " << it.name << " / " << ds.name
+                     << "\n";
+          ++validateFailures;
+          cell.skipped = true;
+          cells.push_back(cell);
+          csv.beginRow();
+          csv.set("driver", "bench_index_oracle");
+          csv.set("dataset", ds.name);
+          csv.set("index_type", it.name);
+          csv.set("skipped", int64_t{1});
+          csv.endRow();
+          continue;
+        }
+      }
+
+      // Bulk decode measurement.
+      {
+        CachePolicy cellPolicy;
+        cellPolicy.state = cacheState;
+        CacheController controller(cellPolicy, topo);
+        auto bufs = target->internalBuffers();
+        EvictionTargets targets;
+        if (!bufs.empty()) {
+          targets.payload = bufs[0];
+        }
+        targets.sink = std::span<std::byte>(
+            reinterpret_cast<std::byte*>(bulkSink.data()),
+            static_cast<size_t>(n) * kElemSize);
+        if (bufs.size() > 1) {
+          targets.codecInternal.assign(bufs.begin() + 1, bufs.end());
+        }
+        auto result = measure(spec, controller, targets, [&]() {
+          target->materializeAll(bulkSink.data(), n);
+        });
+        cell.bulkNs = static_cast<double>(result.time.median_ns);
+      }
+
+      // Point-lookup measurement: only for RA index types.
+      cell.viable = it.randomAccess;
+      if (cell.viable) {
+        CachePolicy cellPolicy;
+        cellPolicy.state = cacheState;
+        CacheController controller(cellPolicy, topo);
+        auto bufs = target->internalBuffers();
+        EvictionTargets targets;
+        if (!bufs.empty()) {
+          targets.payload = bufs[0];
+        }
+        targets.sink = std::span<std::byte>(
+            reinterpret_cast<std::byte*>(&sink), kElemSize);
+        if (bufs.size() > 1) {
+          targets.codecInternal.assign(bufs.begin() + 1, bufs.end());
+        }
+        auto result = measure(spec, controller, targets, [&]() {
+          for (size_t idx : trace.indices) {
+            target->materializeRange(static_cast<uint32_t>(idx), 1, &sink);
+          }
+        });
+        const double timeNs = static_cast<double>(result.time.median_ns);
+        cell.pointNs = probes > 0 ? timeNs / static_cast<double>(probes) : 0.0;
+      } else {
+        cell.pointNs = kNaN;
+      }
+
+      cells.push_back(cell);
+      std::cout << "  " << it.name << ": " << cell.payloadBytes << " B, "
+                 << (cell.viable ? std::to_string(cell.pointNs) : "n/a")
+                 << " ns/probe\n";
+    }
+
+    computeParetoFrontier(cells);
+
+    // Compute best bytes / best latency among viable cells (for regret).
+    size_t bestBytes = std::numeric_limits<size_t>::max();
+    double bestPointNs = std::numeric_limits<double>::max();
+    for (const auto& c : cells) {
+      if (c.skipped) {
+        continue;
+      }
+      bestBytes = std::min(bestBytes, c.payloadBytes);
+      if (c.viable) {
+        bestPointNs = std::min(bestPointNs, c.pointNs);
+      }
+    }
+
+    for (const auto& c : cells) {
+      if (c.skipped) {
+        continue;
+      }
+
+      const int64_t regretBytes = bestBytes != std::numeric_limits<size_t>::max()
+          ? static_cast<int64_t>(c.payloadBytes) - static_cast<int64_t>(bestBytes)
+          : 0;
+      const double regretNs = (c.viable && bestPointNs != std::numeric_limits<double>::max())
+          ? c.pointNs - bestPointNs
+          : kNaN;
+
+      for (double lambda : lambdas) {
+        // Oracle pick over the whole cell set for this lambda: argmin J
+        // among viable cells (point lookups require RA); if no viable cell
+        // exists, the byte-only baseline (NoIndex) is the pick.
+        std::string oraclePick;
+        double bestJ = std::numeric_limits<double>::max();
+        bool anyViable = false;
+        for (const auto& other : cells) {
+          if (other.skipped || !other.viable) {
+            continue;
+          }
+          anyViable = true;
+          const double j = static_cast<double>(other.payloadBytes) +
+              lambda * other.pointNs;
+          if (j < bestJ) {
+            bestJ = j;
+            oraclePick = other.indexTypeName;
+          }
+        }
+        if (!anyViable) {
+          // Fall back to smallest payload (e.g. NoIndex-only viable set).
+          size_t minB = std::numeric_limits<size_t>::max();
+          for (const auto& other : cells) {
+            if (other.skipped) {
+              continue;
+            }
+            if (other.payloadBytes < minB) {
+              minB = other.payloadBytes;
+              oraclePick = other.indexTypeName;
+            }
+          }
+        }
+
+        const double j = c.viable
+            ? static_cast<double>(c.payloadBytes) + lambda * c.pointNs
+            : static_cast<double>(c.payloadBytes);
+
+        csv.beginRow();
+        csv.set("driver", "bench_index_oracle");
+        csv.set("dataset", ds.name);
+        csv.set("index_type", c.indexTypeName);
+        csv.set("N", static_cast<int64_t>(n));
+        csv.set("seed", static_cast<int64_t>(seed));
+        csv.set("cache_state", std::string(cacheStateName(cacheState)));
+        csv.set("payload_bytes", static_cast<int64_t>(c.payloadBytes));
+        csv.set("random_access", c.randomAccess ? int64_t{1} : int64_t{0});
+        csv.set("viable", c.viable ? int64_t{1} : int64_t{0});
+        csv.set("bulk_ns", c.bulkNs);
+        csv.set("point_ns", c.pointNs);
+        csv.set("probes", static_cast<int64_t>(probes));
+        csv.set("on_pareto_frontier", c.onFrontier ? int64_t{1} : int64_t{0});
+        csv.set("lambda_ns_per_byte", lambda);
+        csv.set("objective_J", j);
+        csv.set("oracle_pick", oraclePick);
+        csv.set("regret_bytes", regretBytes);
+        csv.set("regret_ns", regretNs);
+        csv.set("skipped", int64_t{0});
+        csv.endRow();
+      }
+    }
+    csv.flush();
+  }
+
+  std::cout << "\nResults written to: " << csvPath << "\n";
+  if (validateFailures > 0) {
+    std::cerr << validateFailures << " validation failure(s)\n";
+    return 2;
+  }
+  return 0;
+}
+
+#else
+
+#include <iostream>
+int main() {
+  std::cerr
+      << "bench_index_oracle requires NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS\n";
+  return 1;
+}
+
+#endif

--- a/dwio/nimble/ML_ID_Compression/bench_smoke.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_smoke.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <gflags/gflags.h>
+
+#include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
+#include "dwio/nimble/encodings/DictionaryEncoding.h"
+#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
+#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
+#include "dwio/nimble/encodings/RLEEncoding.h"
+#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
+#include "dwio/nimble/encodings/TrivialEncoding.h"
+
+namespace facebook::nimble::mlidc {
+namespace {
+
+using Elem = int64_t;
+
+std::vector<EncoderEntry<Elem>> buildEncoders() {
+  std::vector<EncoderEntry<Elem>> encoders;
+
+  encoders.push_back(
+      makeEncoderEntry<TrivialEncoding<Elem>>(
+          "Trivial", "Baseline", "trivial", true, true, false));
+  encoders.push_back(
+      makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
+          "FixedBitWidth", "Baseline", "fbw", true, true, false));
+  encoders.push_back(
+      makeEncoderEntry<DictionaryEncoding<Elem>>(
+          "Dictionary", "Baseline", "dict", true, false, false));
+  encoders.push_back(
+      makeEncoderEntry<RLEEncoding<Elem>>(
+          "RLE", "Baseline", "rle", true, true, false));
+
+  const std::array<std::string, 4> fpeNames = {
+      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
+  const std::array<bool, 4> fpeRA = {false, true, true, true};
+  const std::array<bool, 4> fpeSkip = {false, true, true, true};
+
+  for (int idx = 0; idx < 4; ++idx) {
+    EncoderEntry<Elem> entry;
+    entry.name = "FPE/" + fpeNames[idx];
+    entry.family = "FrequencyPartition";
+    entry.variant = fpeNames[idx];
+    entry.isSequential = true;
+    entry.fastSkip = fpeSkip[idx];
+    entry.randomAccess = fpeRA[idx];
+    entry.factory = [idx](const Vector<Elem>& data,
+                          const Encoding::Options& opts) {
+      auto impl =
+          std::make_unique<NimbleBenchTargetImpl<
+              FrequencyPartitionEncoding<Elem>>>();
+      Encoding::Options o = opts;
+      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
+      impl->target.encode(data, o);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+
+  {
+    EncoderEntry<Elem> entry;
+    entry.name = "SIS/realNested";
+    entry.family = "SubIntSplit";
+    entry.variant = "real_nested";
+    entry.isSequential = false;
+    entry.fastSkip = false;
+    entry.randomAccess = false;
+    entry.factory = [](const Vector<Elem>& data,
+                       const Encoding::Options& opts) {
+      auto impl =
+          std::make_unique<NimbleBenchTargetImpl<
+              SubIntSplitEncoding<Elem>>>();
+      impl->target.encode(data, opts, /*realNestedSelection=*/true);
+      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
+    };
+    encoders.push_back(std::move(entry));
+  }
+
+  return encoders;
+}
+
+} // namespace
+} // namespace facebook::nimble::mlidc
+
+int main(int argc, char** argv) {
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+  facebook::velox::memory::MemoryManager::initialize({});
+  using namespace facebook::nimble::mlidc;
+
+  const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
+  const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
+  auto encoders = buildEncoders();
+  auto datasets = defaultInt64Datasets<Elem>();
+  int failures = 0;
+
+  for (const auto& ds : datasets) {
+    auto data = ds.generate(n, seed);
+    for (const auto& enc : encoders) {
+      // Skip FPE/fpe_noindex validation (reorders without restoration index)
+      if (enc.variant == "fpe_noindex") {
+        continue;
+      }
+
+      facebook::nimble::Encoding::Options opts;
+      try {
+        auto target = enc.factory(data, opts);
+        std::vector<Elem> out(n);
+        target->materializeAll(out.data(), n);
+        bool ok = true;
+        for (uint32_t i = 0; i < n; ++i) {
+          if (out[i] != data[i]) {
+            ok = false;
+            break;
+          }
+        }
+        if (!ok) {
+          std::cerr << "FAIL: " << enc.name << " / " << ds.name << "\n";
+          ++failures;
+        } else {
+          std::cout << "  OK: " << enc.name << " / " << ds.name << "\n";
+        }
+      } catch (const std::exception& ex) {
+        std::cerr << "EXCEPTION: " << enc.name << " / " << ds.name << ": "
+                  << ex.what() << "\n";
+        ++failures;
+      }
+    }
+  }
+
+  std::cout << (failures == 0 ? "All passed.\n" : "FAILURES detected.\n");
+  return failures > 0 ? 1 : 0;
+}
+
+#else
+#include <iostream>
+int main() {
+  std::cerr << "bench_smoke requires NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS\n";
+  return 1;
+}
+#endif

--- a/dwio/nimble/ML_ID_Compression/bench_smoke.cpp
+++ b/dwio/nimble/ML_ID_Compression/bench_smoke.cpp
@@ -24,81 +24,11 @@
 #include <gflags/gflags.h>
 
 #include "dwio/nimble/ML_ID_Compression/BenchCommon.h"
-#include "dwio/nimble/encodings/DictionaryEncoding.h"
-#include "dwio/nimble/encodings/FixedBitWidthEncoding.h"
-#include "dwio/nimble/encodings/FrequencyPartitionEncoding.h"
-#include "dwio/nimble/encodings/RLEEncoding.h"
-#include "dwio/nimble/encodings/SubIntSplitEncoding.h"
-#include "dwio/nimble/encodings/TrivialEncoding.h"
 
 namespace facebook::nimble::mlidc {
 namespace {
 
 using Elem = int64_t;
-
-std::vector<EncoderEntry<Elem>> buildEncoders() {
-  std::vector<EncoderEntry<Elem>> encoders;
-
-  encoders.push_back(
-      makeEncoderEntry<TrivialEncoding<Elem>>(
-          "Trivial", "Baseline", "trivial", true, true, false));
-  encoders.push_back(
-      makeEncoderEntry<FixedBitWidthEncoding<Elem>>(
-          "FixedBitWidth", "Baseline", "fbw", true, true, false));
-  encoders.push_back(
-      makeEncoderEntry<DictionaryEncoding<Elem>>(
-          "Dictionary", "Baseline", "dict", true, false, false));
-  encoders.push_back(
-      makeEncoderEntry<RLEEncoding<Elem>>(
-          "RLE", "Baseline", "rle", true, true, false));
-
-  const std::array<std::string, 4> fpeNames = {
-      "fpe_noindex", "fpe_pertier", "fpe_tagtag", "fpe_elias"};
-  const std::array<bool, 4> fpeRA = {false, true, true, true};
-  const std::array<bool, 4> fpeSkip = {false, true, true, true};
-
-  for (int idx = 0; idx < 4; ++idx) {
-    EncoderEntry<Elem> entry;
-    entry.name = "FPE/" + fpeNames[idx];
-    entry.family = "FrequencyPartition";
-    entry.variant = fpeNames[idx];
-    entry.isSequential = true;
-    entry.fastSkip = fpeSkip[idx];
-    entry.randomAccess = fpeRA[idx];
-    entry.factory = [idx](const Vector<Elem>& data,
-                          const Encoding::Options& opts) {
-      auto impl =
-          std::make_unique<NimbleBenchTargetImpl<
-              FrequencyPartitionEncoding<Elem>>>();
-      Encoding::Options o = opts;
-      o.frequencyPartitionIndex = static_cast<uint8_t>(idx);
-      impl->target.encode(data, o);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-
-  {
-    EncoderEntry<Elem> entry;
-    entry.name = "SIS/realNested";
-    entry.family = "SubIntSplit";
-    entry.variant = "real_nested";
-    entry.isSequential = false;
-    entry.fastSkip = false;
-    entry.randomAccess = false;
-    entry.factory = [](const Vector<Elem>& data,
-                       const Encoding::Options& opts) {
-      auto impl =
-          std::make_unique<NimbleBenchTargetImpl<
-              SubIntSplitEncoding<Elem>>>();
-      impl->target.encode(data, opts, /*realNestedSelection=*/true);
-      return std::unique_ptr<NimbleBenchTargetBase<Elem>>(std::move(impl));
-    };
-    encoders.push_back(std::move(entry));
-  }
-
-  return encoders;
-}
 
 } // namespace
 } // namespace facebook::nimble::mlidc
@@ -110,7 +40,7 @@ int main(int argc, char** argv) {
 
   const uint32_t n = static_cast<uint32_t>(FLAGS_mlidc_rows);
   const uint64_t seed = static_cast<uint64_t>(FLAGS_mlidc_seed);
-  auto encoders = buildEncoders();
+  auto encoders = buildDefaultEncoders<Elem>();
   auto datasets = defaultInt64Datasets<Elem>();
   int failures = 0;
 

--- a/dwio/nimble/encodings/SubIntSplitSelector.h
+++ b/dwio/nimble/encodings/SubIntSplitSelector.h
@@ -108,11 +108,17 @@ struct SelectorResult {
 // `fullCount` is the total element count of the *full* stream; cost model
 // scores are scaled from the sample size to the full stream so the DP
 // produces estimates in the right units.
-inline SelectorResult selectSplits(
+//
+// `costFn` scores a single segment: given (metrics, numValues, bitWidth,
+// outBestEncoding), return the per-sample cost in bits and write the best
+// encoding into the output parameter.  Defaults to `bestCostBits`.
+template <typename CostFn>
+inline SelectorResult selectSplitsImpl(
     const std::vector<uint64_t>& samples,
-    int kBits, // number of bits in the physical type (32 or 64)
+    int kBits,
     size_t fullCount,
-    const SelectorConfig& cfg = defaultSelectorConfig()) {
+    const SelectorConfig& cfg,
+    CostFn&& costFn) {
   if (samples.empty() || kBits <= 0) {
     return {};
   }
@@ -121,14 +127,11 @@ inline SelectorResult selectSplits(
   const MetricFlags requiredFlags = allCostModelRequiredFlags();
   MetricCollector collector;
 
-  // bestCost[l][r] = {min cost in bits for full stream, best EncodingType}
-  // Only lower-triangular (r >= l) entries are valid.
   struct SegmentChoice {
     double cost{std::numeric_limits<double>::infinity()};
     EncodingType encoding{EncodingType::Trivial};
   };
 
-  // Use flat vector for cache friendliness (kBits can be 32 or 64)
   const int sz = kBits;
   std::vector<SegmentChoice> bestCost(sz * sz);
 
@@ -146,9 +149,8 @@ inline SelectorResult selectSplits(
 
       EncodingType bestEnc = EncodingType::Trivial;
       const double perSampleCost =
-          bestCostBits(metrics, numSamples, bitWidth, bestEnc);
+          costFn(metrics, numSamples, bitWidth, bestEnc);
 
-      // Scale to full stream
       const double fullCost = perSampleCost * static_cast<double>(fullCount) /
           static_cast<double>(numSamples);
 
@@ -156,8 +158,6 @@ inline SelectorResult selectSplits(
     }
   }
 
-  // DP over bit positions [0..kBits].
-  // dp[i] = minimum cost to cover bits [0..i).
   std::vector<double> dp(sz + 1, std::numeric_limits<double>::infinity());
   std::vector<int> prev(sz + 1, -1);
   std::vector<EncodingType> chosen(sz + 1, EncodingType::Trivial);
@@ -187,7 +187,6 @@ inline SelectorResult selectSplits(
   result.totalCost = dp[sz];
 
   if (!std::isfinite(result.totalCost)) {
-    // Fallback: single segment covering all bits, Trivial encoding
     SegmentPlan fallback;
     fallback.bitStart = 0;
     fallback.bitEnd = sz - 1;
@@ -198,7 +197,6 @@ inline SelectorResult selectSplits(
     return result;
   }
 
-  // Backtrack to reconstruct segment plan
   int idx = sz;
   while (idx > 0) {
     const int start = prev[idx];
@@ -216,6 +214,14 @@ inline SelectorResult selectSplits(
 
   std::reverse(result.segments.begin(), result.segments.end());
   return result;
+}
+
+inline SelectorResult selectSplits(
+    const std::vector<uint64_t>& samples,
+    int kBits,
+    size_t fullCount,
+    const SelectorConfig& cfg = defaultSelectorConfig()) {
+  return selectSplitsImpl(samples, kBits, fullCount, cfg, bestCostBits);
 }
 
 } // namespace facebook::nimble::detail::subintsplit


### PR DESCRIPTION
## Summary

Add microbenchmark drivers for SubIntSplitEncoding and FrequencyPartitionEncoding evaluation. These drivers measure compression ratio, encode/decode throughput, point-lookup latency, and cost-model accuracy for the experimental encodings, providing the data pipeline for the paper's evaluation section.

All code is gated behind `NIMBLE_ENABLE_EXPERIMENTAL_ENCODINGS` and lives in a single new directory (`dwio/nimble/ML_ID_Compression/`). The drivers reuse nimble's existing `test::Encoder<E>::encode()` / `createEncoding()` path, `benchmarkPool()`, and data generators rather than duplicating infrastructure.

### Drivers (10)

| Driver | What it measures |
|---|---|
| `bench_compression` | Encoded size, bits/elem, compression ratio (no timing) |
| `bench_encode` | Encode throughput per encoder/dataset pair |
| `bench_decode_bulk` | Full-materialization decode throughput |
| `bench_decode_range` | Contiguous-range decode throughput heatmap |
| `bench_decode_gather` | Gather-pattern decode with (selectivity, run_length) sweep |
| `bench_decode_point` | Single-probe point-lookup latency (emulated via one-row materialize) |
| `bench_costmodel_oracle` | Validates SIS DP cost models against oracle encoding (top-1 accuracy, Spearman ρ, regret) |
| `bench_index_oracle` | Sweeps 4 FPE index types, Pareto frontier, scalarised oracle J = bytes + λ·point_ns |
| `bench_ablation` | Progressive encoding-set restriction for SIS sections (compression vs access-class tradeoff) |
| `bench_smoke` | Encode + decode round-trip correctness for all 9 encoders (no timing) |

### Encoders under test (9)

Trivial, FixedBitWidth, Dictionary, RLE, FPE×4 index variants (NoIndex, PerTierBitmaps, TierTagArray, EliasFano), SIS/realNested.

### Datasets (6)

uniform-64bit, narrow-20bit, narrow-40bit, increasing-small-delta, low-cardinality-256, run-length — deterministic via seeded LCG. (Can be easily extended)

### Measurement contract

Encode-once, hoisted buffers, `clobber()` after each iteration, cache eviction outside timed window, median/p90/min reporting, `--validate` round-trip check, `--dry_run` sweep plan, typed nulls for skipped cells.